### PR TITLE
Added result type metadata.

### DIFF
--- a/commons-core/src/test/scala/com/avsystem/commons/rpc/DummyRPC.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/rpc/DummyRPC.scala
@@ -7,6 +7,7 @@ object DummyRPC extends StandardRPCFramework {
   type Reader[T] = DummyImplicit
   type Writer[T] = DummyImplicit
   type ParamTypeMetadata[T] = TypeName[T]
+  type ResultTypeMetadata[T] = ClassTag[T]
 
   def read[T: Reader](raw: Any): T = raw.asInstanceOf[T]
   def write[T: Writer](value: T): Any = value

--- a/commons-core/src/test/scala/com/avsystem/commons/rpc/RPCMetadataTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/rpc/RPCMetadataTest.scala
@@ -39,13 +39,13 @@ class RPCMetadataTest extends FunSuite {
 
     assert(metadata.signatures("proc") == Signature("proc", List(List(
       ParamMetadata("param", List(Annot("on subparam"), Annot("on base param")), TypeName("String"))
-    )), List(Annot("on submethod"), Annot("on base method"))))
+    )), classTag[Unit], List(Annot("on submethod"), Annot("on base method"))))
 
     assert(metadata.signatures("genproc") == Signature("genproc", List(List(
       ParamMetadata("p", Nil, TypeName("String"))
-    )), Nil))
+    )), classTag[Unit], Nil))
 
-    assert(metadata.signatures("function") == Signature("func", Nil, Nil))
+    assert(metadata.signatures("function") == Signature("func", Nil, classTag[Future[_]], Nil))
 
     val resultMetadata = metadata.getterResults("getter")
     assert(resultMetadata.name == "Base")
@@ -55,12 +55,12 @@ class RPCMetadataTest extends FunSuite {
 
     assert(resultMetadata.signatures("proc") == Signature("proc", List(List(
       ParamMetadata("p", List(Annot("on base param")), TypeName("String"))
-    )), List(Annot("on base method"))))
+    )), classTag[Unit], List(Annot("on base method"))))
 
     assert(metadata.signatures("genproc") == Signature("genproc", List(List(
       ParamMetadata("p", Nil, TypeName("String"))
-    )), Nil))
+    )), classTag[Unit], Nil))
 
-    assert(resultMetadata.signatures("function") == Signature("func", Nil, Nil))
+    assert(resultMetadata.signatures("function") == Signature("func", Nil, classTag[Future[_]], Nil))
   }
 }

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/rpc/RPCMacros.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/rpc/RPCMacros.scala
@@ -250,6 +250,7 @@ class RPCMacros(ctx: blackbox.Context) extends AbstractMacroCommons(ctx) {
           $FrameworkObj.Signature(
             ${pm.method.name.decodedName.toString},
             $ListObj(..${pm.paramLists.map(ps => q"$ListObj(..${ps.map(reifyParamMetadata)})")}),
+            implicitly[$FrameworkObj.ResultTypeMetadata[${pm.returnType}]],
             ${reifyAnnotations(pm.method)}
           )
          """

--- a/commons-shared/src/main/scala/com/avsystem/commons/rpc/RPCFramework.scala
+++ b/commons-shared/src/main/scala/com/avsystem/commons/rpc/RPCFramework.scala
@@ -15,6 +15,7 @@ trait RPCFramework {
   def write[T: Writer](value: T): RawValue
 
   type ParamTypeMetadata[T]
+  type ResultTypeMetadata[T]
 
   object RPCMetadata {
     def apply[T](implicit metadata: RPCMetadata[T]): RPCMetadata[T] = metadata
@@ -96,6 +97,7 @@ trait RPCFramework {
   case class Signature(
     methodName: String,
     paramMetadata: List[List[ParamMetadata]],
+    resultTypeMetadata: ResultTypeMetadata[_],
     annotations: List[MetadataAnnotation]
   )
 


### PR DESCRIPTION
Now RPCMetadata contains also type class for RPC method result type. 