### PR TITLE
CollectionOps fixes

### DIFF
--- a/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsTest.scala
@@ -4,6 +4,11 @@ package misc
 import org.scalatest.{FunSuite, Matchers}
 
 class SharedExtensionsTest extends FunSuite with Matchers {
+  test("mkMap") {
+    List.range(0, 3).mkMap(identity, _.toString) shouldEqual
+      Map(0 -> "0", 1 -> "1", 2 -> "2")
+  }
+
   test("groupToMap") {
     List.range(0, 10).groupToMap(_ % 3, _.toString) shouldEqual
       Map(0 -> List("0", "3", "6", "9"), 1 -> List("1", "4", "7"), 2 -> List("2", "5", "8"))

--- a/commons-shared/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-shared/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -206,12 +206,8 @@ object SharedExtensions extends SharedExtensions {
   }
 
   class CollectionOps[C[X] <: BTraversable[X], A](private val coll: C[A]) extends AnyVal {
-    def toMap[K, V](keyFun: A => K, valueFun: A => V): Map[K, V] = {
-      val res = Map.newBuilder[K, V]
-      coll.foreach { a =>
-        res += ((keyFun(a), valueFun(a)))
-      }
-      res.result()
+    def mkMap[K, V](keyFun: A => K, valueFun: A => V): Map[K, V] = {
+      coll.map { a => (keyFun(a), valueFun(a)) }(scala.collection.breakOut)
     }
 
     def groupToMap[K, V, To](keyFun: A => K, valueFun: A => V)(implicit cbf: CanBuildFrom[C[A], V, To]): Map[K, To] = {
@@ -219,14 +215,14 @@ object SharedExtensions extends SharedExtensions {
       coll.foreach { a =>
         builders.getOrElseUpdate(keyFun(a), cbf(coll)) += valueFun(a)
       }
-      builders.iterator.map({ case (k, v) => (k, v.result()) }).toMap
+      builders.map({ case (k, v) => (k, v.result()) })(scala.collection.breakOut)
     }
 
     def headOpt: Opt[A] = coll.headOption.toOpt
 
     def lastOpt: Opt[A] = coll.lastOption.toOpt
 
-    def findOpt(p: A => Boolean) = coll.find(p).toOpt
+    def findOpt(p: A => Boolean): Opt[A] = coll.find(p).toOpt
 
     def collectFirstOpt[B](pf: PartialFunction[A, B]): Opt[B] = coll.collectFirst(pf).toOpt
 


### PR DESCRIPTION
* rename unusable `toMap` 
* use `breakOut`