### PR TITLE
Better Option Optional interoperability

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/jiop/JOptionalUtils.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/jiop/JOptionalUtils.scala
@@ -39,50 +39,32 @@ trait JOptionalUtils {
 
   implicit def option2AsJavaLong(option: Option[Long]): option2AsJavaLong =
     new option2AsJavaLong(option)
-}
 
-object JOptional {
 
-  import JavaInterop._
+  object JOptional {
+    def apply[T](nullable: T): JOptional[T] = ju.Optional.ofNullable(nullable)
 
-  def apply[T](nullable: T): JOptional[T] = ju.Optional.ofNullable(nullable)
+    def empty[T]: JOptional[T] = ju.Optional.empty[T]()
+  }
 
-  def empty[T]: JOptional[T] = ju.Optional.empty[T]()
+  object JOptionalDouble {
+    def apply(value: Double): JOptionalDouble = ju.OptionalDouble.of(value)
 
-  def none[T]: JOptional[T] = empty
-}
+    def empty: JOptionalDouble = ju.OptionalDouble.empty()
+  }
 
-object JOptionalDouble {
+  object JOptionalInt {
+    def apply(value: Int): JOptionalInt = ju.OptionalInt.of(value)
 
-  import JavaInterop._
+    def empty: JOptionalInt = ju.OptionalInt.empty()
+  }
 
-  def apply(value: Double): JOptionalDouble = ju.OptionalDouble.of(value)
+  object JOptionalLong {
+    def apply(value: Long): JOptionalLong = ju.OptionalLong.of(value)
 
-  def empty: JOptionalDouble = ju.OptionalDouble.empty()
+    def empty: JOptionalLong = ju.OptionalLong.empty()
+  }
 
-  def none: JOptionalDouble = empty
-}
-
-object JOptionalInt {
-
-  import JavaInterop._
-
-  def apply(value: Int): JOptionalInt = ju.OptionalInt.of(value)
-
-  def empty: JOptionalInt = ju.OptionalInt.empty()
-
-  def none: JOptionalInt = empty
-}
-
-object JOptionalLong {
-
-  import JavaInterop._
-
-  def apply(value: Long): JOptionalLong = ju.OptionalLong.of(value)
-
-  def empty: JOptionalLong = ju.OptionalLong.empty()
-
-  def none: JOptionalLong = empty
 }
 
 object JOptionalUtils {
@@ -109,11 +91,13 @@ object JOptionalUtils {
       if (optional.isPresent) Some(optional.getAsLong) else None
   }
 
-  // Note that in scala Some(null) is valid value. It will be translated to Optional.empty, because java Optional
-  // is not able to hold null
   final class option2AsJava[T](private val option: Option[T]) extends AnyVal {
+    /**
+      *Note that in scala Some(null) is valid value. It will throw an exception in such case, because java Optional
+      *  is not able to hold null
+      */
     def asJava: JOptional[T] =
-      if (option.isDefined) ju.Optional.ofNullable(option.get) else ju.Optional.empty()
+      if (option.isDefined) ju.Optional.of(option.get) else ju.Optional.empty()
   }
 
   final class option2AsJavaDouble(private val option: Option[Double]) extends AnyVal {

--- a/commons-core/src/main/scala/com/avsystem/commons/jiop/JOptionalUtils.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/jiop/JOptionalUtils.scala
@@ -27,6 +27,62 @@ trait JOptionalUtils {
 
   implicit def optionalLong2AsScala(optional: JOptionalLong): optionalLong2AsScala =
     new optionalLong2AsScala(optional)
+
+  implicit def option2AsJava[T](option: Option[T]): option2AsJava[T] =
+    new option2AsJava(option)
+
+  implicit def option2AsJavaDouble(option: Option[Double]): option2AsJavaDouble =
+    new option2AsJavaDouble(option)
+
+  implicit def option2AsJavaInt(option: Option[Int]): option2AsJavaInt =
+    new option2AsJavaInt(option)
+
+  implicit def option2AsJavaLong(option: Option[Long]): option2AsJavaLong =
+    new option2AsJavaLong(option)
+}
+
+object JOptional {
+
+  import JavaInterop._
+
+  def apply[T](nullable: T): JOptional[T] = ju.Optional.ofNullable(nullable)
+
+  def empty[T]: JOptional[T] = ju.Optional.empty[T]()
+
+  def none[T]: JOptional[T] = empty
+}
+
+object JOptionalDouble {
+
+  import JavaInterop._
+
+  def apply(value: Double): JOptionalDouble = ju.OptionalDouble.of(value)
+
+  def empty: JOptionalDouble = ju.OptionalDouble.empty()
+
+  def none: JOptionalDouble = empty
+}
+
+object JOptionalInt {
+
+  import JavaInterop._
+
+  def apply(value: Int): JOptionalInt = ju.OptionalInt.of(value)
+
+  def empty: JOptionalInt = ju.OptionalInt.empty()
+
+  def none: JOptionalInt = empty
+}
+
+object JOptionalLong {
+
+  import JavaInterop._
+
+  def apply(value: Long): JOptionalLong = ju.OptionalLong.of(value)
+
+  def empty: JOptionalLong = ju.OptionalLong.empty()
+
+  def none: JOptionalLong = empty
 }
 
 object JOptionalUtils {
@@ -51,6 +107,28 @@ object JOptionalUtils {
   final class optionalLong2AsScala(private val optional: JOptionalLong) extends AnyVal {
     def asScala: Option[Long] =
       if (optional.isPresent) Some(optional.getAsLong) else None
+  }
+
+  // Note that in scala Some(null) is valid value. It will be translated to Optional.empty, because java Optional
+  // is not able to hold null
+  final class option2AsJava[T](private val option: Option[T]) extends AnyVal {
+    def asJava: JOptional[T] =
+      if (option.isDefined) ju.Optional.ofNullable(option.get) else ju.Optional.empty()
+  }
+
+  final class option2AsJavaDouble(private val option: Option[Double]) extends AnyVal {
+    def asJavaDouble: JOptionalDouble =
+      if (option.isDefined) ju.OptionalDouble.of(option.get) else ju.OptionalDouble.empty()
+  }
+
+  final class option2AsJavaInt(private val option: Option[Int]) extends AnyVal {
+    def asJavaInt: JOptionalInt =
+      if (option.isDefined) ju.OptionalInt.of(option.get) else ju.OptionalInt.empty()
+  }
+
+  final class option2AsJavaLong(private val option: Option[Long]) extends AnyVal {
+    def asJavaLong: JOptionalLong =
+      if (option.isDefined) ju.OptionalLong.of(option.get) else ju.OptionalLong.empty()
   }
 
 }

--- a/commons-core/src/test/scala/com/avsystem/commons/jiop/JavaInteropTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/jiop/JavaInteropTest.scala
@@ -218,4 +218,55 @@ class JavaInteropTest extends FunSuite {
     val jmap = Iterator(1 -> "jeden", 2 -> "dwa").toJMap
     assert(jmap === JMap(1 -> "jeden", 2 -> "dwa"))
   }
+
+  test("JOptional companion object should act as factory") {
+    val string = "alamakota"
+    val stringOpt = JOptional(string)
+    assert(stringOpt.isPresent === true)
+    assert(stringOpt.get() === string)
+
+    val nullOpt = JOptional[String](null)
+    assert(nullOpt.isPresent === false)
+
+    assert(JOptional.empty.isPresent === false)
+    assert(JOptional.none.isPresent === false)
+
+    assert(JOptionalInt(3).getAsInt === 3)
+    assert(JOptionalLong(3L).getAsLong === 3L)
+    assert(JOptionalDouble(3.0).getAsDouble === 3.0)
+  }
+
+  test("option to optional converter should work") {
+    val string: String = "alamakota"
+    val empty: String = null
+
+    assert(Option(string).asJava === JOptional(string))
+    assert(Option(empty).asJava === JOptional.none)
+
+    assert(Option(3).asJavaInt === JOptionalInt(3))
+    assert(Option(3).asJava === JOptional(3))
+
+    assert(Option(3L).asJava === JOptional(3L))
+    assert(Option(3L).asJavaLong === JOptionalLong(3l))
+
+    assert(Option(3.0).asJava == JOptional(3.0))
+    assert(Option(3.0).asJavaDouble == JOptionalDouble(3.0))
+  }
+
+  test("optional to option converter should work") {
+    val string: String = "alamakota"
+    val empty: String = null
+
+    assert(Option(string) === JOptional(string).asScala)
+    assert(Option(empty) === JOptional.none.asScala)
+
+    assert(Option(3) === JOptionalInt(3).asScala)
+    assert(Option(3) === JOptional(3).asScala)
+
+    assert(Option(3L) === JOptional(3L).asScala)
+    assert(Option(3L) === JOptionalLong(3l).asScala)
+
+    assert(Option(3.0) === JOptional(3.0).asScala)
+    assert(Option(3.0) === JOptionalDouble(3.0).asScala)
+  }
 }

--- a/commons-core/src/test/scala/com/avsystem/commons/jiop/JavaInteropTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/jiop/JavaInteropTest.scala
@@ -229,7 +229,6 @@ class JavaInteropTest extends FunSuite {
     assert(nullOpt.isPresent === false)
 
     assert(JOptional.empty.isPresent === false)
-    assert(JOptional.none.isPresent === false)
 
     assert(JOptionalInt(3).getAsInt === 3)
     assert(JOptionalLong(3L).getAsLong === 3L)
@@ -241,7 +240,7 @@ class JavaInteropTest extends FunSuite {
     val empty: String = null
 
     assert(Option(string).asJava === JOptional(string))
-    assert(Option(empty).asJava === JOptional.none)
+    assert(Option(empty).asJava === JOptional.empty)
 
     assert(Option(3).asJavaInt === JOptionalInt(3))
     assert(Option(3).asJava === JOptional(3))
@@ -258,7 +257,7 @@ class JavaInteropTest extends FunSuite {
     val empty: String = null
 
     assert(Option(string) === JOptional(string).asScala)
-    assert(Option(empty) === JOptional.none.asScala)
+    assert(Option(empty) === JOptional.empty.asScala)
 
     assert(Option(3) === JOptionalInt(3).asScala)
     assert(Option(3) === JOptional(3).asScala)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.13.2"
+version in ThisBuild := "1.13.3"


### PR DESCRIPTION
asJava extension method (and also asJavaInt, asJavaLong, asJavaDouble)
Companion objects as factories