### PR TITLE
Proposal: provide an implicit Opt(ion) to OptArg conversion

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
@@ -11,6 +11,16 @@ object OptArg {
     */
   implicit def argToOptArg[A](value: A): OptArg[A] = OptArg(value)
 
+  /**
+    * This implicit conversion allows you to pass an `Opt` where `OptArg` is required.
+    */
+  implicit def optToOptArg[A](value: Opt[A]): OptArg[A] = value.toOptArg
+
+  /**
+    * This implicit conversion allows you to pass an `Option` where `OptArg` is required.
+    */
+  implicit def optionToOptArg[A](value: Option[A]): OptArg[A] = value.toOptArg
+
   private object EmptyMarker extends Serializable
 
   def apply[A](value: A): OptArg[A] = new OptArg[A](if (value != null) value else EmptyMarker)
@@ -20,7 +30,7 @@ object OptArg {
     if (value != null) new OptArg[A](value)
     else throw new NullPointerException
 
-  val Empty: OptArg[Nothing] = new OptArg(EmptyMarker)
+  final val Empty: OptArg[Nothing] = new OptArg(EmptyMarker)
   def empty[A]: OptArg[A] = Empty
 }
 

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/OptArgTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/OptArgTest.scala
@@ -25,8 +25,31 @@ class OptArgTest extends FunSuite with Matchers {
 
   def takeMaybeString(str: OptArg[String] = OptArg.Empty): Opt[String] = str.toOpt
 
-  test("argument passing") {
+  val stringzor = "stringzor"
+  val returnedMaybeStringzor = stringzor.opt
+
+  test("empty default argument") {
     takeMaybeString() shouldEqual Opt.Empty
-    takeMaybeString("stringzor") shouldEqual "stringzor".opt
+  }
+
+  test("argument passing") {
+    takeMaybeString(stringzor) shouldEqual returnedMaybeStringzor
+  }
+
+  test("Opt argument passing") {
+    val opt = stringzor.opt
+    val empty = Opt.Empty
+    takeMaybeString(opt) shouldEqual returnedMaybeStringzor
+    takeMaybeString(empty) shouldEqual Opt.Empty
+  }
+
+  test("Option argument passing") {
+    val option: Option[String] = stringzor.option
+    val some: Some[String] = Some(stringzor)
+    val none: None.type = None
+
+    takeMaybeString(option) shouldEqual returnedMaybeStringzor
+    takeMaybeString(some) shouldEqual returnedMaybeStringzor
+    takeMaybeString(none) shouldEqual Opt.Empty
   }
 }


### PR DESCRIPTION
I haven't spent too much time thinking this over, but I've definitely seen a lot of these conversions in `OptArg`-intensive code. Let the Battle for Boilerplatte begin!