### PR TITLE
Opt#zip

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
@@ -146,7 +146,7 @@ final class NOpt[+A] private(private val rawValue: Any) extends AnyVal with Seri
     if (isEmpty) Right(right) else Left(value)
 
   @inline def zip[B](that: NOpt[B]): NOpt[(A, B)] =
-    flatMap(l => that.map((l, _)))
+    if (isEmpty || that.isEmpty) NOpt.Empty else NOpt((this.get, that.get))
 
   /**
     * Apply side effect only if NOpt is empty. It's a bit like foreach for NOpt.Empty

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
@@ -145,6 +145,9 @@ final class NOpt[+A] private(private val rawValue: Any) extends AnyVal with Seri
   @inline def toLeft[X](right: => X): Either[A, X] =
     if (isEmpty) Right(right) else Left(value)
 
+  @inline def zip[B](that: NOpt[B]): NOpt[(A, B)] =
+    flatMap(l => that.map((l, _)))
+
   /**
     * Apply side effect only if NOpt is empty. It's a bit like foreach for NOpt.Empty
     * @param sideEffect - code to be executed if nopt is empty

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/Opt.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/Opt.scala
@@ -140,6 +140,9 @@ final class Opt[+A] private(private val rawValue: Any) extends AnyVal with Seria
   @inline def toLeft[X](right: => X): Either[A, X] =
     if (isEmpty) Right(right) else Left(value)
 
+  @inline def zip[B](that: Opt[B]): Opt[(A, B)] =
+    flatMap(l => that.map((l, _)))
+
   /**
     * Apply side effect only if Opt is empty. It's a bit like foreach for Opt.Empty
     *

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/Opt.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/Opt.scala
@@ -141,7 +141,7 @@ final class Opt[+A] private(private val rawValue: Any) extends AnyVal with Seria
     if (isEmpty) Right(right) else Left(value)
 
   @inline def zip[B](that: Opt[B]): Opt[(A, B)] =
-    flatMap(l => that.map((l, _)))
+    if (isEmpty || that.isEmpty) Opt.Empty else Opt((this.get, that.get))
 
   /**
     * Apply side effect only if Opt is empty. It's a bit like foreach for Opt.Empty

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/OptRef.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/OptRef.scala
@@ -123,6 +123,9 @@ final class OptRef[+A >: Null] private(private val value: A) extends AnyVal with
   @inline def toLeft[X](right: => X): Either[A, X] =
     if (isEmpty) Right(right) else Left(value)
 
+  @inline def zip[B >: Null](that: OptRef[B]): OptRef[(A, B)] =
+    flatMap(l => that.map((l, _)))
+
   /**
     * Apply side effect only if OptRef is empty. It's a bit like foreach for OptRef.Empty
     *

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/OptRef.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/OptRef.scala
@@ -124,7 +124,7 @@ final class OptRef[+A >: Null] private(private val value: A) extends AnyVal with
     if (isEmpty) Right(right) else Left(value)
 
   @inline def zip[B >: Null](that: OptRef[B]): OptRef[(A, B)] =
-    flatMap(l => that.map((l, _)))
+    if (isEmpty || that.isEmpty) OptRef.Empty else OptRef((this.get, that.get))
 
   /**
     * Apply side effect only if OptRef is empty. It's a bit like foreach for OptRef.Empty

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/NOptTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/NOptTest.scala
@@ -50,4 +50,10 @@ class NOptTest extends FunSuite {
     assert(NOpt(3).collect { case 3 => 2 } == NOpt.some(2))
     assert(NOpt(3).collect { case 3 => null } == NOpt.some(null))
   }
+
+  test("zip") {
+    assert(NOpt(3).zip(NOpt(2)) == NOpt((3, 2)))
+    assert(NOpt.Empty.zip(NOpt(2)) == NOpt.Empty)
+    assert(NOpt(3).zip(NOpt.Empty) == NOpt.Empty)
+  }
 }

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/OptRefTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/OptRefTest.scala
@@ -29,4 +29,10 @@ class OptRefTest extends FunSuite {
       case OptRef.Boxed(num) => assert(num == 42)
     }
   }
+
+  test("zip") {
+    assert(OptRef(3).zip(OptRef(2)) == OptRef((3, 2)))
+    assert(OptRef.Empty.zip(OptRef(2)) == OptRef.Empty)
+    assert(OptRef(3).zip(OptRef.Empty) == OptRef.Empty)
+  }
 }

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/OptTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/OptTest.scala
@@ -51,4 +51,10 @@ class OptTest extends FunSuite {
     assert(Opt(3).collect { case 2 => 2 } == Opt.Empty)
     assert(Opt(3).collect { case 3 => null } == Opt.Empty)
   }
+
+  test("zip") {
+    assert(Opt(3).zip(Opt(2)) == Opt((3, 2)))
+    assert(Opt.Empty.zip(Opt(2)) == Opt.Empty)
+    assert(Opt(3).zip(Opt.Empty) == Opt.Empty)
+  }
 }


### PR DESCRIPTION
Source and binary incompatible: previously this would resolve to scala.collection.IterableLike#zip and return `Iterable[(A,B)]`