### PR TITLE
Underlying codec in TransparentCodec should be evaluated lazily

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -61,8 +61,8 @@ abstract class ProductCodec[T <: Product](
 abstract class TransparentCodec[T, U](
   protected val typeRepr: String,
   val nullable: Boolean,
-  underlyingCodec: GenCodec[U]
 ) extends NullSafeCodec[T] with ErrorReportingCodec[T] {
+  protected def underlyingCodec: GenCodec[U]
   protected def wrap(underlying: U): T
   protected def unwrap(value: T): U
 

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/AutoGenCodecTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/AutoGenCodecTest.scala
@@ -40,6 +40,18 @@ class AutoGenCodecTest extends CodecTestBase {
     testAutoWriteRead(TransparentWrapper("something"), "something")
   }
 
+  @transparent
+  case class TransparentWrapperWithDependency(str: String)
+  object TransparentWrapperWithDependency {
+    //order matters
+    implicit val codec: GenCodec[TransparentWrapperWithDependency] = GenCodec.materialize
+    implicit val stringCodec: GenCodec[String] = GenCodec.StringCodec
+  }
+
+  test("transparent wrapper with dependency test") {
+    testAutoWriteRead(TransparentWrapperWithDependency("something"), "something")
+  }
+
   case class SomeCaseClass(@name("some.str") str: String, intList: List[Int])
 
   test("case class test") {

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecTest.scala
@@ -145,16 +145,16 @@ class GenCodecTest extends CodecTestBase {
     testWriteReadAndAutoWriteRead(TransparentWrapper("something"), "something")
   }
 
-  case object Lol
   @transparent
-  case class TransparentWrapperWithDependency(value: Lol.type)
+  case class TransparentWrapperWithDependency(str: String)
   object TransparentWrapperWithDependency {
+    //order matters
     implicit val codec: GenCodec[TransparentWrapperWithDependency] = GenCodec.materialize
-    implicit val lolCodec: GenCodec[Lol.type] = GenCodec.materialize
+    implicit val stringCodec: GenCodec[String] = GenCodec.StringCodec
   }
 
   test("transparent wrapper with dependency test") {
-    testWriteReadAndAutoWriteRead(TransparentWrapperWithDependency(Lol), Map.empty)
+    testWriteReadAndAutoWriteRead(TransparentWrapperWithDependency("something"), "something")
   }
 
   case class StringId(id: String)

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecTest.scala
@@ -145,6 +145,18 @@ class GenCodecTest extends CodecTestBase {
     testWriteReadAndAutoWriteRead(TransparentWrapper("something"), "something")
   }
 
+  case object Lol
+  @transparent
+  case class TransparentWrapperWithDependency(value: Lol.type)
+  object TransparentWrapperWithDependency {
+    implicit val codec: GenCodec[TransparentWrapperWithDependency] = GenCodec.materialize
+    implicit val lolCodec: GenCodec[Lol.type] = GenCodec.materialize
+  }
+
+  test("transparent wrapper with dependency test") {
+    testWriteReadAndAutoWriteRead(TransparentWrapperWithDependency(Lol), Map.empty)
+  }
+
   case class StringId(id: String)
   object StringId extends TransparentWrapperCompanion[String, StringId]
 

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
@@ -209,9 +209,9 @@ class GenCodecMacros(ctx: blackbox.Context) extends CodecMacroCommons(ctx) with 
         q"""
            new $SerializationPkg.TransparentCodec[$dtpe,${p.valueType}](
              ${dtpe.toString},
-             ${typeOf[Null] <:< dtpe},
-             ${p.instance}
+             ${typeOf[Null] <:< dtpe}
            ) {
+             lazy val underlyingCodec: $GenCodecCls[${p.valueType}] = ${p.instance}
              def wrap(underlying: ${p.valueType}): $dtpe = ${applier(List(q"underlying"))}
              def unwrap(value: $dtpe): ${p.valueType} = $unwrapBody
            }


### PR DESCRIPTION
It's very easy to forget about initialization order when using `GenCodec.materialize` in conjunction with a handwritten codec.