### PR TITLE
Added missing test cases and fixed bug concerning classes with single vararg parameter

### DIFF
--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecTest.scala
@@ -221,23 +221,46 @@ class GenCodecTest extends CodecTestBase {
     implicit val codec: GenCodec[VarargsCaseClass] = GenCodec.materialize[VarargsCaseClass]
   }
 
+  case class OnlyVarargsCaseClass(strings: String*)
+  object OnlyVarargsCaseClass {
+    implicit val codec: GenCodec[OnlyVarargsCaseClass] = GenCodec.materialize[OnlyVarargsCaseClass]
+  }
+
   test("varargs case class test") {
     testWriteReadAndAutoWriteRead(VarargsCaseClass(42, "foo", "bar"),
       Map("int" -> 42, "strings" -> List("foo", "bar"))
     )
   }
 
-  class VarargsCaseClassLike(val str: String, val ints: Seq[Int])
-    extends Wrapper[VarargsCaseClassLike](str, ints)
+  test("only varargs case class test") {
+    testWriteReadAndAutoWriteRead(OnlyVarargsCaseClass("42", "420"),
+      Map("strings" -> List("42", "420"))
+    )
+  }
+
+  class VarargsCaseClassLike(val str: String, val ints: Seq[Int]) extends Wrapper[VarargsCaseClassLike](str, ints)
   object VarargsCaseClassLike {
     def apply(@name("some.str") str: String, ints: Int*): VarargsCaseClassLike = new VarargsCaseClassLike(str, ints)
     def unapplySeq(vccl: VarargsCaseClassLike): Opt[(String, Seq[Int])] = (vccl.str, vccl.ints).opt
     implicit val codec: GenCodec[VarargsCaseClassLike] = GenCodec.materialize[VarargsCaseClassLike]
   }
 
+  class OnlyVarargsCaseClassLike(val strings: Seq[String]) extends Wrapper[OnlyVarargsCaseClassLike](strings)
+  object OnlyVarargsCaseClassLike {
+    def apply(strings: String*): OnlyVarargsCaseClassLike = new OnlyVarargsCaseClassLike(strings)
+    def unapplySeq(vccl: OnlyVarargsCaseClassLike): Opt[(Seq[String])] = vccl.strings.opt
+    implicit val codec: GenCodec[OnlyVarargsCaseClassLike] = GenCodec.materialize[OnlyVarargsCaseClassLike]
+  }
+
   test("varargs case class like test") {
     testWriteReadAndAutoWriteRead(VarargsCaseClassLike("dafuq", 1, 2, 3),
       Map("some.str" -> "dafuq", "ints" -> List(1, 2, 3))
+    )
+  }
+
+  test("only varargs case class like test") {
+    testWriteReadAndAutoWriteRead(OnlyVarargsCaseClassLike("dafuq", "indeed"),
+      Map("strings" -> List("dafuq", "indeed"))
     )
   }
 

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/MacroCommons.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/MacroCommons.scala
@@ -349,7 +349,7 @@ trait MacroCommons {
           case Nil =>
             tpe =:= typeOf[Boolean]
           case List(singleParam) =>
-            hasIsEmpty && hasProperGet(resType => elemAdjust(resType) =:= singleParam.typeSignature)
+            hasIsEmpty && hasProperGet(resType => elemAdjust(resType) =:= nonRepeatedType(singleParam.typeSignature))
           case params =>
             hasIsEmpty && hasProperGet { resType =>
               val elemTypes = Iterator.range(1, 22).map { i =>


### PR DESCRIPTION
Classes like:
- case class OnlyVarargsCaseClass(strings: String*)
- class OnlyVarargsCaseClassLike(val strings: Seq[String])

couldn't have their GenCodec auto materialized due to the bug in `isCorrectUnapply` method:

Type `singleParam.typeSignature` (T*) was not equal to `elemAdjust(resType)` (Seq[T]).