### PR TITLE
Mongo 3.5.0 update + minor cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ val scalatestVersion = "3.0.0"
 val upickleVersion = "0.4.4"
 val scalacheckVersion = "1.13.4"
 val jettyVersion = "9.3.8.v20160314"
-val mongoVersion = "3.2.2"
+val mongoVersion = "3.5.0"
+val mongoScalaVersion = "2.1.0"
 val springVersion = "4.0.2.RELEASE"
 val typesafeConfigVersion = "1.3.0"
 val commonsIoVersion = "1.3.2"
@@ -224,7 +225,10 @@ lazy val `commons-mongo` = project
   .settings(jvmCommonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "org.mongodb" % "mongodb-driver" % mongoVersion
+      "org.mongodb" % "mongodb-driver-core" % mongoVersion,
+      "org.mongodb" % "mongodb-driver" % mongoVersion % Optional,
+      "org.mongodb" % "mongodb-driver-async" % mongoVersion % Optional,
+      "org.mongodb.scala" %% "mongo-scala-driver" % mongoScalaVersion % Optional
     )
   )
 

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/BsonCodec.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/BsonCodec.scala
@@ -6,8 +6,8 @@ import java.time.Instant
 import org.bson.types.ObjectId
 import org.bson.{BsonArray, BsonBinary, BsonBoolean, BsonDateTime, BsonDocument, BsonDouble, BsonInt32, BsonInt64, BsonObjectId, BsonString, BsonValue}
 
-import scala.collection.generic.CanBuildFrom
-import scala.language.higherKinds
+import _root_.scala.collection.generic.CanBuildFrom
+import _root_.scala.language.higherKinds
 
 /**
   * @author MKej

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/Filter.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/Filter.scala
@@ -5,7 +5,7 @@ import com.mongodb.client.model.{Filters => F}
 import org.bson.conversions.Bson
 import org.bson.{BsonArray, BsonDateTime, BsonDouble, BsonInt32, BsonInt64, BsonString, BsonValue}
 
-import scala.collection.generic.CanBuildFrom
+import _root_.scala.collection.generic.CanBuildFrom
 
 /**
   * @author MKej

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/async/GenCodecCollection.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/async/GenCodecCollection.scala
@@ -1,0 +1,13 @@
+package com.avsystem.commons
+package mongo.async
+
+import com.avsystem.commons.mongo.core.GenCodecRegistry
+import com.avsystem.commons.serialization.GenCodec
+import com.mongodb.async.client.{MongoCollection, MongoDatabase}
+
+object GenCodecCollection {
+  def create[T: GenCodec](db: MongoDatabase, name: String)(implicit ct: ClassTag[T]): MongoCollection[T] = {
+    val newRegistry = GenCodecRegistry.create[T](db.getCodecRegistry)
+    db.withCodecRegistry(newRegistry).getCollection(name, ct.runtimeClass.asInstanceOf[Class[T]])
+  }
+}

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/core/GenCodecRegistry.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/core/GenCodecRegistry.scala
@@ -1,0 +1,13 @@
+package com.avsystem.commons
+package mongo.core
+
+import com.avsystem.commons.mongo.GenCodecBasedBsonCodec
+import com.avsystem.commons.serialization.GenCodec
+import org.bson.codecs.configuration.{CodecRegistries, CodecRegistry}
+
+object GenCodecRegistry {
+  def create[T: ClassTag : GenCodec](baseRegistry: CodecRegistry): CodecRegistry = {
+    val genRegistry = CodecRegistries.fromCodecs(new GenCodecBasedBsonCodec[T]())
+    CodecRegistries.fromRegistries(genRegistry, baseRegistry)
+  }
+}

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/scala/GenCodecCollection.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/scala/GenCodecCollection.scala
@@ -1,0 +1,13 @@
+package com.avsystem.commons
+package mongo.scala
+
+import com.avsystem.commons.mongo.core.GenCodecRegistry
+import com.avsystem.commons.serialization.GenCodec
+import org.mongodb.scala.{MongoCollection, MongoDatabase}
+
+object GenCodecCollection {
+  def create[T: ClassTag : GenCodec](db: MongoDatabase, name: String): MongoCollection[T] = {
+    val newRegistry = GenCodecRegistry.create[T](db.codecRegistry)
+    db.withCodecRegistry(newRegistry).getCollection(name)
+  }
+}

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/sync/GenCodecCollection.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/sync/GenCodecCollection.scala
@@ -1,0 +1,13 @@
+package com.avsystem.commons
+package mongo.sync
+
+import com.avsystem.commons.mongo.core.GenCodecRegistry
+import com.avsystem.commons.serialization.GenCodec
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+
+object GenCodecCollection {
+  def create[T: GenCodec](db: MongoDatabase, name: String)(implicit ct: ClassTag[T]): MongoCollection[T] = {
+    val newRegistry = GenCodecRegistry.create[T](db.getCodecRegistry)
+    db.withCodecRegistry(newRegistry).getCollection(name, ct.runtimeClass.asInstanceOf[Class[T]])
+  }
+}

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/sync/MongoOps.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/sync/MongoOps.scala
@@ -1,19 +1,20 @@
 package com.avsystem.commons
-package mongo
+package mongo.sync
 
-import com.avsystem.commons.mongo.MongoOps.{DBOps, FindIterableOps}
+import com.avsystem.commons.mongo.{BsonCodec, MongoCodec}
 import com.mongodb.Block
 import com.mongodb.client.{FindIterable, MongoCollection, MongoDatabase}
 import org.bson.BsonDocument
 import org.bson.codecs.configuration.CodecRegistries
 import org.bson.conversions.Bson
 
-import scala.language.implicitConversions
-
 /**
   * @author MKej
   */
 trait MongoOps {
+
+  import MongoOps._
+
   implicit def dbOps(db: MongoDatabase): DBOps = new DBOps(db)
   implicit def findIterableOps[T](find: FindIterable[T]): FindIterableOps[T] = new FindIterableOps(find)
 }

--- a/commons-mongo/src/test/scala/com/avsystem/commons/mongo/SomethingPlain.scala
+++ b/commons-mongo/src/test/scala/com/avsystem/commons/mongo/SomethingPlain.scala
@@ -5,7 +5,7 @@ import com.avsystem.commons.serialization.GenCodec
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 
-import scala.util.hashing.MurmurHash3
+import _root_.scala.util.hashing.MurmurHash3
 
 class BytesWrapper(val bytes: Array[Byte]) {
   override def hashCode(): Int = MurmurHash3.bytesHash(bytes)


### PR DESCRIPTION
- updated driver to 3.5.0
- made specific driver depenencies optional
- moved driver-related utilities to separate packages