### PR TITLE
Fix of unexpected MatchError in case of invalid escape character

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -298,6 +298,7 @@ final class JsonReader(val json: String) {
             case 'r' => '\r'
             case 't' => '\t'
             case 'u' => ((readHex() << 12) + (readHex() << 8) + (readHex() << 4) + readHex()).toChar
+            case c => throw new ReadFailure(s"Unexpected character: '${c.toChar}'")
           }
           sb.append(unesc)
           plainStart = i
@@ -305,8 +306,7 @@ final class JsonReader(val json: String) {
       }
     }
     if (sb != null) {
-      sb.append(json, plainStart, i - 1)
-      sb.toString
+      sb.append(json, plainStart, i - 1).toString
     } else {
       json.substring(plainStart, i - 1)
     }

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
@@ -23,27 +23,33 @@ trait BaseJsonOutput {
     var i = 0
     var s = 0
     while (i < str.length) {
-      val esc = str.charAt(i) match {
-        case '"' => "\\\""
-        case '\\' => "\\\\"
-        case '\b' => "\\b"
-        case '\f' => "\\f"
-        case '\n' => "\\n"
-        case '\r' => "\\r"
-        case '\t' => "\\t"
-        case c if (ascii && c.toInt > 127) || Character.isISOControl(c) =>
-          c.toInt.formatted("\\u%04x")
-        case _ => null
+      val ch = str.charAt(i)
+      val esc = ch match {
+        case '"' => '"'
+        case '\\' => '\\'
+        case '\b' => 'b'
+        case '\f' => 'f'
+        case '\n' => 'n'
+        case '\r' => 'r'
+        case '\t' => 't'
+        case _ => (if ((ascii && ch.toInt > 127) || Character.isISOControl(ch)) 1 else 0).toChar
       }
-      if (esc != null) {
-        builder.append(str, s, i).append(esc)
+      if (esc != 0) {
+        builder.append(str, s, i).append('\\')
         s = i + 1
+        if (esc != 1) {
+          builder.append(esc)
+        } else {
+          builder.append('u').append(toHex((ch >> 12) & 15)).append(toHex((ch >> 8) & 15))
+            .append(toHex((ch >> 4) & 15)).append(toHex(ch & 15))
+        }
       }
       i += 1
     }
-    builder.append(str, s, str.length)
-    builder.append('"')
+    builder.append(str, s, str.length).append('"')
   }
+
+  protected final def toHex(nibble: Int): Char = (nibble + (if (nibble >= 10) 87 else 48)).toChar
 }
 
 final class JsonStringOutput(builder: JStringBuilder, options: JsonOptions = JsonOptions.Default, depth: Int = 0)

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
@@ -110,6 +110,7 @@ class JsonStringInputOutputTest extends FunSuite with SerializationTestUtils wit
     val options = JsonOptions(asciiOutput = true)
     assert(write[String]("ąę", options) == "\"\\u0105\\u0119\"")
     assert(read[String]("\"\\u0105\\u0119\"", options) == "ąę")
+    intercept[ReadFailure](read[String]("\"\\x0105\""))
   }
 
   test("indentation") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.29.1"
+version in ThisBuild := "1.29.2-SNAPSHOT"


### PR DESCRIPTION
...and more efficient implementation of escaping during serialization.

Here are sources and results of benches that show ~25x times speed up with these changes: 
https://github.com/plokhotnyuk/jsoniter-scala/blob/8d0ddbe182c976cd2719fc96ff00e5d2b0a4328b/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/StringOfEscapedCharsBenchmark.scala#L79

Before:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                                  (size)   Mode  Cnt       Score       Error  Units
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec                           128  thrpt   15   14040.946 ±   627.483  ops/s
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:CPI                       128  thrpt    3       0.372 ±     0.093   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-dcache-load-misses     128  thrpt    3    2987.633 ±   787.590   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-dcache-loads           128  thrpt    3  184943.085 ± 48280.045   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-dcache-stores          128  thrpt    3  108028.813 ± 33434.628   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-icache-load-misses     128  thrpt    3    2290.099 ±  8855.335   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-load-misses           128  thrpt    3      12.700 ±    45.160   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-loads                 128  thrpt    3      64.759 ±    65.113   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-store-misses          128  thrpt    3     103.756 ±   124.405   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-stores                128  thrpt    3     553.939 ±  1937.347   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:branch-misses             128  thrpt    3      52.472 ±   225.503   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:branches                  128  thrpt    3  135800.930 ±  2307.957   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:cycles                    128  thrpt    3  262690.909 ± 95125.420   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-load-misses          128  thrpt    3       5.945 ±    35.759   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-loads                128  thrpt    3  184584.781 ± 43213.580   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-store-misses         128  thrpt    3       0.324 ±     2.084   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-stores               128  thrpt    3  107811.640 ± 19724.146   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:iTLB-load-misses          128  thrpt    3       1.268 ±     3.698   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:iTLB-loads                128  thrpt    3       3.872 ±    48.190   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:instructions              128  thrpt    3  705268.484 ± 90807.324   #/op
```
After:
```
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                                                                  (size)   Mode  Cnt       Score       Error  Units
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec                           128  thrpt   15  355209.187 ±  7480.180  ops/s
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:CPI                       128  thrpt    3       0.306 ±     0.034   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-dcache-load-misses     128  thrpt    3     155.642 ±    12.174   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-dcache-loads           128  thrpt    3    8602.742 ± 14827.823   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-dcache-stores          128  thrpt    3    6932.436 ±  2303.462   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:L1-icache-load-misses     128  thrpt    3       1.357 ±    16.514   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-load-misses           128  thrpt    3       1.540 ±     1.601   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-loads                 128  thrpt    3       2.075 ±     5.073   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-store-misses          128  thrpt    3     103.469 ±    32.613   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:LLC-stores                128  thrpt    3     129.667 ±    59.683   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:branch-misses             128  thrpt    3       6.125 ±     4.782   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:branches                  128  thrpt    3    4922.500 ±   782.927   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:cycles                    128  thrpt    3   10636.261 ±  1937.043   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-load-misses          128  thrpt    3       2.090 ±     0.216   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-loads                128  thrpt    3    8357.249 ± 15612.960   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-store-misses         128  thrpt    3       0.015 ±     0.166   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:dTLB-stores               128  thrpt    3    6760.776 ±  5198.999   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:iTLB-load-misses          128  thrpt    3       0.045 ±     0.210   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:iTLB-loads                128  thrpt    3       0.078 ±     0.792   #/op
[info] StringOfEscapedCharsBenchmark.writeAVSystemGenCodec:instructions              128  thrpt    3   34779.867 ±  8756.952   #/op
```