### PR TITLE
Redis 5.0 support + better blocking operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 env:
   global:
-    - REDIS_VERSION=4.0.0
+    - REDIS_VERSION=5.0.0
     - REDIS_HOME=$PWD/redis-$REDIS_VERSION/src
   matrix:
     - JOB="commons-jvm/test"

--- a/commons-benchmark/jvm/src/main/scala/com/avsystem/commons/redis/RedisClientBenchmark.scala
+++ b/commons-benchmark/jvm/src/main/scala/com/avsystem/commons/redis/RedisClientBenchmark.scala
@@ -141,7 +141,7 @@ class RedisClientBenchmark extends RedisBenchmark with CrossRedisBenchmark {
       value <- watch(key) *> get(key)
       _ <- set(key, value.getOrElse("v")).transaction
     } yield ()
-    client.executeOp(operation, ExecutionConfig(timeout = Timeout(2, TimeUnit.SECONDS)))
+    client.executeOp(operation, ExecutionConfig(responseTimeout = Timeout(2, TimeUnit.SECONDS)))
   }
 
   def mixedFuture(client: RedisKeyedExecutor with RedisOpExecutor, seq: Int, i: Int) =

--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -567,6 +567,23 @@ object SharedExtensions extends SharedExtensions {
   }
 
   class IteratorOps[A](private val it: Iterator[A]) extends AnyVal {
+    def pairs: Iterator[(A, A)] = new AbstractIterator[(A, A)] {
+      private var first: NOpt[A] = NOpt.empty
+
+      def hasNext: Boolean = it.hasNext && (first.nonEmpty || {
+        first = NOpt(it.next())
+        it.hasNext
+      })
+
+      def next(): (A, A) =
+        if (!hasNext) throw new NoSuchElementException
+        else {
+          val f = first.get // safe because hasNext was called
+          first = NOpt.Empty
+          (f, it.next())
+        }
+    }
+
     def nextOpt: Opt[A] =
       if (it.hasNext) it.next().opt else Opt.Empty
 

--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -464,6 +464,13 @@ object SharedExtensions extends SharedExtensions {
   }
 
   class TraversableOnceOps[C[X] <: TraversableOnce[X], A](private val coll: C[A]) extends AnyVal {
+    def toSized[M[_]](sizeHint: Int)(implicit cbf: CanBuildFrom[Nothing, A, M[A]]): M[A] = {
+      val b = cbf()
+      b.sizeHint(sizeHint)
+      b ++= coll
+      b.result()
+    }
+
     def toMapBy[K](keyFun: A => K): Map[K, A] =
       mkMap(keyFun, identity)
 

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
@@ -10,6 +10,7 @@ object OptArg {
     * This implicit conversion allows you to pass unwrapped values where `OptArg` is required.
     */
   implicit def argToOptArg[A](value: A): OptArg[A] = OptArg(value)
+  implicit def intToOptArgLong(int: Int): OptArg[Long] = OptArg(int)
 
   private object EmptyMarker extends Serializable
 

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
@@ -10,7 +10,10 @@ object OptArg {
     * This implicit conversion allows you to pass unwrapped values where `OptArg` is required.
     */
   implicit def argToOptArg[A](value: A): OptArg[A] = OptArg(value)
+
+  // additional implicits to cover most common, safe numeric promotions
   implicit def intToOptArgLong(int: Int): OptArg[Long] = OptArg(int)
+  implicit def intToOptArgDouble(int: Int): OptArg[Double] = OptArg(int)
 
   private object EmptyMarker extends Serializable
 

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
@@ -1,26 +1,15 @@
 package com.avsystem.commons
 package serialization
 
-import com.avsystem.commons.misc.MacroGenerated
+import com.avsystem.commons.meta.MacroInstances
 
 /**
   * Convenience abstract class for companion objects of types that have a [[GenCodec]].
   */
-abstract class HasGenCodec[T](implicit macroCodec: MacroGenerated[Any, GenCodec[T]]) {
-  /**
-    * Use this constructor and pass `GenCodec.materialize` explicitly if you're getting the
-    * "super constructor cannot be passed a self reference unless parameter is declared by-name" error.
-    *
-    * {{{
-    *   case class Stuff(int: Int = 42)
-    *   object Stuff extends HasGenCodec[Stuff](GenCodec.materialize)
-    * }}}
-    */
-  def this(codec: => GenCodec[T]) = this()(MacroGenerated(codec))
-
-  implicit val codec: GenCodec[T] = macroCodec.forCompanion(this)
+abstract class HasGenCodec[T](implicit macroCodec: MacroInstances[Unit, () => GenCodec[T]]) {
+  implicit val codec: GenCodec[T] = macroCodec((), this).apply()
 }
 
-abstract class HasApplyUnapplyCodec[T](implicit macroCodec: MacroGenerated[Any, ApplyUnapplyCodec[T]]) {
-  implicit val codec: ApplyUnapplyCodec[T] = macroCodec.forCompanion(this)
+abstract class HasApplyUnapplyCodec[T](implicit macroCodec: MacroInstances[Unit, () => ApplyUnapplyCodec[T]]) {
+  implicit val codec: ApplyUnapplyCodec[T] = macroCodec((), this).apply()
 }

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
@@ -20,3 +20,7 @@ abstract class HasGenCodec[T](implicit macroCodec: MacroGenerated[Any, GenCodec[
 
   implicit val codec: GenCodec[T] = macroCodec.forCompanion(this)
 }
+
+abstract class HasApplyUnapplyCodec[T](implicit macroCodec: MacroGenerated[Any, ApplyUnapplyCodec[T]]) {
+  implicit val codec: ApplyUnapplyCodec[T] = macroCodec.forCompanion(this)
+}

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -48,6 +48,9 @@ abstract class ApplyUnapplyCodec[T](
     instantiate(fieldValues)
   }
 }
+object ApplyUnapplyCodec {
+  def materialize[T]: ApplyUnapplyCodec[T] = macro macros.serialization.GenCodecMacros.applyUnapplyCodec[T]
+}
 
 abstract class ProductCodec[T <: Product](
   typeRepr: String,

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -92,7 +92,7 @@ trait RedisBlockingApi extends RedisExecutedApi {
   type Result[A] = A
   def execute[A](command: RedisCommand[A]): A =
   // executeAsync should already handle timeouts, but just to be safe let's pass the standard timeout plus one second
-    Await.result(executeAsync(command), execConfig.timeout.duration + 1.second)
+    Await.result(executeAsync(command), execConfig.responseTimeout.duration + 1.second)
   def recoverWith[A](executed: => A)(fun: PartialFunction[Throwable, A]): A =
     try executed catch fun
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -129,7 +129,5 @@ trait RedisConnectionApi extends RedisOperationApi
   with ConnectionConnectionApi
   with ConnectionServerApi
   with ConnectionScriptingApi
-  with BlockingListsApi
-  with BlockingSortedSetsApi
 
 trait RedisRecoverableConnectionApi extends RedisRecoverableNodeApi with RedisConnectionApi

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -38,7 +38,7 @@ trait RedisSerialization {
   type Value
 
   /**
-    * Type used to represent key-value pair sequences, primarily entries in [[StreamsApi]] but also hashes in
+    * Type used to represent key-value pair sequences, primarily entries in Streams API but also hashes in
     * [[HashesApi]]. `Record` might be a "raw" type like `Map[Key, Value]` or `Seq[(Key, Value)]` but normally
     * `Record` is customized to be an ADT - a case class or sealed hierarchy.
     */

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -16,31 +16,6 @@ trait ApiSubset { self =>
     */
   type Result[A]
 
-  /**
-    * The type of Redis keys or key patterns used in methods representing Redis commands. For example, if `Key = String`
-    * then [[commands.StringsApi.get get]] returns `Result[Opt[String]]`. This type is used only for toplevel Redis keys, hash
-    * keys have their own type, [[Field]].
-    */
-  type Key
-  /**
-    * The type of Redis hash keys or hash key patterns used in methods representing Redis commands that work on
-    * hashes ([[commands.HashesApi HashesApi]]).
-    */
-  type Field
-  /**
-    * The type of Redis values used in methods representing Redis commands. "Value" is the data that might be
-    * stored directly under a Redis key (e.g. using [[commands.StringsApi.set set]]) but also a value of hash field, list element,
-    * set member, sorted set member, geo set member or element inserted into hyper-log-log structure.
-    * There are no separate types specified for every of those use cases because only one of them can be used in a
-    * single command (for example, there is no Redis command that works on both list elements and set members
-    * at the same time).
-    */
-  type Value
-
-  protected implicit def keyCodec: RedisDataCodec[Key]
-  protected implicit def fieldCodec: RedisDataCodec[Field]
-  protected implicit def valueCodec: RedisDataCodec[Value]
-
   def execute[A](command: RedisCommand[A]): Result[A]
 
   protected implicit def iterableTailOps[T](tail: Iterable[T]): IterableTailOps[T] = new IterableTailOps(tail)
@@ -58,6 +33,47 @@ object ApiSubset {
   class IteratorTailOps[A](private val tail: Iterator[A]) extends AnyVal {
     def +::(head: A): Iterator[A] = new HeadIterator(head, tail)
   }
+}
+
+trait KeyedApiSubset extends ApiSubset {
+  /**
+    * The type of Redis keys or key patterns used in methods representing Redis commands. For example, if `Key = String`
+    * then [[commands.StringsApi.get get]] returns `Result[Opt[String]]`. This type is used only for toplevel Redis keys, hash
+    * keys have their own type, [[FieldValueApiSubset.Field]]
+    */
+  type Key
+
+  protected implicit def keyCodec: RedisDataCodec[Key]
+}
+
+trait ValueApiSubset extends KeyedApiSubset {
+  /**
+    * The type of Redis values used in methods representing Redis commands. "Value" is the data that might be
+    * stored directly under a Redis key (e.g. using [[commands.StringsApi.set set]]) but also a value of hash field,
+    * list element, set member, sorted set member, geo set member or element inserted into hyper-log-log structure.
+    * There are no separate types specified for every of those use cases because only one of them can be used in a
+    * single command (for example, there is no Redis command that works on both list elements and set members
+    * at the same time).
+    */
+  type Value
+
+  protected implicit def valueCodec: RedisDataCodec[Value]
+}
+
+trait RecordApiSubset extends KeyedApiSubset {
+  type Record
+
+  protected implicit def recordCodec: RedisRecordCodec[Record]
+}
+
+trait FieldValueApiSubset extends ValueApiSubset {
+  /**
+    * The type of Redis hash keys or hash key patterns used in methods representing Redis commands that work on
+    * hashes ([[commands.HashesApi HashesApi]]).
+    */
+  type Field
+
+  protected implicit def fieldCodec: RedisDataCodec[Field]
 }
 
 trait RecoverableApiSubset extends ApiSubset {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -1,6 +1,7 @@
 package com.avsystem.commons
 package redis
 
+import akka.util.ByteString
 import com.avsystem.commons.redis.ApiSubset.{HeadOps, IterableTailOps, IteratorTailOps}
 import com.avsystem.commons.redis.commands._
 import com.avsystem.commons.redis.config.ExecutionConfig
@@ -9,7 +10,98 @@ import com.avsystem.commons.redis.util.{HeadIterable, HeadIterator, SingletonSeq
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+/**
+  * Encapsulates types that Redis commands may be parameterized with and provides serialization for these types.
+  */
+trait RedisSerialization {
+  /**
+    * The type of Redis keys or key patterns used in methods representing Redis commands. For example, if `Key = String`
+    * then [[commands.StringsApi.get get]] returns `Result[Opt[String]]`. This type is used only for toplevel Redis keys,
+    * hash keys have their own type, [[Field]]
+    */
+  type Key
+
+  /**
+    * The type of Redis hash keys or hash key patterns used in methods representing Redis commands that work on
+    * hashes ([[commands.HashesApi HashesApi]]).
+    */
+  type Field
+
+  /**
+    * The type of Redis values used in methods representing Redis commands. "Value" is the data that might be
+    * stored directly under a Redis key (e.g. using [[commands.StringsApi.set set]]) but also a value of hash field,
+    * list element, set member, sorted set member, geo set member or element inserted into hyper-log-log structure.
+    * There are no separate types specified for every of those use cases because only one of them can be used in a
+    * single command (for example, there is no Redis command that works on both list elements and set members
+    * at the same time).
+    */
+  type Value
+
+  /**
+    * Type used to represent key-value pair sequences, primarily entries in [[StreamsApi]] but also hashes in
+    * [[HashesApi]]. `Record` might be a "raw" type like `Map[Key, Value]` or `Seq[(Key, Value)]` but normally
+    * `Record` is customized to be an ADT - a case class or sealed hierarchy.
+    */
+  type Record
+
+  def keyCodec: RedisDataCodec[Key]
+  def fieldCodec: RedisDataCodec[Field]
+  def valueCodec: RedisDataCodec[Value]
+  def recordCodec: RedisRecordCodec[Record]
+
+  type WithKey[K] = RedisSerialization.Aux[K, Field, Value, Record]
+  type WithField[F] = RedisSerialization.Aux[Key, F, Value, Record]
+  type WithValue[V] = RedisSerialization.Aux[Key, Field, V, Record]
+  type WithRecord[R] = RedisSerialization.Aux[Key, Field, Value, R]
+
+  def keyType[K0: RedisDataCodec]: WithKey[K0]
+  def fieldType[F0: RedisDataCodec]: WithField[F0]
+  def valueType[V0: RedisDataCodec]: WithValue[V0]
+  def recordType[R0: RedisRecordCodec]: WithRecord[R0]
+}
+
+object RedisSerialization {
+  type Aux[K, F, V, R] = RedisSerialization {
+    type Key = K
+    type Field = F
+    type Value = V
+    type Record = R
+  }
+
+  object Strings extends Generic[String, String, String, Map[String, String]]
+  object ByteStrings extends Generic[ByteString, ByteString, ByteString, Map[ByteString, ByteString]]
+
+  class Generic[K, F, V, R](implicit
+    val keyCodec: RedisDataCodec[K],
+    val fieldCodec: RedisDataCodec[F],
+    val valueCodec: RedisDataCodec[V],
+    val recordCodec: RedisRecordCodec[R]
+  ) extends RedisSerialization {
+    type Key = K
+    type Field = F
+    type Value = V
+    type Record = R
+
+    def keyType[K0: RedisDataCodec]: WithKey[K0] = new Generic
+    def fieldType[F0: RedisDataCodec]: WithField[F0] = new Generic
+    def valueType[V0: RedisDataCodec]: WithValue[V0] = new Generic
+    def recordType[R0: RedisRecordCodec]: WithRecord[R0] = new Generic
+  }
+}
+
 trait ApiSubset { self =>
+  val serialization: RedisSerialization
+
+  type Key = serialization.Key
+  type Field = serialization.Field
+  type Value = serialization.Value
+  type Record = serialization.Record
+
+  protected implicit final def keyCodec: RedisDataCodec[Key] = serialization.keyCodec
+  protected implicit final def fieldCodec: RedisDataCodec[Field] = serialization.fieldCodec
+  protected implicit final def valueCodec: RedisDataCodec[Value] = serialization.valueCodec
+  protected implicit final def recordCodec: RedisRecordCodec[Record] = serialization.recordCodec
+
   /**
     * The type constructor into which a result of each command is wrapped. For example if `Result` is
     * `Future`, then [[commands.StringsApi.incr incr]] returns `Future[Long]`.
@@ -33,47 +125,6 @@ object ApiSubset {
   class IteratorTailOps[A](private val tail: Iterator[A]) extends AnyVal {
     def +::(head: A): Iterator[A] = new HeadIterator(head, tail)
   }
-}
-
-trait KeyedApiSubset extends ApiSubset {
-  /**
-    * The type of Redis keys or key patterns used in methods representing Redis commands. For example, if `Key = String`
-    * then [[commands.StringsApi.get get]] returns `Result[Opt[String]]`. This type is used only for toplevel Redis keys, hash
-    * keys have their own type, [[FieldValueApiSubset.Field]]
-    */
-  type Key
-
-  protected implicit def keyCodec: RedisDataCodec[Key]
-}
-
-trait ValueApiSubset extends KeyedApiSubset {
-  /**
-    * The type of Redis values used in methods representing Redis commands. "Value" is the data that might be
-    * stored directly under a Redis key (e.g. using [[commands.StringsApi.set set]]) but also a value of hash field,
-    * list element, set member, sorted set member, geo set member or element inserted into hyper-log-log structure.
-    * There are no separate types specified for every of those use cases because only one of them can be used in a
-    * single command (for example, there is no Redis command that works on both list elements and set members
-    * at the same time).
-    */
-  type Value
-
-  protected implicit def valueCodec: RedisDataCodec[Value]
-}
-
-trait RecordApiSubset extends KeyedApiSubset {
-  type Record
-
-  protected implicit def recordCodec: RedisRecordCodec[Record]
-}
-
-trait FieldValueApiSubset extends ValueApiSubset {
-  /**
-    * The type of Redis hash keys or hash key patterns used in methods representing Redis commands that work on
-    * hashes ([[commands.HashesApi HashesApi]]).
-    */
-  type Field
-
-  protected implicit def fieldCodec: RedisDataCodec[Field]
 }
 
 trait RecoverableApiSubset extends ApiSubset {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -19,14 +19,14 @@ trait ApiSubset { self =>
   /**
     * The type of Redis keys or key patterns used in methods representing Redis commands. For example, if `Key = String`
     * then [[commands.StringsApi.get get]] returns `Result[Opt[String]]`. This type is used only for toplevel Redis keys, hash
-    * keys have their own type, [[HashKey]].
+    * keys have their own type, [[Field]].
     */
   type Key
   /**
     * The type of Redis hash keys or hash key patterns used in methods representing Redis commands that work on
     * hashes ([[commands.HashesApi HashesApi]]).
     */
-  type HashKey
+  type Field
   /**
     * The type of Redis values used in methods representing Redis commands. "Value" is the data that might be
     * stored directly under a Redis key (e.g. using [[commands.StringsApi.set set]]) but also a value of hash field, list element,
@@ -38,7 +38,7 @@ trait ApiSubset { self =>
   type Value
 
   protected implicit def keyCodec: RedisDataCodec[Key]
-  protected implicit def hashKeyCodec: RedisDataCodec[HashKey]
+  protected implicit def fieldCodec: RedisDataCodec[Field]
   protected implicit def valueCodec: RedisDataCodec[Value]
 
   def execute[A](command: RedisCommand[A]): Result[A]

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -38,9 +38,9 @@ trait RedisSerialization {
   type Value
 
   /**
-    * Type used to represent key-value pair sequences, primarily entries in Streams API but also hashes in
-    * [[HashesApi]]. `Record` might be a "raw" type like `Map[Key, Value]` or `Seq[(Key, Value)]` but normally
-    * `Record` is customized to be an ADT - a case class or sealed hierarchy.
+    * Type used to represent key-value pair sequences, primarily entries in [[commands.StreamsApi StreamsApi]]
+    * but also hashes in [[commands.HashesApi HashesApi]]. `Record` might be a "raw" type like `Map[Key, Value]` or
+    * `Seq[(Key, Value)]` but normally `Record` is customized to be an ADT - a case class or sealed hierarchy.
     */
   type Record
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -130,5 +130,6 @@ trait RedisConnectionApi extends RedisOperationApi
   with ConnectionServerApi
   with ConnectionScriptingApi
   with BlockingListsApi
+  with BlockingSortedSetsApi
 
 trait RedisRecoverableConnectionApi extends RedisRecoverableNodeApi with RedisConnectionApi

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -108,6 +108,7 @@ trait RedisKeyedApi extends AnyRef
   with ListsApi
   with SetsApi
   with HyperLogLogApi
+  with StreamsApi
 
 trait RedisRecoverableKeyedApi extends RedisKeyedApi
   with RecoverableKeyedScriptingApi

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
@@ -76,10 +76,10 @@ import com.avsystem.commons.redis.config.ExecutionConfig
   * }}}
   */
 object RedisApi {
-  class Raw[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec]
-    extends AbstractRedisApi[Raw, Key, HashKey, Value] with RedisConnectionApi with RedisRawApi {
-    def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-      new Raw[K, H, V]()(newKeyCodec, newHashKeyCodec, newValueCodec)
+  class Raw[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec]
+    extends AbstractRedisApi[Raw, Key, Field, Value] with RedisConnectionApi with RedisRawApi {
+    def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+      new Raw[K, H, V]()(newKeyCodec, newFieldCodec, newValueCodec)
   }
   /**
     * Entry point for API variants which return [[RawCommand]]s.
@@ -89,10 +89,10 @@ object RedisApi {
     object BinaryTyped extends Raw[ByteString, ByteString, ByteString]
   }
 
-  class Batches[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec]
-    extends AbstractRedisApi[Batches, Key, HashKey, Value] with RedisConnectionApi with RedisBatchApi {
-    def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-      new Batches[K, H, V]()(newKeyCodec, newHashKeyCodec, newValueCodec)
+  class Batches[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec]
+    extends AbstractRedisApi[Batches, Key, Field, Value] with RedisConnectionApi with RedisBatchApi {
+    def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+      new Batches[K, H, V]()(newKeyCodec, newFieldCodec, newValueCodec)
   }
   /**
     * Entry point for API variants which return [[RedisBatch]]es.
@@ -106,12 +106,12 @@ object RedisApi {
     * Entry point for API variants which expose only keyed commands.
     */
   object Keyed {
-    class Async[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec](
+    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
       val executor: RedisKeyedExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Async, Key, HashKey, Value] with RedisRecoverableKeyedApi with RedisAsyncApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, H, V](executor, execConfig)(newKeyCodec, newHashKeyCodec, newValueCodec)
+    ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableKeyedApi with RedisAsyncApi {
+      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+        new Async[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisKeyedExecutor]] (e.g. [[RedisClusterClient]])
@@ -124,12 +124,12 @@ object RedisApi {
         extends Async[ByteString, ByteString, ByteString](exec, config)
     }
 
-    class Blocking[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec](
+    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
       val executor: RedisKeyedExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Blocking, Key, HashKey, Value] with RedisRecoverableKeyedApi with RedisBlockingApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newHashKeyCodec, newValueCodec)
+    ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableKeyedApi with RedisBlockingApi {
+      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisKeyedExecutor]] (e.g. [[RedisClusterClient]])
@@ -148,12 +148,12 @@ object RedisApi {
     * Redis connection state.
     */
   object Node {
-    class Async[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec](
+    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
       val executor: RedisNodeExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Async, Key, HashKey, Value] with RedisRecoverableNodeApi with RedisAsyncApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, H, V](executor, execConfig)(newKeyCodec, newHashKeyCodec, newValueCodec)
+    ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableNodeApi with RedisAsyncApi {
+      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+        new Async[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisNodeExecutor]] (e.g. [[RedisNodeClient]])
@@ -166,12 +166,12 @@ object RedisApi {
         extends Async[ByteString, ByteString, ByteString](exec, config)
     }
 
-    class Blocking[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec](
+    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
       val executor: RedisNodeExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Blocking, Key, HashKey, Value] with RedisRecoverableNodeApi with RedisBlockingApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newHashKeyCodec, newValueCodec)
+    ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableNodeApi with RedisBlockingApi {
+      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisNodeExecutor]] (e.g. [[RedisNodeClient]])
@@ -190,12 +190,12 @@ object RedisApi {
     * access or modify Redis connection state.
     */
   object Connection {
-    class Async[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec](
+    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
       val executor: RedisConnectionExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Async, Key, HashKey, Value] with RedisRecoverableConnectionApi with RedisAsyncApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, H, V](executor, execConfig)(newKeyCodec, newHashKeyCodec, newValueCodec)
+    ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableConnectionApi with RedisAsyncApi {
+      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+        new Async[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisConnectionExecutor]] (e.g. [[RedisConnectionClient]])
@@ -208,12 +208,12 @@ object RedisApi {
         extends Async[ByteString, ByteString, ByteString](exec, config)
     }
 
-    class Blocking[Key: RedisDataCodec, HashKey: RedisDataCodec, Value: RedisDataCodec](
+    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
       val executor: RedisConnectionExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Blocking, Key, HashKey, Value] with RedisRecoverableConnectionApi with RedisBlockingApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newHashKeyCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newHashKeyCodec, newValueCodec)
+    ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableConnectionApi with RedisBlockingApi {
+      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
+        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisConnectionExecutor]] (e.g. [[RedisConnectionClient]])
@@ -228,17 +228,17 @@ object RedisApi {
   }
 }
 
-abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H0, V0], K, H, V](implicit
-  val keyCodec: RedisDataCodec[K], val hashKeyCodec: RedisDataCodec[H], val valueCodec: RedisDataCodec[V])
+abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H0, V0], K, F, V](implicit
+  val keyCodec: RedisDataCodec[K], val fieldCodec: RedisDataCodec[F], val valueCodec: RedisDataCodec[V])
   extends ApiSubset {
 
   type Key = K
-  type HashKey = H
+  type Field = F
   type Value = V
 
-  type WithKey[K0] = Self[K0, H, V]
-  type WithHashKey[H0] = Self[K, H0, V]
-  type WithValue[V0] = Self[K, H, V0]
+  type WithKey[K0] = Self[K0, F, V]
+  type WithField[F0] = Self[K, F0, V]
+  type WithValue[V0] = Self[K, F, V0]
 
   /**
     * Changes the type of key used by this API variant to some other type for which an instance of
@@ -258,15 +258,15 @@ abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H
     * Changes the type of hash key used by this API variant to some other type for which an instance of
     * [[RedisDataCodec]] exists.
     */
-  def hashKeyType[H0: RedisDataCodec]: WithHashKey[H0] =
-    copy(newHashKeyCodec = RedisDataCodec[H0])
+  def fieldType[F0: RedisDataCodec]: WithField[F0] =
+    copy(newFieldCodec = RedisDataCodec[F0])
 
   /**
     * Changes the type of hash key used by this API variant to some other type by directly providing
     * functions which convert between new and old type.
     */
-  def transformHashKey[H0](read: H => H0)(write: H0 => H): WithHashKey[H0] =
-    copy(newHashKeyCodec = RedisDataCodec(hashKeyCodec.read andThen read, write andThen hashKeyCodec.write))
+  def transformField[H0](read: F => H0)(write: H0 => F): WithField[H0] =
+    copy(newFieldCodec = RedisDataCodec(fieldCodec.read andThen read, write andThen fieldCodec.write))
 
   /**
     * Changes the type of value used by this API variant to some other type for which an instance of
@@ -284,7 +284,7 @@ abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H
 
   def copy[K0, H0, V0](
     newKeyCodec: RedisDataCodec[K0] = keyCodec,
-    newHashKeyCodec: RedisDataCodec[H0] = hashKeyCodec,
+    newFieldCodec: RedisDataCodec[H0] = fieldCodec,
     newValueCodec: RedisDataCodec[V0] = valueCodec
   ): Self[K0, H0, V0]
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
@@ -229,8 +229,10 @@ object RedisApi {
 }
 
 abstract class AbstractRedisApi[Self[K0, F0, V0] <: AbstractRedisApi[Self, K0, F0, V0], K, F, V](implicit
-  val keyCodec: RedisDataCodec[K], val fieldCodec: RedisDataCodec[F], val valueCodec: RedisDataCodec[V])
-  extends ApiSubset {
+  protected val keyCodec: RedisDataCodec[K],
+  protected val fieldCodec: RedisDataCodec[F],
+  protected val valueCodec: RedisDataCodec[V]
+) extends ApiSubset {
 
   type Key = K
   type Field = F

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
@@ -78,8 +78,8 @@ import com.avsystem.commons.redis.config.ExecutionConfig
 object RedisApi {
   class Raw[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec]
     extends AbstractRedisApi[Raw, Key, Field, Value] with RedisConnectionApi with RedisRawApi {
-    def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-      new Raw[K, H, V]()(newKeyCodec, newFieldCodec, newValueCodec)
+    def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+      new Raw[K, F, V]()(newKeyCodec, newFieldCodec, newValueCodec)
   }
   /**
     * Entry point for API variants which return [[RawCommand]]s.
@@ -91,8 +91,8 @@ object RedisApi {
 
   class Batches[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec]
     extends AbstractRedisApi[Batches, Key, Field, Value] with RedisConnectionApi with RedisBatchApi {
-    def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-      new Batches[K, H, V]()(newKeyCodec, newFieldCodec, newValueCodec)
+    def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+      new Batches[K, F, V]()(newKeyCodec, newFieldCodec, newValueCodec)
   }
   /**
     * Entry point for API variants which return [[RedisBatch]]es.
@@ -110,8 +110,8 @@ object RedisApi {
       val executor: RedisKeyedExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
     ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableKeyedApi with RedisAsyncApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+        new Async[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisKeyedExecutor]] (e.g. [[RedisClusterClient]])
@@ -128,8 +128,8 @@ object RedisApi {
       val executor: RedisKeyedExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
     ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableKeyedApi with RedisBlockingApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+        new Blocking[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisKeyedExecutor]] (e.g. [[RedisClusterClient]])
@@ -152,8 +152,8 @@ object RedisApi {
       val executor: RedisNodeExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
     ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableNodeApi with RedisAsyncApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+        new Async[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisNodeExecutor]] (e.g. [[RedisNodeClient]])
@@ -170,8 +170,8 @@ object RedisApi {
       val executor: RedisNodeExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
     ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableNodeApi with RedisBlockingApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+        new Blocking[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisNodeExecutor]] (e.g. [[RedisNodeClient]])
@@ -194,8 +194,8 @@ object RedisApi {
       val executor: RedisConnectionExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
     ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableConnectionApi with RedisAsyncApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+        new Async[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisConnectionExecutor]] (e.g. [[RedisConnectionClient]])
@@ -212,8 +212,8 @@ object RedisApi {
       val executor: RedisConnectionExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
     ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableConnectionApi with RedisBlockingApi {
-      def copy[K, H, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[H], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, H, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
+        new Blocking[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisConnectionExecutor]] (e.g. [[RedisConnectionClient]])
@@ -228,7 +228,7 @@ object RedisApi {
   }
 }
 
-abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H0, V0], K, F, V](implicit
+abstract class AbstractRedisApi[Self[K0, F0, V0] <: AbstractRedisApi[Self, K0, F0, V0], K, F, V](implicit
   val keyCodec: RedisDataCodec[K], val fieldCodec: RedisDataCodec[F], val valueCodec: RedisDataCodec[V])
   extends ApiSubset {
 
@@ -265,7 +265,7 @@ abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H
     * Changes the type of hash key used by this API variant to some other type by directly providing
     * functions which convert between new and old type.
     */
-  def transformField[H0](read: F => H0)(write: H0 => F): WithField[H0] =
+  def transformField[F0](read: F => F0)(write: F0 => F): WithField[F0] =
     copy(newFieldCodec = RedisDataCodec(fieldCodec.read andThen read, write andThen fieldCodec.write))
 
   /**
@@ -282,9 +282,9 @@ abstract class AbstractRedisApi[Self[K0, H0, V0] <: AbstractRedisApi[Self, K0, H
   def transformValue[V0](read: V => V0)(write: V0 => V): WithValue[V0] =
     copy(newValueCodec = RedisDataCodec(valueCodec.read andThen read, write andThen valueCodec.write))
 
-  def copy[K0, H0, V0](
+  def copy[K0, F0, V0](
     newKeyCodec: RedisDataCodec[K0] = keyCodec,
-    newFieldCodec: RedisDataCodec[H0] = fieldCodec,
+    newFieldCodec: RedisDataCodec[F0] = fieldCodec,
     newValueCodec: RedisDataCodec[V0] = valueCodec
-  ): Self[K0, H0, V0]
+  ): Self[K0, F0, V0]
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisApi.scala
@@ -76,42 +76,47 @@ import com.avsystem.commons.redis.config.ExecutionConfig
   * }}}
   */
 object RedisApi {
-  class Raw[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec]
-    extends AbstractRedisApi[Raw, Key, Field, Value] with RedisConnectionApi with RedisRawApi {
-    def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-      new Raw[K, F, V]()(newKeyCodec, newFieldCodec, newValueCodec)
+  class Raw[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec]
+    extends AbstractRedisApi[Raw, Key, Field, Value, Record] with RedisConnectionApi with RedisRawApi {
+
+    def copy[K, F, V, R](
+      kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+    ): Raw[K, F, V, R] = new Raw[K, F, V, R]()(kc, fc, vc, rc)
   }
   /**
     * Entry point for API variants which return [[RawCommand]]s.
     */
   object Raw {
-    object StringTyped extends Raw[String, String, String]
-    object BinaryTyped extends Raw[ByteString, ByteString, ByteString]
+    object StringTyped extends Raw[String, String, String, Map[String, String]]
+    object BinaryTyped extends Raw[ByteString, ByteString, ByteString, Map[ByteString, ByteString]]
   }
 
-  class Batches[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec]
-    extends AbstractRedisApi[Batches, Key, Field, Value] with RedisConnectionApi with RedisBatchApi {
-    def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-      new Batches[K, F, V]()(newKeyCodec, newFieldCodec, newValueCodec)
+  class Batches[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec]
+    extends AbstractRedisApi[Batches, Key, Field, Value, Record] with RedisConnectionApi with RedisBatchApi {
+
+    def copy[K, F, V, R](
+      kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+    ): Batches[K, F, V, R] = new Batches[K, F, V, R]()(kc, fc, vc, rc)
   }
   /**
     * Entry point for API variants which return [[RedisBatch]]es.
     */
   object Batches {
-    object StringTyped extends Batches[String, String, String]
-    object BinaryTyped extends Batches[ByteString, ByteString, ByteString]
+    object StringTyped extends Batches[String, String, String, Map[String, String]]
+    object BinaryTyped extends Batches[ByteString, ByteString, ByteString, Map[ByteString, ByteString]]
   }
 
   /**
     * Entry point for API variants which expose only keyed commands.
     */
   object Keyed {
-    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
+    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec](
       val executor: RedisKeyedExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableKeyedApi with RedisAsyncApi {
-      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+    ) extends AbstractRedisApi[Async, Key, Field, Value, Record] with RedisRecoverableKeyedApi with RedisAsyncApi {
+      def copy[K, F, V, R](
+        kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+      ): Async[K, F, V, R] = new Async[K, F, V, R](executor, execConfig)(kc, fc, vc, rc)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisKeyedExecutor]] (e.g. [[RedisClusterClient]])
@@ -119,17 +124,18 @@ object RedisApi {
       */
     object Async {
       case class StringTyped(exec: RedisKeyedExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Async[String, String, String](exec, config)
+        extends Async[String, String, String, Map[String, String]](exec, config)
       case class BinaryTyped(exec: RedisKeyedExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Async[ByteString, ByteString, ByteString](exec, config)
+        extends Async[ByteString, ByteString, ByteString, Map[ByteString, ByteString]](exec, config)
     }
 
-    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
+    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec](
       val executor: RedisKeyedExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableKeyedApi with RedisBlockingApi {
-      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+    ) extends AbstractRedisApi[Blocking, Key, Field, Value, Record] with RedisRecoverableKeyedApi with RedisBlockingApi {
+      def copy[K, F, V, R](
+        kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+      ): Blocking[K, F, V, R] = new Blocking[K, F, V, R](executor, execConfig)(kc, fc, vc, rc)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisKeyedExecutor]] (e.g. [[RedisClusterClient]])
@@ -137,9 +143,9 @@ object RedisApi {
       */
     object Blocking {
       case class StringTyped(exec: RedisKeyedExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Blocking[String, String, String](exec, config)
+        extends Blocking[String, String, String, Map[String, String]](exec, config)
       case class BinaryTyped(exec: RedisKeyedExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Blocking[ByteString, ByteString, ByteString](exec, config)
+        extends Blocking[ByteString, ByteString, ByteString, Map[ByteString, ByteString]](exec, config)
     }
   }
 
@@ -148,12 +154,13 @@ object RedisApi {
     * Redis connection state.
     */
   object Node {
-    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
+    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec](
       val executor: RedisNodeExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableNodeApi with RedisAsyncApi {
-      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+    ) extends AbstractRedisApi[Async, Key, Field, Value, Record] with RedisRecoverableNodeApi with RedisAsyncApi {
+      def copy[K, F, V, R](
+        kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+      ): Async[K, F, V, R] = new Async[K, F, V, R](executor, execConfig)(kc, fc, vc, rc)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisNodeExecutor]] (e.g. [[RedisNodeClient]])
@@ -161,17 +168,18 @@ object RedisApi {
       */
     object Async {
       case class StringTyped(exec: RedisNodeExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Async[String, String, String](exec, config)
+        extends Async[String, String, String, Map[String, String]](exec, config)
       case class BinaryTyped(exec: RedisNodeExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Async[ByteString, ByteString, ByteString](exec, config)
+        extends Async[ByteString, ByteString, ByteString, Map[ByteString, ByteString]](exec, config)
     }
 
-    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
+    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec](
       val executor: RedisNodeExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableNodeApi with RedisBlockingApi {
-      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+    ) extends AbstractRedisApi[Blocking, Key, Field, Value, Record] with RedisRecoverableNodeApi with RedisBlockingApi {
+      def copy[K, F, V, R](
+        kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+      ): Blocking[K, F, V, R] = new Blocking[K, F, V, R](executor, execConfig)(kc, fc, vc, rc)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisNodeExecutor]] (e.g. [[RedisNodeClient]])
@@ -179,9 +187,9 @@ object RedisApi {
       */
     object Blocking {
       case class StringTyped(exec: RedisNodeExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Blocking[String, String, String](exec, config)
+        extends Blocking[String, String, String, Map[String, String]](exec, config)
       case class BinaryTyped(exec: RedisNodeExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Blocking[ByteString, ByteString, ByteString](exec, config)
+        extends Blocking[ByteString, ByteString, ByteString, Map[ByteString, ByteString]](exec, config)
     }
   }
 
@@ -190,12 +198,13 @@ object RedisApi {
     * access or modify Redis connection state.
     */
   object Connection {
-    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
+    class Async[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec](
       val executor: RedisConnectionExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Async, Key, Field, Value] with RedisRecoverableConnectionApi with RedisAsyncApi {
-      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-        new Async[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+    ) extends AbstractRedisApi[Async, Key, Field, Value, Record] with RedisRecoverableConnectionApi with RedisAsyncApi {
+      def copy[K, F, V, R](
+        kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+      ): Async[K, F, V, R] = new Async[K, F, V, R](executor, execConfig)(kc, fc, vc, rc)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisConnectionExecutor]] (e.g. [[RedisConnectionClient]])
@@ -203,17 +212,18 @@ object RedisApi {
       */
     object Async {
       case class StringTyped(exec: RedisConnectionExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Async[String, String, String](exec, config)
+        extends Async[String, String, String, Map[String, String]](exec, config)
       case class BinaryTyped(exec: RedisConnectionExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Async[ByteString, ByteString, ByteString](exec, config)
+        extends Async[ByteString, ByteString, ByteString, Map[ByteString, ByteString]](exec, config)
     }
 
-    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec](
+    class Blocking[Key: RedisDataCodec, Field: RedisDataCodec, Value: RedisDataCodec, Record: RedisRecordCodec](
       val executor: RedisConnectionExecutor,
       val execConfig: ExecutionConfig = ExecutionConfig.Default
-    ) extends AbstractRedisApi[Blocking, Key, Field, Value] with RedisRecoverableConnectionApi with RedisBlockingApi {
-      def copy[K, F, V](newKeyCodec: RedisDataCodec[K], newFieldCodec: RedisDataCodec[F], newValueCodec: RedisDataCodec[V]) =
-        new Blocking[K, F, V](executor, execConfig)(newKeyCodec, newFieldCodec, newValueCodec)
+    ) extends AbstractRedisApi[Blocking, Key, Field, Value, Record] with RedisRecoverableConnectionApi with RedisBlockingApi {
+      def copy[K, F, V, R](
+        kc: RedisDataCodec[K], fc: RedisDataCodec[F], vc: RedisDataCodec[V], rc: RedisRecordCodec[R]
+      ): Blocking[K, F, V, R] = new Blocking[K, F, V, R](executor, execConfig)(kc, fc, vc, rc)
     }
     /**
       * Entry point for API variants which execute commands using [[RedisConnectionExecutor]] (e.g. [[RedisConnectionClient]])
@@ -221,26 +231,29 @@ object RedisApi {
       */
     object Blocking {
       case class StringTyped(exec: RedisConnectionExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Blocking[String, String, String](exec, config)
+        extends Blocking[String, String, String, Map[String, String]](exec, config)
       case class BinaryTyped(exec: RedisConnectionExecutor, config: ExecutionConfig = ExecutionConfig.Default)
-        extends Blocking[ByteString, ByteString, ByteString](exec, config)
+        extends Blocking[ByteString, ByteString, ByteString, Map[ByteString, ByteString]](exec, config)
     }
   }
 }
 
-abstract class AbstractRedisApi[Self[K0, F0, V0] <: AbstractRedisApi[Self, K0, F0, V0], K, F, V](implicit
-  protected val keyCodec: RedisDataCodec[K],
-  protected val fieldCodec: RedisDataCodec[F],
-  protected val valueCodec: RedisDataCodec[V]
+abstract class AbstractRedisApi[Self[K0, F0, V0, R0] <: AbstractRedisApi[Self, K0, F0, V0, R0], K, F, V, R](
+  implicit val keyCodec: RedisDataCodec[K],
+  val fieldCodec: RedisDataCodec[F],
+  val valueCodec: RedisDataCodec[V],
+  val recordCodec: RedisRecordCodec[R]
 ) extends ApiSubset {
 
   type Key = K
   type Field = F
   type Value = V
+  type Record = R
 
-  type WithKey[K0] = Self[K0, F, V]
-  type WithField[F0] = Self[K, F0, V]
-  type WithValue[V0] = Self[K, F, V0]
+  type WithKey[K0] = Self[K0, F, V, R]
+  type WithField[F0] = Self[K, F0, V, R]
+  type WithValue[V0] = Self[K, F, V0, R]
+  type WithRecord[R0] = Self[K, F, V, R0]
 
   /**
     * Changes the type of key used by this API variant to some other type for which an instance of
@@ -284,9 +297,16 @@ abstract class AbstractRedisApi[Self[K0, F0, V0] <: AbstractRedisApi[Self, K0, F
   def transformValue[V0](read: V => V0)(write: V0 => V): WithValue[V0] =
     copy(newValueCodec = RedisDataCodec(valueCodec.read andThen read, write andThen valueCodec.write))
 
-  def copy[K0, F0, V0](
+  def recordType[R0: RedisRecordCodec]: WithRecord[R0] =
+    copy(newRecordCodec = RedisRecordCodec[R0])
+
+  def transformRecord[R0](read: R => R0)(write: R0 => R): WithRecord[R0] =
+    copy(newRecordCodec = RedisRecordCodec(recordCodec.read andThen read, write andThen recordCodec.write))
+
+  def copy[K0, F0, V0, R0](
     newKeyCodec: RedisDataCodec[K0] = keyCodec,
     newFieldCodec: RedisDataCodec[F0] = fieldCodec,
-    newValueCodec: RedisDataCodec[V0] = valueCodec
-  ): Self[K0, F0, V0]
+    newValueCodec: RedisDataCodec[V0] = valueCodec,
+    newRecordCodec: RedisRecordCodec[R0] = recordCodec
+  ): Self[K0, F0, V0, R0]
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisBatch.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisBatch.scala
@@ -276,7 +276,7 @@ object RedisBatch extends HasFlatMap[RedisBatch] {
 }
 
 trait SinglePackBatch[+A] extends RedisBatch[A] with RawCommandPack {
-  final def rawCommandPacks = this
+  final def rawCommandPacks: RawCommandPacks = this
 }
 
 trait ImmediateBatch[+A] extends RedisBatch[A] with RawCommandPacks {
@@ -284,7 +284,7 @@ trait ImmediateBatch[+A] extends RedisBatch[A] with RawCommandPacks {
   final def rawCommandPacks: RawCommandPacks = this
   final def decodeReplies(replies: Int => RedisReply, index: RedisBatch.Index, inTransaction: Boolean): A = result
   final def emitCommandPacks(consumer: RawCommandPack => Unit): Unit = ()
-  final def computeSize(limit: Int) = 0
+  final def computeSize(limit: Int): Int = 0
 }
 
 /**

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisBatch.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisBatch.scala
@@ -285,6 +285,7 @@ trait ImmediateBatch[+A] extends RedisBatch[A] with RawCommandPacks {
   final def decodeReplies(replies: Int => RedisReply, index: RedisBatch.Index, inTransaction: Boolean): A = result
   final def emitCommandPacks(consumer: RawCommandPack => Unit): Unit = ()
   final def computeSize(limit: Int): Int = 0
+  override final def maxBlockingMillis: Int = 0
 }
 
 /**

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisBatch.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisBatch.scala
@@ -36,21 +36,21 @@ trait RedisBatch[+A] { self =>
     */
   def map2[B, C](other: RedisBatch[B])(f: (A, B) => C): RedisBatch[C] =
     new RedisBatch[C] with RawCommandPacks {
-      def rawCommandPacks = this
+      def rawCommandPacks: RawCommandPacks = this
 
-      def emitCommandPacks(consumer: RawCommandPack => Unit) = {
+      def emitCommandPacks(consumer: RawCommandPack => Unit): Unit = {
         self.rawCommandPacks.emitCommandPacks(consumer)
         other.rawCommandPacks.emitCommandPacks(consumer)
       }
 
-      def computeSize(limit: Int) =
+      def computeSize(limit: Int): Int =
         if (limit <= 0) limit
         else {
           val selfSize = self.rawCommandPacks.computeSize(limit)
           selfSize + other.rawCommandPacks.computeSize(limit - selfSize)
         }
 
-      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean) = {
+      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean): C = {
         // we must invoke both decoders regardless of intermediate errors because index must be properly advanced
         var failure: Opt[Throwable] = Opt.Empty
         val a = try self.decodeReplies(replies, index, inTransaction) catch {
@@ -72,15 +72,15 @@ trait RedisBatch[+A] { self =>
 
   def transform[B](fun: Try[A] => Try[B]): RedisBatch[B] =
     new RedisBatch[B] {
-      def rawCommandPacks = self.rawCommandPacks
-      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean) =
+      def rawCommandPacks: RawCommandPacks = self.rawCommandPacks
+      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean): B =
         fun(Try(self.decodeReplies(replies, index, inTransaction))).get
     }
 
   def recover[B >: A](f: PartialFunction[Throwable, B]): RedisBatch[B] =
     new RedisBatch[B] {
-      def rawCommandPacks = self.rawCommandPacks
-      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean) =
+      def rawCommandPacks: RawCommandPacks = self.rawCommandPacks
+      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean): B =
         try self.decodeReplies(replies, index, inTransaction) catch f
     }
 
@@ -112,7 +112,7 @@ trait RedisBatch[+A] { self =>
 
   def map[B](f: A => B): RedisBatch[B] =
     new RedisBatch[B] {
-      def rawCommandPacks = self.rawCommandPacks
+      def rawCommandPacks: RawCommandPacks = self.rawCommandPacks
       def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean) =
         f(self.decodeReplies(replies, index, inTransaction))
     }
@@ -160,13 +160,13 @@ trait RedisBatch[+A] { self =>
     */
   def asking: RedisBatch[A] =
     new RedisBatch[A] with RawCommandPacks {
-      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean) =
+      def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean): A =
         self.decodeReplies(replies, index, inTransaction)
-      def emitCommandPacks(consumer: RawCommandPack => Unit) =
+      def emitCommandPacks(consumer: RawCommandPack => Unit): Unit =
         self.rawCommandPacks.emitCommandPacks(pack => consumer(new RedisClusterClient.AskingPack(pack)))
-      def computeSize(limit: Int) =
+      def computeSize(limit: Int): Int =
         self.rawCommandPacks.computeSize(limit)
-      def rawCommandPacks = this
+      def rawCommandPacks: RawCommandPacks = this
     }
 }
 
@@ -202,7 +202,7 @@ object RedisBatch extends HasFlatMap[RedisBatch] {
     case Failure(cause) => failure(cause)
   }
 
-  val unit = success(())
+  final val unit: RedisBatch[Unit] = success(())
 
   implicit class SequenceOps[Ops, Res](private val ops: Ops) extends AnyVal {
     /**

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
@@ -228,7 +228,7 @@ final class RedisClusterClient(
     * cluster state changes and `TRYAGAIN` errors which might be returned for multikey commands during slot migration.
     * See [[http://redis.io/topics/cluster-spec#redirection-and-resharding Redis Cluster specification]] for
     * more detailed information on redirections and migrations.
-    * Redirection and `TRYAGAIN` handling is configured by retry strategies in [[ClusterConfig]].
+    * Redirection and `TRYAGAIN` handling is configured by retry strategies in [[config.ClusterConfig]].
     *
     * In general, you can assume that if there are no redirections involved, commands executed on the same master
     * node are executed in the same order as specified in the original batch.

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
@@ -146,7 +146,7 @@ final class RedisClusterClient(
         case Opt.Empty => Future.successful(reply)
         case Opt((delay, nextStrat)) =>
           val result = DelayedFuture(delay).flatMapNow(_ => state.clientForSlot(slot).executeRaw(pack).mapNow(_.apply(0)))
-          handleRedirection(pack, slot, result, config.redirectionRetryStrategy, nextStrat)
+          handleRedirection(pack, slot, result, config.redirectionStrategy, nextStrat)
       }
       case _ => result
     } recoverWithNow {
@@ -282,7 +282,7 @@ final class RedisClusterClient(
     val slot = determineSlot(pack)
     val client = currentState.clientForSlot(slot)
     val result = client.executeRaw(pack).mapNow(_.apply(0))
-    handleRedirection(pack, slot, result, config.redirectionRetryStrategy, config.tryagainStrategy)
+    handleRedirection(pack, slot, result, config.redirectionStrategy, config.tryagainStrategy)
       .mapNow(PacksResult.Single)
   }
 
@@ -298,7 +298,7 @@ final class RedisClusterClient(
       val result = resultsByNode.getOrElseUpdate(client,
         barrier.future.flatMapNow(_ => client.executeRaw(CollectionPacks(packBuffer)))
       ).mapNow(_.apply(idx))
-      handleRedirection(pack, slot, result, config.redirectionRetryStrategy, config.tryagainStrategy)
+      handleRedirection(pack, slot, result, config.redirectionStrategy, config.tryagainStrategy)
     }
 
     val results = new ArrayBuffer[Future[RedisReply]]

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
@@ -224,15 +224,11 @@ final class RedisClusterClient(
     * automatically distributed over Redis Cluster master nodes, in parallel, using a scatter-gather like manner.
     *
     * [[RedisClusterClient]] also automatically retries execution of commands that fail due to cluster redirections
-    * ([[http://redis.io/topics/cluster-spec#moved-redirection MOVED]] and [[http://redis.io/topics/cluster-spec#ask-redirection ASK]])
-    * and cluster state changes. However, remember that multi-key commands may still fail with
-    * `TRYAGAIN` error during resharding of the slot targeted by the multi-key operation.
-    * (see [[http://redis.io/topics/cluster-spec#multiple-keys-operations Redis Cluster specification]]).
-    * [[RedisClusterClient]] makes no attempt to recover from these errors. It would require waiting for an
-    * indeterminate time until the migration is finished. The maximum number of consecutive retries caused by
-    * redirections is configured by [[config.ClusterConfig.maxRedirections maxRedirections]].
+    * ([[http://redis.io/topics/cluster-spec#moved-redirection MOVED]] and [[http://redis.io/topics/cluster-spec#ask-redirection ASK]]),
+    * cluster state changes and `TRYAGAIN` errors which might be returned for multikey commands during slot migration.
     * See [[http://redis.io/topics/cluster-spec#redirection-and-resharding Redis Cluster specification]] for
-    * more detailed information on redirections.
+    * more detailed information on redirections and migrations.
+    * Redirection and `TRYAGAIN` handling is configured by retry strategies in [[ClusterConfig]].
     *
     * In general, you can assume that if there are no redirections involved, commands executed on the same master
     * node are executed in the same order as specified in the original batch.

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -82,6 +82,8 @@ final class CommandEncoder(private val buffer: ArrayBuffer[BulkStringMsg]) exten
     fluent(value.foreach(t => add(t)))
   def optAdd[T: CommandArg](flag: String, value: Opt[T]): CommandEncoder =
     fluent(value.foreach(t => add(flag).add(t)))
+  def optAdd[T: CommandArg, D: CommandArg](value: Opt[T], default: D): CommandEncoder =
+    fluent(value.fold(CommandArg.add(this, default))(CommandArg.add(this, _)))
   def optKey[K: RedisDataCodec](flag: String, value: Opt[K]): CommandEncoder =
     fluent(value.foreach(t => add(flag).key(t)))
   def optData[V: RedisDataCodec](flag: String, value: Opt[V]): CommandEncoder =

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -16,7 +16,8 @@ trait RedisCommand[+A] extends SinglePackBatch[A] with RawCommand { self =>
 
   final protected def decode(replyMsg: RedisReply): A = replyMsg match {
     case validReply: ValidRedisMsg =>
-      decodeExpected.applyOrElse(validReply, (r: ValidRedisMsg) => throw new UnexpectedReplyException(r.toString))
+      decodeExpected.applyOrElse(validReply, (r: ValidRedisMsg) =>
+        throw new UnexpectedReplyException(r.toString))
     case err: ErrorMsg =>
       throw new ErrorReplyException(err)
     case error: FailureReply =>

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -95,6 +95,8 @@ final class CommandEncoder(private val buffer: ArrayBuffer[BulkStringMsg]) exten
     fluent(keyDatas.foreach({ case (k, v) => key(k).data(v) }))
   def dataPairs[K: RedisDataCodec, V: RedisDataCodec](dataPairs: TraversableOnce[(K, V)]): CommandEncoder =
     fluent(dataPairs.foreach({ case (k, v) => data(k).data(v) }))
+  def dataPairs[R: RedisRecordCodec](record: R): CommandEncoder =
+    fluent(buffer ++= RedisRecordCodec[R].write(record))
   def argDataPairs[T: CommandArg, V: RedisDataCodec](argDataPairs: TraversableOnce[(T, V)]): CommandEncoder =
     fluent(argDataPairs.foreach({ case (a, v) => add(a).data(v) }))
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -40,6 +40,8 @@ trait RedisCommand[+A] extends SinglePackBatch[A] with RawCommand { self =>
         self.immediateResult.map(fun)
       override def updateWatchState(message: RedisMsg, state: WatchState): Unit =
         self.updateWatchState(message, state)
+      override def maxBlockingMillis: Int =
+        self.maxBlockingMillis
     }
 
   /**

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -50,7 +50,7 @@ trait RedisCommand[+A] extends SinglePackBatch[A] with RawCommand { self =>
     */
   def immediateResult: Opt[A] = Opt.Empty
 
-  protected[this] final def whenEmpty(args: Iterable[Any], value: A): Opt[A] =
+  protected[this] final def whenEmpty(args: TraversableOnce[Any], value: A): Opt[A] =
     if (args.isEmpty) Opt(value) else Opt.Empty
 
   final def batchOrFallback: RedisBatch[A] =

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -19,7 +19,7 @@ trait RedisCommand[+A] extends SinglePackBatch[A] with RawCommand { self =>
       decodeExpected.applyOrElse(validReply, (r: ValidRedisMsg) =>
         throw new UnexpectedReplyException(r.toString))
     case err: ErrorMsg =>
-      throw new ErrorReplyException(err)
+      throw new ErrorReplyException(err, this)
     case error: FailureReply =>
       throw error.exception
     case _ =>

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisCommand.scala
@@ -25,18 +25,18 @@ trait RedisCommand[+A] extends SinglePackBatch[A] with RawCommand { self =>
       throw new UnexpectedReplyException(replyMsg.toString)
   }
 
-  final def decodeReplies(replies: Int => RedisReply, idx: Index, inTransaction: Boolean) =
+  final def decodeReplies(replies: Int => RedisReply, idx: Index, inTransaction: Boolean): A =
     decode(replies(idx.inc()))
 
-  override def toString =
+  override def toString: String =
     encoded.elements.iterator.map(bs => RedisMsg.escape(bs.string)).mkString(" ")
 
   override def map[B](fun: A => B): RedisCommand[B] =
     new RedisCommand[B] {
-      def level = self.level
-      def encoded = self.encoded
-      def decodeExpected = self.decodeExpected andThen fun
-      override def immediateResult =
+      def level: RawCommand.Level = self.level
+      def encoded: ArrayMsg[BulkStringMsg] = self.encoded
+      def decodeExpected: ReplyDecoder[B] = self.decodeExpected andThen fun
+      override def immediateResult: Opt[B] =
         self.immediateResult.map(fun)
       override def updateWatchState(message: RedisMsg, state: WatchState): Unit =
         self.updateWatchState(message, state)
@@ -48,7 +48,7 @@ trait RedisCommand[+A] extends SinglePackBatch[A] with RawCommand { self =>
     */
   def immediateResult: Opt[A] = Opt.Empty
 
-  protected[this] final def whenEmpty(args: Iterable[Any], value: A) =
+  protected[this] final def whenEmpty(args: Iterable[Any], value: A): Opt[A] =
     if (args.isEmpty) Opt(value) else Opt.Empty
 
   final def batchOrFallback: RedisBatch[A] =
@@ -66,21 +66,31 @@ final class CommandEncoder(private val buffer: ArrayBuffer[BulkStringMsg]) exten
     this
   }
 
-  def key[K: RedisDataCodec](k: K) = fluent(buffer += CommandKeyMsg(RedisDataCodec.write(k)))
-  def keys[K: RedisDataCodec](keys: TraversableOnce[K]) = fluent(keys.foreach(key[K]))
-  def data[V: RedisDataCodec](v: V) = fluent(buffer += BulkStringMsg(RedisDataCodec.write(v)))
-  def datas[V: RedisDataCodec](values: TraversableOnce[V]) = fluent(values.foreach(data[V]))
-  def add[T: CommandArg](value: T): CommandEncoder = fluent(CommandArg.add(this, value))
-  def addFlag(flag: String, value: Boolean): CommandEncoder = if (value) add(flag) else this
-  def optAdd[T: CommandArg](value: Opt[T]) = fluent(value.foreach(t => add(t)))
-  def optAdd[T: CommandArg](flag: String, value: Opt[T]) = fluent(value.foreach(t => add(flag).add(t)))
-  def optKey[K: RedisDataCodec](flag: String, value: Opt[K]) = fluent(value.foreach(t => add(flag).key(t)))
-  def optData[V: RedisDataCodec](flag: String, value: Opt[V]) = fluent(value.foreach(t => add(flag).data(t)))
-  def keyDatas[K: RedisDataCodec, V: RedisDataCodec](keyDatas: TraversableOnce[(K, V)]) =
+  def key[K: RedisDataCodec](k: K): CommandEncoder =
+    fluent(buffer += CommandKeyMsg(RedisDataCodec.write(k)))
+  def keys[K: RedisDataCodec](keys: TraversableOnce[K]): CommandEncoder =
+    fluent(keys.foreach(key[K]))
+  def data[V: RedisDataCodec](v: V): CommandEncoder =
+    fluent(buffer += BulkStringMsg(RedisDataCodec.write(v)))
+  def datas[V: RedisDataCodec](values: TraversableOnce[V]): CommandEncoder =
+    fluent(values.foreach(data[V]))
+  def add[T: CommandArg](value: T): CommandEncoder =
+    fluent(CommandArg.add(this, value))
+  def addFlag(flag: String, value: Boolean): CommandEncoder =
+    if (value) add(flag) else this
+  def optAdd[T: CommandArg](value: Opt[T]): CommandEncoder =
+    fluent(value.foreach(t => add(t)))
+  def optAdd[T: CommandArg](flag: String, value: Opt[T]): CommandEncoder =
+    fluent(value.foreach(t => add(flag).add(t)))
+  def optKey[K: RedisDataCodec](flag: String, value: Opt[K]): CommandEncoder =
+    fluent(value.foreach(t => add(flag).key(t)))
+  def optData[V: RedisDataCodec](flag: String, value: Opt[V]): CommandEncoder =
+    fluent(value.foreach(t => add(flag).data(t)))
+  def keyDatas[K: RedisDataCodec, V: RedisDataCodec](keyDatas: TraversableOnce[(K, V)]): CommandEncoder =
     fluent(keyDatas.foreach({ case (k, v) => key(k).data(v) }))
-  def dataPairs[K: RedisDataCodec, V: RedisDataCodec](dataPairs: TraversableOnce[(K, V)]) =
+  def dataPairs[K: RedisDataCodec, V: RedisDataCodec](dataPairs: TraversableOnce[(K, V)]): CommandEncoder =
     fluent(dataPairs.foreach({ case (k, v) => data(k).data(v) }))
-  def argDataPairs[T: CommandArg, V: RedisDataCodec](argDataPairs: TraversableOnce[(T, V)]) =
+  def argDataPairs[T: CommandArg, V: RedisDataCodec](argDataPairs: TraversableOnce[(T, V)]): CommandEncoder =
     fluent(argDataPairs.foreach({ case (a, v) => add(a).data(v) }))
 }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
@@ -55,12 +55,12 @@ final class RedisConnectionClient(
     system.dispatcher
 
   def executeBatch[A](batch: RedisBatch[A], config: ExecutionConfig): Future[A] =
-    ifReady(connectionActor.ask(batch.rawCommandPacks.requireLevel(Level.Connection, "ConnectionClient"))(config.timeout)
+    ifReady(connectionActor.ask(batch.rawCommandPacks.requireLevel(Level.Connection, "ConnectionClient"))(config.responseTimeout)
       .map({ case pr: PacksResult => batch.decodeReplies(pr) })(config.decodeOn))
 
   //TODO: don't ignore executionConfig.decodeOn
   def executeOp[A](op: RedisOp[A], executionConfig: ExecutionConfig): Future[A] =
-    ifReady(system.actorOf(Props(new RedisOperationActor(connectionActor))).ask(op)(executionConfig.timeout)
+    ifReady(system.actorOf(Props(new RedisOperationActor(connectionActor))).ask(op)(executionConfig.responseTimeout)
       .mapNow({ case or: OpResult[A@unchecked] => or.get }))
 
   def close(): Unit = {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
@@ -9,7 +9,7 @@ import com.avsystem.commons.redis.RawCommand.Level
 import com.avsystem.commons.redis.actor.RedisConnectionActor.PacksResult
 import com.avsystem.commons.redis.actor.RedisOperationActor.OpResult
 import com.avsystem.commons.redis.actor.{RedisConnectionActor, RedisOperationActor}
-import com.avsystem.commons.redis.config.{ConfigDefaults, ConnectionConfig, ExecutionConfig, NoRetryStrategy}
+import com.avsystem.commons.redis.config.{ConfigDefaults, ConnectionConfig, ExecutionConfig, RetryStrategy}
 import com.avsystem.commons.redis.exception.ClientStoppedException
 
 /**
@@ -32,7 +32,7 @@ final class RedisConnectionClient(
 
   private val initPromise = Promise[Unit]
   private val connectionActor = {
-    val props = Props(new RedisConnectionActor(address, config.copy(reconnectionStrategy = NoRetryStrategy)))
+    val props = Props(new RedisConnectionActor(address, config.copy(reconnectionStrategy = RetryStrategy.never)))
       .withDispatcher(ConfigDefaults.Dispatcher)
     config.actorName.fold(system.actorOf(props))(system.actorOf(props, _))
   }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
@@ -64,7 +64,8 @@ final class RedisConnectionClient(
       .mapNow({ case or: OpResult[A@unchecked] => or.get }))
 
   def close(): Unit = {
-    failure = new ClientStoppedException(address.opt).opt
-    system.stop(connectionActor)
+    val cause = new ClientStoppedException(address.opt)
+    failure = cause.opt
+    connectionActor ! RedisConnectionActor.Close(cause, stop = true)
   }
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
@@ -27,7 +27,8 @@ object RedisDataCodec extends LowPriorityRedisDataCodecs {
   implicit val ByteStringCodec: RedisDataCodec[ByteString] = RedisDataCodec(identity, identity)
   implicit val ByteArrayCodec: RedisDataCodec[Array[Byte]] = RedisDataCodec(_.toArray, ByteString(_))
   implicit val StringCodec: RedisDataCodec[String] = RedisDataCodec(_.utf8String, ByteString(_))
-  implicit val BooleanKeyCodec: RedisDataCodec[Boolean] = RedisDataCodec(bs => bs.utf8String.toInt != 0, b => ByteString(if (b) "1" else "0"))
+  implicit val BooleanKeyCodec: RedisDataCodec[Boolean] =
+    RedisDataCodec(bs => bs.utf8String.toInt != 0, b => ByteString(if (b) "1" else "0"))
   implicit val CharCodec: RedisDataCodec[Char] = RedisDataCodec(_.utf8String.charAt(0), v => ByteString(v.toString))
   implicit val ByteCodec: RedisDataCodec[Byte] = RedisDataCodec(_.utf8String.toByte, v => ByteString(v.toString))
   implicit val ShortCodec: RedisDataCodec[Short] = RedisDataCodec(_.utf8String.toShort, v => ByteString(v.toString))
@@ -35,7 +36,8 @@ object RedisDataCodec extends LowPriorityRedisDataCodecs {
   implicit val LongCodec: RedisDataCodec[Long] = RedisDataCodec(_.utf8String.toLong, v => ByteString(v.toString))
   implicit val FloatCodec: RedisDataCodec[Float] = RedisDataCodec(_.utf8String.toFloat, v => ByteString(v.toString))
   implicit val DoubleCodec: RedisDataCodec[Double] = RedisDataCodec(_.utf8String.toDouble, v => ByteString(v.toString))
-  implicit val NothingCodec: RedisDataCodec[Nothing] = new RedisDataCodec[Nothing](_ => sys.error("nothing"), _ => sys.error("nothing"))
+  implicit val NothingCodec: RedisDataCodec[Nothing] =
+    new RedisDataCodec[Nothing](_ => sys.error("nothing"), _ => sys.error("nothing"))
   implicit def namedEnumCodec[E <: NamedEnum](implicit companion: NamedEnumCompanion[E]): RedisDataCodec[E] =
     RedisDataCodec(bs => companion.byName(bs.utf8String), v => ByteString(v.name))
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
@@ -2,9 +2,9 @@ package com.avsystem.commons
 package redis
 
 import akka.util.ByteString
-import com.avsystem.commons.misc.{NamedEnum, NamedEnumCompanion}
-import com.avsystem.commons.redis.util.ByteStringSerialization
-import com.avsystem.commons.serialization.GenCodec
+import com.avsystem.commons.serialization.GenCodec.ReadFailure
+import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.json.{JsonReader, JsonStringInput, JsonStringOutput}
 
 /**
   * Typeclass which expresses that values of some type are serializable to binary form (`ByteString`) and deserializable
@@ -25,23 +25,91 @@ object RedisDataCodec extends LowPriorityRedisDataCodecs {
   def read[T](raw: ByteString)(implicit rdc: RedisDataCodec[T]): T = rdc.read(raw)
 
   implicit val ByteStringCodec: RedisDataCodec[ByteString] = RedisDataCodec(identity, identity)
-  implicit val ByteArrayCodec: RedisDataCodec[Array[Byte]] = RedisDataCodec(_.toArray, ByteString(_))
-  implicit val StringCodec: RedisDataCodec[String] = RedisDataCodec(_.utf8String, ByteString(_))
-  implicit val BooleanKeyCodec: RedisDataCodec[Boolean] =
-    RedisDataCodec(bs => bs.utf8String.toInt != 0, b => ByteString(if (b) "1" else "0"))
-  implicit val CharCodec: RedisDataCodec[Char] = RedisDataCodec(_.utf8String.charAt(0), v => ByteString(v.toString))
-  implicit val ByteCodec: RedisDataCodec[Byte] = RedisDataCodec(_.utf8String.toByte, v => ByteString(v.toString))
-  implicit val ShortCodec: RedisDataCodec[Short] = RedisDataCodec(_.utf8String.toShort, v => ByteString(v.toString))
-  implicit val IntCodec: RedisDataCodec[Int] = RedisDataCodec(_.utf8String.toInt, v => ByteString(v.toString))
-  implicit val LongCodec: RedisDataCodec[Long] = RedisDataCodec(_.utf8String.toLong, v => ByteString(v.toString))
-  implicit val FloatCodec: RedisDataCodec[Float] = RedisDataCodec(_.utf8String.toFloat, v => ByteString(v.toString))
-  implicit val DoubleCodec: RedisDataCodec[Double] = RedisDataCodec(_.utf8String.toDouble, v => ByteString(v.toString))
-  implicit val NothingCodec: RedisDataCodec[Nothing] =
-    new RedisDataCodec[Nothing](_ => sys.error("nothing"), _ => sys.error("nothing"))
-  implicit def namedEnumCodec[E <: NamedEnum](implicit companion: NamedEnumCompanion[E]): RedisDataCodec[E] =
-    RedisDataCodec(bs => companion.byName(bs.utf8String), v => ByteString(v.name))
 }
 trait LowPriorityRedisDataCodecs { this: RedisDataCodec.type =>
   implicit def fromGenCodec[T: GenCodec]: RedisDataCodec[T] =
-    RedisDataCodec(bytes => ByteStringSerialization.read(bytes), value => ByteStringSerialization.write(value))
+    RedisDataCodec(bytes => RedisDataInput.read(bytes), value => RedisDataOutput.write(value))
+}
+
+object RedisDataUtils {
+  final val Null = ByteString(0)
+}
+
+object RedisDataOutput {
+  def write[T: GenCodec](value: T): ByteString = {
+    var bs: ByteString = null
+    GenCodec.write(new RedisDataOutput(bs = _), value)
+    bs
+  }
+}
+
+final class RedisDataOutput(consumer: ByteString => Unit) extends Output {
+  private def writeBytes(bytes: ByteString): Unit =
+    if (bytes.headOpt.contains(0: Byte)) consumer(RedisDataUtils.Null ++ bytes)
+    else consumer(bytes)
+
+  def writeNull(): Unit = consumer(RedisDataUtils.Null)
+  def writeBoolean(boolean: Boolean): Unit = writeInt(if (boolean) 1 else 0)
+  def writeString(str: String): Unit = writeBytes(ByteString(str))
+  def writeInt(int: Int): Unit = writeString(int.toString)
+  def writeLong(long: Long): Unit = writeString(long.toString)
+  def writeDouble(double: Double): Unit = writeString(double.toString)
+  def writeBigInt(bigInt: BigInt): Unit = writeString(bigInt.toString)
+  def writeBigDecimal(bigDecimal: BigDecimal): Unit = writeString(bigDecimal.toString)
+  def writeBinary(binary: Array[Byte]): Unit = writeBytes(ByteString(binary))
+
+  def writeList(): ListOutput = new ListOutput {
+    private val sb = new JStringBuilder
+    private val jlo = new JsonStringOutput(sb).writeList()
+
+    def writeElement(): Output = jlo.writeElement()
+    def finish(): Unit = {
+      jlo.finish()
+      consumer(ByteString(sb.toString))
+    }
+  }
+
+  def writeObject(): ObjectOutput = new ObjectOutput {
+    private val sb = new JStringBuilder
+    private val joo = new JsonStringOutput(sb).writeObject()
+
+    def writeField(key: String): Output = joo.writeField(key)
+    def finish(): Unit = {
+      joo.finish()
+      consumer(ByteString(sb.toString))
+    }
+  }
+}
+
+object RedisDataInput {
+  def read[T: GenCodec](bytes: ByteString): T =
+    GenCodec.read[T](new RedisDataInput(bytes))
+}
+
+class RedisDataInput(bytes: ByteString) extends Input {
+  private lazy val jsonInput = new JsonStringInput(new JsonReader(readBytes().utf8String))
+
+  def isNull: Boolean = bytes == RedisDataUtils.Null
+
+  private def fail(msg: String) = throw new ReadFailure(msg)
+  private def readBytes(): ByteString = bytes match {
+    case RedisDataUtils.Null => fail("null")
+    case _ if bytes.headOpt.contains(0: Byte) => bytes.drop(1)
+    case _ => bytes
+  }
+
+  def readNull(): Null = if (isNull) null else fail("not null")
+  def readString(): String = readBytes().utf8String
+  def readBoolean(): Boolean = readString().toInt > 0
+  def readInt(): Int = readString().toInt
+  def readLong(): Long = readString().toLong
+  def readDouble(): Double = readString().toDouble
+  def readBigInt(): BigInt = BigInt(readString())
+  def readBigDecimal(): BigDecimal = BigDecimal(readString())
+  def readBinary(): Array[Byte] = readBytes().toArray
+
+  def readList(): ListInput = jsonInput.readList()
+  def readObject(): ObjectInput = jsonInput.readObject()
+
+  def skip(): Unit = ()
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
@@ -27,8 +27,8 @@ import scala.concurrent.duration._
 final class RedisNodeClient(
   val address: NodeAddress = NodeAddress.Default,
   val config: NodeConfig = NodeConfig(),
-  val clusterNode: Boolean = false)
-  (implicit system: ActorSystem) extends RedisNodeExecutor with Closeable { client =>
+  val clusterNode: Boolean = false
+)(implicit system: ActorSystem) extends RedisNodeExecutor with Closeable { client =>
 
   private def newConnection(i: Int): ActorRef = {
     val connConfig: ConnectionConfig = config.connectionConfigs(i)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
@@ -148,7 +148,7 @@ final class RedisNodeClient(
     * </ul>
     */
   def executeBatch[A](batch: RedisBatch[A], config: ExecutionConfig): Future[A] =
-    executeRaw(batch.rawCommandPacks.requireLevel(RawCommand.Level.Node, "NodeClient"))(config.timeout)
+    executeRaw(batch.rawCommandPacks.requireLevel(RawCommand.Level.Node, "NodeClient"))(config.responseTimeout)
       .map(result => batch.decodeReplies(result))(config.decodeOn)
 
   /**
@@ -165,7 +165,7 @@ final class RedisNodeClient(
     */
   //TODO: executionConfig.decodeOn is ignored now
   def executeOp[A](op: RedisOp[A], executionConfig: ExecutionConfig): Future[A] =
-    ifReady(executeOp(nextConnection(), op)(executionConfig.timeout))
+    ifReady(executeOp(nextConnection(), op)(executionConfig.responseTimeout))
 
   private def executeOp[A](connection: ActorRef, op: RedisOp[A])(implicit timeout: Timeout): Future[A] =
     system.actorOf(Props(new RedisOperationActor(connection))).ask(op)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
@@ -49,15 +49,13 @@ final class RedisNodeClient(
   private val blockingConnectionPool =
     system.actorOf(Props(new ConnectionPoolActor(address, config, blockingConnectionQueue)))
 
-  private def newBlockingConnection(): Future[ActorRef] = {
-    implicit val timeout: Timeout = Timeout(1.second)
-    blockingConnectionPool.ask(ConnectionPoolActor.CreateNewConnection).mapNow {
+  private def newBlockingConnection(): Future[ActorRef] =
+    blockingConnectionPool.ask(ConnectionPoolActor.CreateNewConnection)(Timeout(1.second)).mapNow {
       case ConnectionPoolActor.NewConnection(connection) =>
         connection
       case ConnectionPoolActor.Full =>
         throw new TooManyConnectionsException(config.maxBlockingPoolSize)
     }
-  }
 
   @volatile private[this] var initSuccess = false
   @volatile private[this] var failure = Opt.empty[Throwable]

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisRecordCodec.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisRecordCodec.scala
@@ -1,0 +1,46 @@
+package com.avsystem.commons
+package redis
+
+import com.avsystem.commons.redis.protocol.BulkStringMsg
+import com.avsystem.commons.serialization.ApplyUnapplyCodec
+
+import scala.collection.generic.CanBuildFrom
+
+case class RedisRecordCodec[T](read: IndexedSeq[BulkStringMsg] => T, write: T => IndexedSeq[BulkStringMsg])
+object RedisRecordCodec {
+  implicit def fromApplyUnapplyCodec[T](implicit codec: ApplyUnapplyCodec[T]): RedisRecordCodec[T] =
+    RedisRecordCodec(
+      elems => codec.readObject(new RedisRecordInput(elems)),
+      value => {
+        val result = new MArrayBuffer[BulkStringMsg]
+        codec.writeObject(new RedisRecordOutput(result), value)
+        result
+      }
+    )
+
+  implicit def forDataMap[M[X, Y] <: BMap[X, Y], F: RedisDataCodec, V: RedisDataCodec](
+    implicit cbf: CanBuildFrom[Nothing, (F, V), M[F, V]]
+  ): RedisRecordCodec[M[F, V] with BMap[F, V]] =
+    RedisRecordCodec(elems => record[F, V, M[F, V]](elems), map => bulks(map.iterator, map.size))
+
+  implicit def forDataSeq[M[X] <: Seq[X], F: RedisDataCodec, V: RedisDataCodec](
+    implicit cbf: CanBuildFrom[Nothing, (F, V), M[(F, V)]]
+  ): RedisRecordCodec[M[(F, V)] with Seq[(F, V)]] =
+    RedisRecordCodec(elems => record[F, V, M[(F, V)]](elems), seq => bulks(seq.iterator, seq.size))
+
+  private def record[F: RedisDataCodec, V: RedisDataCodec, To](
+    elems: IndexedSeq[BulkStringMsg])(implicit cbf: CanBuildFrom[Nothing, (F, V), To]
+  ): To = {
+    val b = cbf()
+    b.sizeHint(elems.size)
+    elems.iterator.pairs.foreach {
+      case (BulkStringMsg(f), BulkStringMsg(v)) =>
+        b += RedisDataCodec[F].read(f) -> RedisDataCodec[V].read(v)
+    }
+    b.result()
+  }
+
+  private def bulks[F: RedisDataCodec, V: RedisDataCodec](it: Iterator[(F, V)], size: Int): IndexedSeq[BulkStringMsg] =
+    it.flatMap { case (f, v) => List(RedisDataCodec.write(f), RedisDataCodec.write(v)) }
+      .map(BulkStringMsg).toSized[MArrayBuffer](size)
+}

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisRecordCodec.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisRecordCodec.scala
@@ -4,10 +4,15 @@ package redis
 import com.avsystem.commons.redis.protocol.BulkStringMsg
 import com.avsystem.commons.serialization.ApplyUnapplyCodec
 
+import scala.annotation.implicitNotFound
 import scala.collection.generic.CanBuildFrom
 
+@implicitNotFound("${T} has no RedisRecordCodec. It can be derived from ApplyUnapplyCodec which can be provided " +
+  "by making your case class companion extend HasApplyUnapplyCodec")
 case class RedisRecordCodec[T](read: IndexedSeq[BulkStringMsg] => T, write: T => IndexedSeq[BulkStringMsg])
 object RedisRecordCodec {
+  def apply[T](implicit codec: RedisRecordCodec[T]): RedisRecordCodec[T] = codec
+
   implicit def fromApplyUnapplyCodec[T](implicit codec: ApplyUnapplyCodec[T]): RedisRecordCodec[T] =
     RedisRecordCodec(
       elems => codec.readObject(new RedisRecordInput(elems)),

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/TupleSequencers.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/TupleSequencers.scala
@@ -960,15 +960,15 @@ trait TupleSequencers { this: Sequencer.type =>
 
 object TupleSequencers {
   private class TupleBatch[T](batches: Product, fun: Array[Any] => T) extends RedisBatch[T] with RawCommandPacks {
-    def rawCommandPacks = this
-    def emitCommandPacks(consumer: RawCommandPack => Unit) = {
+    def rawCommandPacks: TupleBatch[T] = this
+    def emitCommandPacks(consumer: RawCommandPack => Unit): Unit = {
       var i = 0
       while (i < batches.productArity) {
         batches.productElement(i).asInstanceOf[RedisBatch[Any]].rawCommandPacks.emitCommandPacks(consumer)
         i += 1
       }
     }
-    def computeSize(limit: Int) = {
+    def computeSize(limit: Int): Int = {
       var res = 0
       var i = 0
       while (i < batches.productArity && res < limit) {
@@ -977,7 +977,7 @@ object TupleSequencers {
       }
       res
     }
-    def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean) = {
+    def decodeReplies(replies: Int => RedisReply, index: Index, inTransaction: Boolean): T = {
       val result = new Array[Any](batches.productArity)
       var failure: Opt[Throwable] = Opt.Empty
       var i = 0

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ClusterMonitoringActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ClusterMonitoringActor.scala
@@ -168,7 +168,7 @@ object ClusterMonitoringActor {
   val MappingComparator: Ordering[(SlotRange, RedisNodeClient)] =
     Ordering.by[(SlotRange, RedisNodeClient), Int](_._1.start)
 
-  case class Refresh(fromNodes: Opt[Seq[NodeAddress]] = Opt.Empty)
-  case class GetClient(addr: NodeAddress)
-  case class GetClientResponse(client: RedisNodeClient)
+  final case class Refresh(fromNodes: Opt[Seq[NodeAddress]] = Opt.Empty)
+  final case class GetClient(addr: NodeAddress)
+  final case class GetClientResponse(client: RedisNodeClient)
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ClusterMonitoringActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ClusterMonitoringActor.scala
@@ -118,8 +118,9 @@ final class ClusterMonitoringActor(
           }
         }
 
-      case Failure(err: ErrorReplyException) if state.isEmpty && seedNodes.size == 1 && config.fallbackToSingleNode &&
-        err.reply.errorString.utf8String == "ERR This instance has cluster support disabled" =>
+      case Failure(err: ErrorReplyException)
+        if state.isEmpty && seedNodes.size == 1 && config.fallbackToSingleNode &&
+          err.errorStr == "ERR This instance has cluster support disabled" =>
 
         val addr = seedNodes.head
         log.info(s"$addr is a non-clustered node, falling back to regular node client")

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ClusterMonitoringActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ClusterMonitoringActor.scala
@@ -69,7 +69,7 @@ final class ClusterMonitoringActor(
     pool.slice(0, count)
   }
 
-  def receive = {
+  def receive: Receive = {
     case Refresh(nodesOpt) =>
       if (suspendUntil.isOverdue) {
         val addresses = nodesOpt.getOrElse(randomMasters())
@@ -153,7 +153,7 @@ final class ClusterMonitoringActor(
       sender() ! GetClientResponse(client)
   }
 
-  override def postStop() = {
+  override def postStop(): Unit = {
     scheduledRefresh.foreach(_.cancel())
     clients.values.foreach(_.close())
   }
@@ -164,7 +164,8 @@ object ClusterMonitoringActor {
     val api = RedisApi.Batches.BinaryTyped
     api.clusterSlots zip api.clusterNodes
   }
-  val MappingComparator = Ordering.by[(SlotRange, RedisNodeClient), Int](_._1.start)
+  val MappingComparator: Ordering[(SlotRange, RedisNodeClient)] =
+    Ordering.by[(SlotRange, RedisNodeClient), Int](_._1.start)
 
   case class Refresh(fromNodes: Opt[Seq[NodeAddress]] = Opt.Empty)
   case class GetClient(addr: NodeAddress)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
@@ -1,35 +1,73 @@
 package com.avsystem.commons
 package redis.actor
 
+import java.util.concurrent.ConcurrentLinkedDeque
+
 import akka.actor.{Actor, ActorRef, Props}
 import com.avsystem.commons.redis.NodeAddress
 import com.avsystem.commons.redis.actor.ConnectionPoolActor._
 import com.avsystem.commons.redis.config.{ConnectionConfig, NodeConfig}
 import com.typesafe.scalalogging.LazyLogging
 
-class ConnectionPoolActor(address: NodeAddress, config: NodeConfig)
+import scala.annotation.tailrec
+
+class ConnectionPoolActor(address: NodeAddress, config: NodeConfig, queue: ConcurrentLinkedDeque[QueuedConn])
   extends Actor with LazyLogging {
 
-  private val connections = new MArrayBuffer[ActorRef]
+  import context._
+
+  private val connections = new MHashSet[ActorRef]
+
+  if (config.maxBlockingIdleTime.isFinite) {
+    val interval = config.blockingCleanupInterval
+    system.scheduler.schedule(interval, interval, self, Cleanup)
+  }
 
   def receive: Receive = {
     case CreateNewConnection if connections.size < config.maxBlockingPoolSize =>
       logger.info(s"Creating new blocking connection to $address")
       val connConfig: ConnectionConfig = config.blockingConnectionConfigs(connections.size)
       val props = Props(new RedisConnectionActor(address, connConfig))
-      val connection = connConfig.actorName.fold(context.actorOf(props))(context.actorOf(props, _))
+      val connection = connConfig.actorName.fold(actorOf(props))(actorOf(props, _))
       connections += connection
       connection ! RedisConnectionActor.Open(mustInitiallyConnect = false, Promise[Unit]())
       sender() ! NewConnection(connection)
     case CreateNewConnection =>
       sender() ! Full
+    case Cleanup =>
+      cleanup(System.nanoTime(), config.maxBlockingIdleTime.toNanos)
     case Close(cause) =>
       connections.foreach(_ ! RedisConnectionActor.Close(cause))
   }
+
+  private def cleanup(nowNanos: Long, maxIdleNanos: Long): Unit = {
+    @tailrec def loop(dequeue: Boolean): Unit = {
+      val last = if (dequeue) queue.pollLast() else queue.peekLast()
+      last match {
+        case QueuedConn(conn, enqueuedAt) =>
+          val stale = (nowNanos - enqueuedAt) > maxIdleNanos
+          if (!dequeue && stale) {
+            loop(dequeue = true)
+          } else if (dequeue && stale) {
+            context.stop(conn)
+            connections.remove(conn)
+            loop(dequeue = false)
+          } else if (dequeue && !stale) {
+            // unlikely situation where we dequeued something else than we peeked before
+            queue.addLast(last)
+          }
+        case null =>
+      }
+    }
+    loop(dequeue = false)
+  }
 }
 object ConnectionPoolActor {
+  case class QueuedConn(conn: ActorRef, enqueuedAt: Long)
+
   object CreateNewConnection
   case class Close(cause: Throwable)
+  object Cleanup
 
   case class NewConnection(connection: ActorRef)
   object Full

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
@@ -1,8 +1,6 @@
 package com.avsystem.commons
 package redis.actor
 
-import java.util.concurrent.ConcurrentLinkedDeque
-
 import akka.actor.{Actor, ActorRef, Props}
 import com.avsystem.commons.redis.NodeAddress
 import com.avsystem.commons.redis.actor.ConnectionPoolActor._
@@ -12,7 +10,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.annotation.tailrec
 
-class ConnectionPoolActor(address: NodeAddress, config: NodeConfig, queue: ConcurrentLinkedDeque[QueuedConn])
+class ConnectionPoolActor(address: NodeAddress, config: NodeConfig, queue: JDeque[QueuedConn])
   extends Actor with LazyLogging {
 
   import context._

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
@@ -7,6 +7,7 @@ import akka.actor.{Actor, ActorRef, Props}
 import com.avsystem.commons.redis.NodeAddress
 import com.avsystem.commons.redis.actor.ConnectionPoolActor._
 import com.avsystem.commons.redis.config.{ConnectionConfig, NodeConfig}
+import com.avsystem.commons.redis.exception.RedisException
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.annotation.tailrec
@@ -49,6 +50,7 @@ class ConnectionPoolActor(address: NodeAddress, config: NodeConfig, queue: Concu
           if (!dequeue && stale) {
             loop(dequeue = true)
           } else if (dequeue && stale) {
+            conn ! RedisConnectionActor.Close(new RedisException("Idle blocking connection closed"))
             context.stop(conn)
             connections.remove(conn)
             loop(dequeue = false)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
@@ -1,0 +1,36 @@
+package com.avsystem.commons
+package redis.actor
+
+import akka.actor.{Actor, ActorRef, Props}
+import com.avsystem.commons.redis.NodeAddress
+import com.avsystem.commons.redis.actor.ConnectionPoolActor._
+import com.avsystem.commons.redis.config.{ConnectionConfig, NodeConfig}
+import com.typesafe.scalalogging.LazyLogging
+
+class ConnectionPoolActor(address: NodeAddress, config: NodeConfig)
+  extends Actor with LazyLogging {
+
+  private val connections = new MArrayBuffer[ActorRef]
+
+  def receive: Receive = {
+    case CreateNewConnection if connections.size < config.maxBlockingPoolSize =>
+      logger.info(s"Creating new blocking connection to $address")
+      val connConfig: ConnectionConfig = config.blockingConnectionConfigs(connections.size)
+      val props = Props(new RedisConnectionActor(address, connConfig))
+      val connection = connConfig.actorName.fold(context.actorOf(props))(context.actorOf(props, _))
+      connections += connection
+      connection ! RedisConnectionActor.Open(mustInitiallyConnect = false, Promise[Unit]())
+      sender() ! NewConnection(connection)
+    case CreateNewConnection =>
+      sender() ! Full
+    case Close(cause) =>
+      connections.foreach(_ ! RedisConnectionActor.Close(cause))
+  }
+}
+object ConnectionPoolActor {
+  object CreateNewConnection
+  case class Close(cause: Throwable)
+
+  case class NewConnection(connection: ActorRef)
+  object Full
+}

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/ConnectionPoolActor.scala
@@ -68,12 +68,12 @@ class ConnectionPoolActor(address: NodeAddress, config: NodeConfig, queue: Concu
   }
 }
 object ConnectionPoolActor {
-  case class QueuedConn(conn: ActorRef, enqueuedAt: Long)
+  final case class QueuedConn(conn: ActorRef, enqueuedAt: Long)
 
   object CreateNewConnection
-  case class Close(cause: Throwable, stop: Boolean)
+  final case class Close(cause: Throwable, stop: Boolean)
   object Cleanup
 
-  case class NewConnection(connection: ActorRef)
+  final case class NewConnection(connection: ActorRef)
   object Full
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
@@ -43,7 +43,7 @@ final class RedisConnectionActor(address: NodeAddress, config: ConnectionConfig)
   private val queuedToWrite = new JArrayDeque[QueuedPacks]
   private var writeBuffer = ByteBuffer.allocate(config.maxWriteSizeHint.getOrElse(0) + 1024)
 
-  def receive = {
+  def receive: Receive = {
     case IncomingPacks(packs) =>
       handlePacks(packs)
     case open: Open =>
@@ -131,7 +131,7 @@ final class RedisConnectionActor(address: NodeAddress, config: ConnectionConfig)
     private var open = true
     private var unwatch = false
 
-    def become(receive: Receive) =
+    def become(receive: Receive): Unit =
       context.become(receive unless {
         case Tcp.Connected(_, _) => sender() ! Tcp.Close
         case _: Tcp.Event if sender() != connection => //ignore
@@ -440,16 +440,16 @@ object RedisConnectionActor {
   sealed trait PacksResult extends (Int => RedisReply)
   object PacksResult {
     case object Empty extends PacksResult {
-      def apply(idx: Int) = throw new NoSuchElementException
+      def apply(idx: Int): RedisReply = throw new NoSuchElementException
     }
     case class Single(reply: RedisReply) extends PacksResult {
-      def apply(idx: Int) = reply
+      def apply(idx: Int): RedisReply = reply
     }
     case class Multiple(replySeq: IndexedSeq[RedisReply]) extends PacksResult {
-      def apply(idx: Int) = replySeq(idx)
+      def apply(idx: Int): RedisReply = replySeq(idx)
     }
     case class Failure(cause: Throwable) extends PacksResult {
-      def apply(idx: Int) = throw cause
+      def apply(idx: Int): RedisReply = throw cause
     }
   }
 
@@ -458,7 +458,7 @@ object RedisConnectionActor {
     def onReceive(data: ByteString): Unit
   }
   object DevNullListener extends DebugListener {
-    def onSend(data: ByteString) = ()
-    def onReceive(data: ByteString) = ()
+    def onSend(data: ByteString): Unit = ()
+    def onReceive(data: ByteString): Unit = ()
   }
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
@@ -385,9 +385,9 @@ final class RedisConnectionActor(address: NodeAddress, config: ConnectionConfig)
 }
 
 object RedisConnectionActor {
-  case class Open(mustInitiallyConnect: Boolean, initPromise: Promise[Unit])
-  case class Close(cause: Throwable, stop: Boolean)
-  case class Reserving(packs: RawCommandPacks)
+  final case class Open(mustInitiallyConnect: Boolean, initPromise: Promise[Unit])
+  final case class Close(cause: Throwable, stop: Boolean)
+  final case class Reserving(packs: RawCommandPacks)
   case object Release
 
   private object Connect

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -293,7 +293,9 @@ object ReplyDecoders {
   }
 
   def multiBulkXEntriesMap[K: RedisDataCodec, F: RedisDataCodec, V: RedisDataCodec]: ReplyDecoder[BMap[K, Seq[XEntry[F, V]]]] =
-    multiBulkMap(bulk[K], multiBulkSeq(multiBulkXEntry[F, V]))
+    multiBulkMap(bulk[K], multiBulkSeq(multiBulkXEntry[F, V])) unless {
+      case NullArrayMsg => Map.empty
+    }
 
   val multiBulkXConsumerInfo: ReplyDecoder[XConsumerInfo] =
     flatMultiBulkMap(bulkUTF8, undecoded).andThen(XConsumerInfo)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -285,6 +285,15 @@ object ReplyDecoders {
   def multiBulkXEntriesByKey[K: RedisDataCodec, F: RedisDataCodec, V: RedisDataCodec]: ReplyDecoder[BMap[K, Seq[(XEntryId, BMap[F, V])]]] =
     mapMultiBulk(bulk[K], multiBulkSeq(multiBulkXEntry[F, V]))
 
+  val multiBulkXConsumerInfo: ReplyDecoder[XConsumerInfo] =
+    mapMultiBulk(bulkUTF8, undecoded).andThen(XConsumerInfo)
+
+  val multiBulkXGroupInfo: ReplyDecoder[XGroupInfo] =
+    mapMultiBulk(bulkUTF8, undecoded).andThen(XGroupInfo)
+
+  def multiBulkXStreamInfo[F: RedisDataCodec, V: RedisDataCodec]: ReplyDecoder[XStreamInfo[F, V]] =
+    mapMultiBulk(bulkUTF8, undecoded).andThen(XStreamInfo[F, V])
+
   def groupedMultiBulk[T](size: Int, elementDecoder: ReplyDecoder[T]): ReplyDecoder[Seq[Seq[T]]] = {
     case ArrayMsg(elements) =>
       def elemDecode(msg: RedisMsg): T = msg match {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -289,7 +289,7 @@ object ReplyDecoders {
 
   def multiBulkXEntry[F: RedisDataCodec, V: RedisDataCodec]: ReplyDecoder[XEntry[F, V]] = {
     case ArrayMsg(IndexedSeq(BulkStringMsg(id), data: ArrayMsg[RedisMsg])) =>
-      XEntry(XEntryId.parse(id.utf8String), flatMultiBulkMap[F, V].apply(data))
+      XEntry(XEntryId.parse(id.utf8String), flatMultiBulkSeq[F, V].apply(data))
   }
 
   def multiBulkXEntriesMap[K: RedisDataCodec, F: RedisDataCodec, V: RedisDataCodec]: ReplyDecoder[BMap[K, Seq[XEntry[F, V]]]] =

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -107,6 +107,10 @@ object ReplyDecoders {
     case BulkStringMsg(data) => Cursor(data.utf8String.toLong)
   }
 
+  val bulkXEntryId: ReplyDecoder[XEntryId] = {
+    case BulkStringMsg(data) => XEntryId.parse(data.utf8String)
+  }
+
   val simpleUTF8: ReplyDecoder[String] =
     simple(_.utf8String)
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -301,8 +301,8 @@ object ReplyDecoders {
   val multiBulkXGroupInfo: ReplyDecoder[XGroupInfo] =
     flatMultiBulkMap(bulkUTF8, undecoded).andThen(XGroupInfo)
 
-  def multiBulkXStreamInfo[F: RedisDataCodec, V: RedisDataCodec]: ReplyDecoder[XStreamInfo[F, V]] =
-    flatMultiBulkMap(bulkUTF8, undecoded).andThen(XStreamInfo[F, V])
+  def multiBulkXStreamInfo[Entry <: XEntry[_, _]](entryDecoder: ReplyDecoder[Entry]): ReplyDecoder[XStreamInfo[Entry]] =
+    flatMultiBulkMap(bulkUTF8, undecoded).andThen(XStreamInfo[Entry](_)(entryDecoder))
 
   def multiBulkGroupedSeq[T](size: Int, elementDecoder: ReplyDecoder[T]): ReplyDecoder[Seq[Seq[T]]] = {
     case ArrayMsg(elements) =>

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -278,7 +278,7 @@ object ReplyDecoders {
     case ArrayMsg(IndexedSeq(IntegerMsg(count), BulkStringMsg(minid), BulkStringMsg(maxid), ArrayMsg(byConsumer))) =>
       XPendingOverview(
         count, XEntryId.parse(minid.utf8String), XEntryId.parse(maxid.utf8String),
-        new mutable.OpenHashMap() ++ flatPairedMultiBulkIterator(byConsumer, bulkXConsumer, bulkLong)
+        new mutable.OpenHashMap() ++ multiBulkIterator(byConsumer, multiBulkPair(bulkXConsumer, bulkLong))
       )
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -57,6 +57,10 @@ object ReplyDecoders {
     case IntegerMsg(ttl) => Opt(Opt(ttl))
   }
 
+  val integerClientId: ReplyDecoder[ClientId] = {
+    case IntegerMsg(value) => ClientId(value)
+  }
+
   def bulkNamedEnum[E <: NamedEnum](companion: NamedEnumCompanion[E]): ReplyDecoder[E] = {
     case BulkStringMsg(data) => companion.byName(data.utf8String)
   }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/ReplyDecoders.scala
@@ -107,10 +107,6 @@ object ReplyDecoders {
     case BulkStringMsg(data) => Cursor(data.utf8String.toLong)
   }
 
-  val bulkXEntryId: ReplyDecoder[XEntryId] = {
-    case BulkStringMsg(data) => XEntryId.parse(data.utf8String)
-  }
-
   val simpleUTF8: ReplyDecoder[String] =
     simple(_.utf8String)
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/cluster.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/cluster.scala
@@ -9,7 +9,7 @@ import com.avsystem.commons.redis.commands.ReplyDecoders._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-trait KeyedClusterApi extends ApiSubset {
+trait KeyedClusterApi extends KeyedApiSubset {
   def keySlot(key: Key): Int =
     Hash.slot(keyCodec.write(key))
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/cluster.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/cluster.scala
@@ -9,7 +9,7 @@ import com.avsystem.commons.redis.commands.ReplyDecoders._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-trait KeyedClusterApi extends KeyedApiSubset {
+trait KeyedClusterApi extends ApiSubset {
   def keySlot(key: Key): Int =
     Hash.slot(keyCodec.write(key))
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/cluster.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/cluster.scala
@@ -18,7 +18,7 @@ trait KeyedClusterApi extends ApiSubset {
     execute(new ClusterKeyslot(key))
 
   private final class ClusterKeyslot(key: Key) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "KEYSLOT").key(key).result
+    val encoded: Encoded = encoder("CLUSTER", "KEYSLOT").key(key).result
   }
 }
 
@@ -92,83 +92,83 @@ trait NodeClusterApi extends KeyedClusterApi {
     execute(ClusterSlots)
 
   private final class ClusterAddslots(slots: Iterable[Int]) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "ADDSLOTS").add(slots).result
-    override def immediateResult = whenEmpty(slots, ())
+    val encoded: Encoded = encoder("CLUSTER", "ADDSLOTS").add(slots).result
+    override def immediateResult: Opt[Unit] = whenEmpty(slots, ())
   }
 
   private final class ClusterCountFailureReports(nodeId: NodeId) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "COUNT-FAILURE-REPORTS").add(nodeId.raw).result
+    val encoded: Encoded = encoder("CLUSTER", "COUNT-FAILURE-REPORTS").add(nodeId.raw).result
   }
 
   private final class ClusterCountkeysinslot(slot: Int) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "COUNTKEYSINSLOT").add(slot).result
+    val encoded: Encoded = encoder("CLUSTER", "COUNTKEYSINSLOT").add(slot).result
   }
 
   private final class ClusterDelslots(slots: Iterable[Int]) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "DELSLOTS").add(slots).result
-    override def immediateResult = whenEmpty(slots, ())
+    val encoded: Encoded = encoder("CLUSTER", "DELSLOTS").add(slots).result
+    override def immediateResult: Opt[Unit] = whenEmpty(slots, ())
   }
 
   private final class ClusterFailover(option: Opt[FailoverOption]) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "FAILOVER").optAdd(option).result
+    val encoded: Encoded = encoder("CLUSTER", "FAILOVER").optAdd(option).result
   }
 
   private object ClusterFlushslots extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "FLUSHSLOTS").result
+    val encoded: Encoded = encoder("CLUSTER", "FLUSHSLOTS").result
   }
 
   private final class ClusterForget(nodeId: NodeId) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "FORGET").add(nodeId.raw).result
+    val encoded: Encoded = encoder("CLUSTER", "FORGET").add(nodeId.raw).result
   }
 
   private final class ClusterGetkeysinslot(slot: Int, count: Int) extends RedisDataSeqCommand[Key] with NodeCommand {
-    val encoded = encoder("CLUSTER", "GETKEYSINSLOT").add(slot).add(count).result
+    val encoded: Encoded = encoder("CLUSTER", "GETKEYSINSLOT").add(slot).add(count).result
   }
 
   private object ClusterInfo
     extends AbstractRedisCommand[ClusterStateInfo](bulk(bs => ClusterStateInfo(bs.utf8String))) with NodeCommand {
-    val encoded = encoder("CLUSTER", "INFO").result
+    val encoded: Encoded = encoder("CLUSTER", "INFO").result
   }
 
   private final class ClusterMeet(address: NodeAddress) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "MEET").add(address.ip).add(address.port).result
+    val encoded: Encoded = encoder("CLUSTER", "MEET").add(address.ip).add(address.port).result
   }
 
   private final object ClusterMyid extends AbstractRedisCommand[NodeId](bulkNodeId) with NodeCommand {
-    val encoded = encoder("CLUSTER", "MYID").result
+    val encoded: Encoded = encoder("CLUSTER", "MYID").result
   }
 
   private object ClusterNodes extends AbstractRedisCommand[Seq[NodeInfo]](bulkNodeInfos) with NodeCommand {
-    val encoded = encoder("CLUSTER", "NODES").result
+    val encoded: Encoded = encoder("CLUSTER", "NODES").result
   }
 
   private final class ClusterReplicate(nodeId: NodeId) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "REPLICATE").add(nodeId.raw).result
+    val encoded: Encoded = encoder("CLUSTER", "REPLICATE").add(nodeId.raw).result
   }
 
   private final class ClusterReset(hard: Boolean) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "RESET").addFlag("HARD", hard).result
+    val encoded: Encoded = encoder("CLUSTER", "RESET").addFlag("HARD", hard).result
   }
 
   private object ClusterSaveconfig extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "SAVECONFIG").result
+    val encoded: Encoded = encoder("CLUSTER", "SAVECONFIG").result
   }
 
   private final class ClusterSetConfigEpoch(configEpoch: Long) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "SET-CONFIG-EPOCH").add(configEpoch).result
+    val encoded: Encoded = encoder("CLUSTER", "SET-CONFIG-EPOCH").add(configEpoch).result
   }
 
   private final class ClusterSetslot(slot: Int, subcommand: SetslotCmd) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLUSTER", "SETSLOT").add(slot).add(subcommand).result
+    val encoded: Encoded = encoder("CLUSTER", "SETSLOT").add(slot).add(subcommand).result
   }
 
   private final class ClusterSlaves(nodeId: NodeId) extends AbstractRedisCommand[Seq[NodeInfo]](multiBulkNodeInfos) with NodeCommand {
-    val encoded = encoder("CLUSTER", "SLAVES").add(nodeId.raw).result
+    val encoded: Encoded = encoder("CLUSTER", "SLAVES").add(nodeId.raw).result
   }
 
   private object ClusterSlots
     extends RedisSeqCommand[SlotRangeMapping](multiBulkSlotRangeMapping) with NodeCommand {
-    val encoded = encoder("CLUSTER", "SLOTS").result
+    val encoded: Encoded = encoder("CLUSTER", "SLOTS").result
   }
 }
 
@@ -181,16 +181,16 @@ trait ConnectionClusterApi extends NodeClusterApi {
     execute(Readwrite)
 
   private object Readonly extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("READONLY").result
+    val encoded: Encoded = encoder("READONLY").result
   }
 
   private object Readwrite extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("READWRITE").result
+    val encoded: Encoded = encoder("READWRITE").result
   }
 }
 
 case object Asking extends UnsafeCommand {
-  val encoded = encoder("ASKING").result
+  val encoded: Encoded = encoder("ASKING").result
 }
 
 case class NodeId(raw: String) extends AnyVal
@@ -220,32 +220,32 @@ object SetslotCmd {
 }
 
 case class ClusterStateInfo(info: String) extends ParsedInfo(info, "\r\n", ":") {
-  val stateOk = attrMap("cluster_state") == "ok"
-  val slotsAssigned = attrMap("cluster_slots_assigned").toInt
-  val slotsOk = attrMap("cluster_slots_ok").toInt
-  val slotsPfail = attrMap("cluster_slots_pfail").toInt
-  val slotsFail = attrMap("cluster_slots_fail").toInt
-  val knownNodes = attrMap("cluster_known_nodes").toInt
-  val size = attrMap("cluster_size").toInt
-  val currentEpoch = attrMap("cluster_current_epoch").toLong
-  val myEpoch = attrMap("cluster_my_epoch").toLong
-  val statsMessagesSent = attrMap("cluster_stats_messages_sent").toLong
-  val statsMessagesReceived = attrMap("cluster_stats_messages_received").toLong
+  val stateOk: Boolean = attrMap("cluster_state") == "ok"
+  val slotsAssigned: Int = attrMap("cluster_slots_assigned").toInt
+  val slotsOk: Int = attrMap("cluster_slots_ok").toInt
+  val slotsPfail: Int = attrMap("cluster_slots_pfail").toInt
+  val slotsFail: Int = attrMap("cluster_slots_fail").toInt
+  val knownNodes: Int = attrMap("cluster_known_nodes").toInt
+  val size: Int = attrMap("cluster_size").toInt
+  val currentEpoch: Long = attrMap("cluster_current_epoch").toLong
+  val myEpoch: Long = attrMap("cluster_my_epoch").toLong
+  val statsMessagesSent: Long = attrMap("cluster_stats_messages_sent").toLong
+  val statsMessagesReceived: Long = attrMap("cluster_stats_messages_received").toLong
 }
 
 case class NodeInfo(infoLine: String) {
   private val splitLine: Array[String] = infoLine.split(' ')
   private val splitAddr: Array[String] = splitLine(1).split('@')
 
-  val id = NodeId(splitLine(0))
-  val address = NodeAddress.parse(splitAddr(0))
-  val clusterPort = splitAddr.opt.filter(_.length > 1).map(_.apply(1))
-  val flags = NodeFlags(splitLine(2))
-  val master = Opt(splitLine(3)).filter(_ != "-").map(NodeId)
-  val pingSent = splitLine(4).toLong
-  val pongRecv = splitLine(5).toLong
-  val configEpoch = splitLine(6).toLong
-  val connected = splitLine(7) == "connected"
+  val id: NodeId = NodeId(splitLine(0))
+  val address: NodeAddress = NodeAddress.parse(splitAddr(0))
+  val clusterPort: Opt[String] = splitAddr.opt.filter(_.length > 1).map(_.apply(1))
+  val flags: NodeFlags = NodeFlags(splitLine(2))
+  val master: Opt[NodeId] = Opt(splitLine(3)).filter(_ != "-").map(NodeId)
+  val pingSent: Long = splitLine(4).toLong
+  val pongRecv: Long = splitLine(5).toLong
+  val configEpoch: Long = splitLine(6).toLong
+  val connected: Boolean = splitLine(7) == "connected"
   val (slots: Seq[SlotRange], importingSlots: Seq[(Int, NodeId)], migratingSlots: Seq[(Int, NodeId)]) = {
 
     val slots = new ArrayBuffer[SlotRange]
@@ -269,16 +269,16 @@ case class NodeInfo(infoLine: String) {
     (slots, importingSlots, migratingSlots)
   }
 
-  override def toString = infoLine
+  override def toString: String = infoLine
 }
 
 class NodeFlags(val raw: Int) extends AnyVal {
 
   import NodeFlags._
 
-  def |(other: NodeFlags) = new NodeFlags(raw | other.raw)
-  def &(other: NodeFlags) = new NodeFlags(raw & other.raw)
-  def ^(other: NodeFlags) = new NodeFlags(raw ^ other.raw)
+  def |(other: NodeFlags): NodeFlags = new NodeFlags(raw | other.raw)
+  def &(other: NodeFlags): NodeFlags = new NodeFlags(raw & other.raw)
+  def ^(other: NodeFlags): NodeFlags = new NodeFlags(raw ^ other.raw)
   def unary_~ : NodeFlags = new NodeFlags(~raw)
 
   def myself: Boolean = (this & Myself) != Noflags
@@ -289,7 +289,7 @@ class NodeFlags(val raw: Int) extends AnyVal {
   def handshake: Boolean = (this & Handshake) != Noflags
   def noaddr: Boolean = (this & Noaddr) != Noflags
 
-  override def toString =
+  override def toString: String =
     if (this == Noflags) "noflags"
     else reprValuePairs.iterator
       .collect({ case (str, flags) if (this & flags) != Noflags => str })
@@ -324,14 +324,18 @@ object NodeFlags {
   }
 }
 
-case class SlotRangeMapping(range: SlotRange, master: NodeAddress, masterId: Opt[NodeId], slaves: Seq[(NodeAddress, Opt[NodeId])]) {
-  private def nodeRepr(addr: NodeAddress, idOpt: Opt[NodeId]) = addr.toString + idOpt.fold("")(id => s" (${id.raw})")
-  override def toString = s"slots: $range, master: ${nodeRepr(master, masterId)}, slaves: ${slaves.map((nodeRepr _).tupled).mkString(",")}"
+case class SlotRangeMapping(
+  range: SlotRange, master: NodeAddress, masterId: Opt[NodeId], slaves: Seq[(NodeAddress, Opt[NodeId])]
+) {
+  private def nodeRepr(addr: NodeAddress, idOpt: Opt[NodeId]): String =
+    addr.toString + idOpt.fold("")(id => s" (${id.raw})")
+  override def toString: String =
+    s"slots: $range, master: ${nodeRepr(master, masterId)}, slaves: ${slaves.map((nodeRepr _).tupled).mkString(",")}"
 }
 case class SlotRange(start: Int, end: Int) {
   def toRange: Range = start to end
   def contains(slot: Int): Boolean = slot >= start && slot <= end
-  override def toString = if (start == end) start.toString else s"$start-$end"
+  override def toString: String = if (start == end) start.toString else s"$start-$end"
 }
 object SlotRange {
   final val LastSlot = Hash.TotalSlots - 1

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/common.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/common.scala
@@ -17,7 +17,7 @@ object SortOrder extends NamedEnumCompanion[SortOrder] {
 }
 
 case class Cursor(raw: Long) extends AnyVal {
-  override def toString = raw.toString
+  override def toString: String = raw.toString
 }
 object Cursor {
   final val NoCursor = Cursor(0)
@@ -30,5 +30,5 @@ abstract class ParsedInfo(info: String, attrSeparator: String, nameValueSeparato
       (name, value)
     }
 
-  override def toString = info
+  override def toString: String = info
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/connection.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/connection.scala
@@ -17,15 +17,15 @@ trait NodeConnectionApi extends ApiSubset {
     execute(new Swapdb(first, second))
 
   private final class Echo(message: Value) extends RedisDataCommand[Value] with NodeCommand {
-    val encoded = encoder("ECHO").data(message).result
+    val encoded: Encoded = encoder("ECHO").data(message).result
   }
 
   private object Ping extends AbstractRedisCommand[ByteString](simpleBinary) with NodeCommand {
-    val encoded = encoder("PING").result
+    val encoded: Encoded = encoder("PING").result
   }
 
   private final class Swapdb(first: Int, second: Int) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("SWAPDB").add(first).add(second).result
+    val encoded: Encoded = encoder("SWAPDB").add(first).add(second).result
   }
 }
 
@@ -41,15 +41,15 @@ trait ConnectionConnectionApi extends NodeConnectionApi {
     execute(new Select(index))
 
   private final class Auth(password: String) extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("AUTH").add(password).result
+    val encoded: Encoded = encoder("AUTH").add(password).result
   }
 
   private object Quit extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("QUIT").result
+    val encoded: Encoded = encoder("QUIT").result
   }
 
   private final class Select(index: Int) extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("SELECT").add(index).result
+    val encoded: Encoded = encoder("SELECT").add(index).result
   }
 }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/connection.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/connection.scala
@@ -7,7 +7,7 @@ import com.avsystem.commons.redis.commands.ReplyDecoders._
 
 trait NodeConnectionApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/echo ECHO]] */
-  def echo(message: Value): Result[Value] =
+  def echo(message: ByteString): Result[ByteString] =
     execute(new Echo(message))
   /** Executes [[http://redis.io/commands/ping PING]] */
   def ping: Result[ByteString] =
@@ -16,7 +16,7 @@ trait NodeConnectionApi extends ApiSubset {
   def swapdb(first: Int, second: Int): Result[Unit] =
     execute(new Swapdb(first, second))
 
-  private final class Echo(message: Value) extends RedisDataCommand[Value] with NodeCommand {
+  private final class Echo(message: ByteString) extends RedisBinaryCommand with NodeCommand {
     val encoded: Encoded = encoder("ECHO").data(message).result
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/geo.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/geo.scala
@@ -10,7 +10,7 @@ import com.avsystem.commons.redis.protocol._
 
 import scala.collection.mutable.ListBuffer
 
-trait GeoApi extends ValueApiSubset {
+trait GeoApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/geoadd GEOADD]] */
   def geoadd(key: Key, member: Value, point: GeoPoint): Result[Boolean] =
     execute(new Geoadd(key, (member, point).single).map(_ > 0))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/geo.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/geo.scala
@@ -10,7 +10,7 @@ import com.avsystem.commons.redis.protocol._
 
 import scala.collection.mutable.ListBuffer
 
-trait GeoApi extends ApiSubset {
+trait GeoApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/geoadd GEOADD]] */
   def geoadd(key: Key, member: Value, point: GeoPoint): Result[Boolean] =
     execute(new Geoadd(key, (member, point).single).map(_ > 0))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
@@ -4,7 +4,7 @@ package redis.commands
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait HashesApi extends FieldValueApiSubset with RecordApiSubset {
+trait HashesApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/hdel HDEL]] */
   def hdel(key: Key, field: Field): Result[Boolean] =
     execute(new Hdel(key, field.single).map(_ > 0))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
@@ -6,101 +6,101 @@ import com.avsystem.commons.redis.commands.ReplyDecoders._
 
 trait HashesApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/hdel HDEL]] */
-  def hdel(key: Key, field: HashKey): Result[Boolean] =
+  def hdel(key: Key, field: Field): Result[Boolean] =
     execute(new Hdel(key, field.single).map(_ > 0))
   /** Executes [[http://redis.io/commands/hdel HDEL]] */
-  def hdel(key: Key, field: HashKey, fields: HashKey*): Result[Int] =
+  def hdel(key: Key, field: Field, fields: Field*): Result[Int] =
     execute(new Hdel(key, field +:: fields))
   /** Executes [[http://redis.io/commands/hdel HDEL]]
     * or simply returns 0 when `fields` is empty, without sending the command to Redis */
-  def hdel(key: Key, fields: Iterable[HashKey]): Result[Int] =
+  def hdel(key: Key, fields: Iterable[Field]): Result[Int] =
     execute(new Hdel(key, fields))
   /** Executes [[http://redis.io/commands/hexists HEXISTS]] */
-  def hexists(key: Key, field: HashKey): Result[Boolean] =
+  def hexists(key: Key, field: Field): Result[Boolean] =
     execute(new Hexists(key, field))
   /** Executes [[http://redis.io/commands/hget HGET]] */
-  def hget(key: Key, field: HashKey): Result[Opt[Value]] =
+  def hget(key: Key, field: Field): Result[Opt[Value]] =
     execute(new Hget(key, field))
   /** Executes [[http://redis.io/commands/hgetall HGETALL]] */
-  def hgetall(key: Key): Result[BMap[HashKey, Value]] =
+  def hgetall(key: Key): Result[BMap[Field, Value]] =
     execute(new Hgetall(key))
   /** Executes [[http://redis.io/commands/hincrby HINCRBY]] */
-  def hincrby(key: Key, field: HashKey, increment: Long): Result[Long] =
+  def hincrby(key: Key, field: Field, increment: Long): Result[Long] =
     execute(new Hincrby(key, field, increment))
   /** Executes [[http://redis.io/commands/hincrbyfloat HINCRBYFLOAT]] */
-  def hincrbyfloat(key: Key, field: HashKey, increment: Double): Result[Double] =
+  def hincrbyfloat(key: Key, field: Field, increment: Double): Result[Double] =
     execute(new Hincrbyfloat(key, field, increment))
   /** Executes [[http://redis.io/commands/hkeys HKEYS]] */
-  def hkeys(key: Key): Result[BSet[HashKey]] =
+  def hkeys(key: Key): Result[BSet[Field]] =
     execute(new Hkeys(key))
   /** Executes [[http://redis.io/commands/hlen HLEN]] */
   def hlen(key: Key): Result[Long] =
     execute(new Hlen(key))
   /** Executes [[http://redis.io/commands/hmget HMGET]] */
-  def hmget(key: Key, field: HashKey, fields: HashKey*): Result[Seq[Opt[Value]]] =
+  def hmget(key: Key, field: Field, fields: Field*): Result[Seq[Opt[Value]]] =
     execute(new Hmget(key, field +:: fields))
   /** Executes [[http://redis.io/commands/hmget HMGET]]
     * or simply returns empty `Seq` when `fields` is empty, without sending the command to Redis */
-  def hmget(key: Key, fields: Iterable[HashKey]): Result[Seq[Opt[Value]]] =
+  def hmget(key: Key, fields: Iterable[Field]): Result[Seq[Opt[Value]]] =
     execute(new Hmget(key, fields))
   /** Executes [[http://redis.io/commands/hmset HMSET]] */
-  def hmset(key: Key, fieldValue: (HashKey, Value), fieldValues: (HashKey, Value)*): Result[Unit] =
+  def hmset(key: Key, fieldValue: (Field, Value), fieldValues: (Field, Value)*): Result[Unit] =
     execute(new Hmset(key, fieldValue +:: fieldValues))
   /** Executes [[http://redis.io/commands/hmset HMSET]]
     * or does nothing when `fieldValues` is empty, without sending the command to Redis */
-  def hmset(key: Key, fieldValues: Iterable[(HashKey, Value)]): Result[Unit] =
+  def hmset(key: Key, fieldValues: Iterable[(Field, Value)]): Result[Unit] =
     execute(new Hmset(key, fieldValues))
   /** Executes [[http://redis.io/commands/hscan HSCAN]] */
-  def hscan(key: Key, cursor: Cursor, matchPattern: OptArg[HashKey] = OptArg.Empty, count: OptArg[Int] = OptArg.Empty): Result[(Cursor, Seq[(HashKey, Value)])] =
+  def hscan(key: Key, cursor: Cursor, matchPattern: OptArg[Field] = OptArg.Empty, count: OptArg[Int] = OptArg.Empty): Result[(Cursor, Seq[(Field, Value)])] =
     execute(new Hscan(key, cursor, matchPattern.toOpt, count.toOpt))
   /** Executes [[http://redis.io/commands/hset HSET]] */
-  def hset(key: Key, field: HashKey, value: Value): Result[Boolean] =
+  def hset(key: Key, field: Field, value: Value): Result[Boolean] =
     execute(new Hset(key, (field, value).single).map(_ > 0))
   /** Executes [[http://redis.io/commands/hset HSET]] */
-  def hset(key: Key, fieldValue: (HashKey, Value), fieldValues: (HashKey, Value)*): Result[Int] =
+  def hset(key: Key, fieldValue: (Field, Value), fieldValues: (Field, Value)*): Result[Int] =
     execute(new Hset(key, fieldValue +:: fieldValues))
   /** Executes [[http://redis.io/commands/hset HSET]]
     * or does nothing when `fieldValues` is empty, without sending the command to Redis */
-  def hset(key: Key, fieldValues: Iterable[(HashKey, Value)]): Result[Int] =
+  def hset(key: Key, fieldValues: Iterable[(Field, Value)]): Result[Int] =
     execute(new Hset(key, fieldValues))
   /** Executes [[http://redis.io/commands/hsetnx HSETNX]] */
-  def hsetnx(key: Key, field: HashKey, value: Value): Result[Boolean] =
+  def hsetnx(key: Key, field: Field, value: Value): Result[Boolean] =
     execute(new Hsetnx(key, field, value))
   /** Executes [[http://redis.io/commands/hstrlen HSTRLEN]] */
-  def hstrlen(key: Key, field: HashKey): Result[Int] =
+  def hstrlen(key: Key, field: Field): Result[Int] =
     execute(new Hstrlen(key, field))
   /** Executes [[http://redis.io/commands/hvals HVALS]] */
   def hvals(key: Key): Result[Iterable[Value]] =
     execute(new Hvals(key))
 
-  private final class Hdel(key: Key, fields: Iterable[HashKey]) extends RedisIntCommand with NodeCommand {
+  private final class Hdel(key: Key, fields: Iterable[Field]) extends RedisIntCommand with NodeCommand {
     val encoded = encoder("HDEL").key(key).datas(fields).result
     override def immediateResult = whenEmpty(fields, 0)
   }
 
-  private final class Hexists(key: Key, field: HashKey) extends RedisBooleanCommand with NodeCommand {
+  private final class Hexists(key: Key, field: Field) extends RedisBooleanCommand with NodeCommand {
     val encoded = encoder("HEXISTS").key(key).data(field).result
   }
 
-  private final class Hget(key: Key, field: HashKey)
+  private final class Hget(key: Key, field: Field)
     extends RedisOptDataCommand[Value] with NodeCommand {
     val encoded = encoder("HGET").key(key).data(field).result
   }
 
   private final class Hgetall(key: Key)
-    extends AbstractRedisCommand[BMap[HashKey, Value]](mapMultiBulk[HashKey, Value]) with NodeCommand {
+    extends AbstractRedisCommand[BMap[Field, Value]](mapMultiBulk[Field, Value]) with NodeCommand {
     val encoded = encoder("HGETALL").key(key).result
   }
 
-  private final class Hincrby(key: Key, field: HashKey, increment: Long) extends RedisLongCommand with NodeCommand {
+  private final class Hincrby(key: Key, field: Field, increment: Long) extends RedisLongCommand with NodeCommand {
     val encoded = encoder("HINCRBY").key(key).data(field).add(increment).result
   }
 
-  private final class Hincrbyfloat(key: Key, field: HashKey, increment: Double) extends RedisDoubleCommand with NodeCommand {
+  private final class Hincrbyfloat(key: Key, field: Field, increment: Double) extends RedisDoubleCommand with NodeCommand {
     val encoded = encoder("HINCRBYFLOAT").key(key).data(field).add(increment).result
   }
 
-  private final class Hkeys(key: Key) extends RedisDataSetCommand[HashKey] with NodeCommand {
+  private final class Hkeys(key: Key) extends RedisDataSetCommand[Field] with NodeCommand {
     val encoded = encoder("HKEYS").key(key).result
   }
 
@@ -108,32 +108,32 @@ trait HashesApi extends ApiSubset {
     val encoded = encoder("HLEN").key(key).result
   }
 
-  private final class Hmget(key: Key, fields: Iterable[HashKey])
+  private final class Hmget(key: Key, fields: Iterable[Field])
     extends RedisOptDataSeqCommand[Value] with NodeCommand {
     val encoded = encoder("HMGET").key(key).datas(fields).result
     override def immediateResult = whenEmpty(fields, Seq.empty)
   }
 
-  private final class Hmset(key: Key, fieldValues: Iterable[(HashKey, Value)]) extends RedisUnitCommand with NodeCommand {
+  private final class Hmset(key: Key, fieldValues: Iterable[(Field, Value)]) extends RedisUnitCommand with NodeCommand {
     val encoded = encoder("HMSET").key(key).dataPairs(fieldValues).result
     override def immediateResult = whenEmpty(fieldValues, ())
   }
 
-  private final class Hscan(key: Key, cursor: Cursor, matchPattern: Opt[HashKey], count: Opt[Int])
-    extends RedisScanCommand[(HashKey, Value)](pairedMultiBulk[HashKey, Value]) with NodeCommand {
+  private final class Hscan(key: Key, cursor: Cursor, matchPattern: Opt[Field], count: Opt[Int])
+    extends RedisScanCommand[(Field, Value)](pairedMultiBulk[Field, Value]) with NodeCommand {
     val encoded = encoder("HSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
   }
 
-  private final class Hset(key: Key, fieldValues: Iterable[(HashKey, Value)]) extends RedisIntCommand with NodeCommand {
+  private final class Hset(key: Key, fieldValues: Iterable[(Field, Value)]) extends RedisIntCommand with NodeCommand {
     val encoded = encoder("HSET").key(key).dataPairs(fieldValues).result
     override def immediateResult = whenEmpty(fieldValues, 0)
   }
 
-  private final class Hsetnx(key: Key, field: HashKey, value: Value) extends RedisBooleanCommand with NodeCommand {
+  private final class Hsetnx(key: Key, field: Field, value: Value) extends RedisBooleanCommand with NodeCommand {
     val encoded = encoder("HSETNX").key(key).data(field).data(value).result
   }
 
-  private final class Hstrlen(key: Key, field: HashKey) extends RedisIntCommand with NodeCommand {
+  private final class Hstrlen(key: Key, field: Field) extends RedisIntCommand with NodeCommand {
     val encoded = encoder("HSTRLEN").key(key).data(field).result
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
@@ -74,70 +74,70 @@ trait HashesApi extends ApiSubset {
     execute(new Hvals(key))
 
   private final class Hdel(key: Key, fields: Iterable[Field]) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("HDEL").key(key).datas(fields).result
-    override def immediateResult = whenEmpty(fields, 0)
+    val encoded: Encoded = encoder("HDEL").key(key).datas(fields).result
+    override def immediateResult: Opt[Int] = whenEmpty(fields, 0)
   }
 
   private final class Hexists(key: Key, field: Field) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("HEXISTS").key(key).data(field).result
+    val encoded: Encoded = encoder("HEXISTS").key(key).data(field).result
   }
 
   private final class Hget(key: Key, field: Field)
     extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("HGET").key(key).data(field).result
+    val encoded: Encoded = encoder("HGET").key(key).data(field).result
   }
 
   private final class Hgetall(key: Key)
     extends AbstractRedisCommand[BMap[Field, Value]](mapMultiBulk[Field, Value]) with NodeCommand {
-    val encoded = encoder("HGETALL").key(key).result
+    val encoded: Encoded = encoder("HGETALL").key(key).result
   }
 
   private final class Hincrby(key: Key, field: Field, increment: Long) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("HINCRBY").key(key).data(field).add(increment).result
+    val encoded: Encoded = encoder("HINCRBY").key(key).data(field).add(increment).result
   }
 
   private final class Hincrbyfloat(key: Key, field: Field, increment: Double) extends RedisDoubleCommand with NodeCommand {
-    val encoded = encoder("HINCRBYFLOAT").key(key).data(field).add(increment).result
+    val encoded: Encoded = encoder("HINCRBYFLOAT").key(key).data(field).add(increment).result
   }
 
   private final class Hkeys(key: Key) extends RedisDataSetCommand[Field] with NodeCommand {
-    val encoded = encoder("HKEYS").key(key).result
+    val encoded: Encoded = encoder("HKEYS").key(key).result
   }
 
   private final class Hlen(key: Key) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("HLEN").key(key).result
+    val encoded: Encoded = encoder("HLEN").key(key).result
   }
 
   private final class Hmget(key: Key, fields: Iterable[Field])
     extends RedisOptDataSeqCommand[Value] with NodeCommand {
-    val encoded = encoder("HMGET").key(key).datas(fields).result
-    override def immediateResult = whenEmpty(fields, Seq.empty)
+    val encoded: Encoded = encoder("HMGET").key(key).datas(fields).result
+    override def immediateResult: Opt[Seq[Opt[Value]]] = whenEmpty(fields, Seq.empty)
   }
 
   private final class Hmset(key: Key, fieldValues: Iterable[(Field, Value)]) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("HMSET").key(key).dataPairs(fieldValues).result
-    override def immediateResult = whenEmpty(fieldValues, ())
+    val encoded: Encoded = encoder("HMSET").key(key).dataPairs(fieldValues).result
+    override def immediateResult: Opt[Unit] = whenEmpty(fieldValues, ())
   }
 
   private final class Hscan(key: Key, cursor: Cursor, matchPattern: Opt[Field], count: Opt[Int])
     extends RedisScanCommand[(Field, Value)](pairedMultiBulk[Field, Value]) with NodeCommand {
-    val encoded = encoder("HSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
+    val encoded: Encoded = encoder("HSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
   }
 
   private final class Hset(key: Key, fieldValues: Iterable[(Field, Value)]) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("HSET").key(key).dataPairs(fieldValues).result
-    override def immediateResult = whenEmpty(fieldValues, 0)
+    val encoded: Encoded = encoder("HSET").key(key).dataPairs(fieldValues).result
+    override def immediateResult: Opt[Int] = whenEmpty(fieldValues, 0)
   }
 
   private final class Hsetnx(key: Key, field: Field, value: Value) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("HSETNX").key(key).data(field).data(value).result
+    val encoded: Encoded = encoder("HSETNX").key(key).data(field).data(value).result
   }
 
   private final class Hstrlen(key: Key, field: Field) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("HSTRLEN").key(key).data(field).result
+    val encoded: Encoded = encoder("HSTRLEN").key(key).data(field).result
   }
 
   private final class Hvals(key: Key) extends RedisDataSeqCommand[Value] with NodeCommand {
-    val encoded = encoder("HVALS").key(key).result
+    val encoded: Encoded = encoder("HVALS").key(key).result
   }
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
@@ -88,7 +88,7 @@ trait HashesApi extends ApiSubset {
   }
 
   private final class Hgetall(key: Key)
-    extends AbstractRedisCommand[BMap[Field, Value]](mapMultiBulk[Field, Value]) with NodeCommand {
+    extends AbstractRedisCommand[BMap[Field, Value]](flatMultiBulkMap[Field, Value]) with NodeCommand {
     val encoded: Encoded = encoder("HGETALL").key(key).result
   }
 
@@ -120,7 +120,7 @@ trait HashesApi extends ApiSubset {
   }
 
   private final class Hscan(key: Key, cursor: Cursor, matchPattern: Opt[Field], count: Opt[Int])
-    extends RedisScanCommand[(Field, Value)](pairedMultiBulk[Field, Value]) with NodeCommand {
+    extends RedisScanCommand[(Field, Value)](flatMultiBulkSeq[Field, Value]) with NodeCommand {
     val encoded: Encoded = encoder("HSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hashes.scala
@@ -4,7 +4,7 @@ package redis.commands
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait HashesApi extends ApiSubset {
+trait HashesApi extends FieldValueApiSubset with RecordApiSubset {
   /** Executes [[http://redis.io/commands/hdel HDEL]] */
   def hdel(key: Key, field: Field): Result[Boolean] =
     execute(new Hdel(key, field.single).map(_ > 0))
@@ -24,6 +24,9 @@ trait HashesApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/hgetall HGETALL]] */
   def hgetall(key: Key): Result[BMap[Field, Value]] =
     execute(new Hgetall(key))
+  /** Executes [[http://redis.io/commands/hgetall HGETALL]] */
+  def hgetallRecord(key: Key): Result[Opt[Record]] =
+    execute(new HgetallRecord(key))
   /** Executes [[http://redis.io/commands/hincrby HINCRBY]] */
   def hincrby(key: Key, field: Field, increment: Long): Result[Long] =
     execute(new Hincrby(key, field, increment))
@@ -50,6 +53,10 @@ trait HashesApi extends ApiSubset {
     * or does nothing when `fieldValues` is empty, without sending the command to Redis */
   def hmset(key: Key, fieldValues: Iterable[(Field, Value)]): Result[Unit] =
     execute(new Hmset(key, fieldValues))
+  /** Executes [[http://redis.io/commands/hmset HMSET]]
+    * or does nothing when `data` is empty, without sending the command to Redis */
+  def hmsetRecord(key: Key, data: Record): Result[Unit] =
+    execute(new HmsetRecord(key, data))
   /** Executes [[http://redis.io/commands/hscan HSCAN]] */
   def hscan(key: Key, cursor: Cursor, matchPattern: OptArg[Field] = OptArg.Empty, count: OptArg[Int] = OptArg.Empty): Result[(Cursor, Seq[(Field, Value)])] =
     execute(new Hscan(key, cursor, matchPattern.toOpt, count.toOpt))
@@ -63,6 +70,10 @@ trait HashesApi extends ApiSubset {
     * or does nothing when `fieldValues` is empty, without sending the command to Redis */
   def hset(key: Key, fieldValues: Iterable[(Field, Value)]): Result[Int] =
     execute(new Hset(key, fieldValues))
+  /** Executes [[http://redis.io/commands/hset HSET]]
+    * or does nothing when `data` is empty, without sending the command to Redis */
+  def hsetRecord(key: Key, data: Record): Result[Int] =
+    execute(new HsetRecord(key, data))
   /** Executes [[http://redis.io/commands/hsetnx HSETNX]] */
   def hsetnx(key: Key, field: Field, value: Value): Result[Boolean] =
     execute(new Hsetnx(key, field, value))
@@ -89,6 +100,11 @@ trait HashesApi extends ApiSubset {
 
   private final class Hgetall(key: Key)
     extends AbstractRedisCommand[BMap[Field, Value]](flatMultiBulkMap[Field, Value]) with NodeCommand {
+    val encoded: Encoded = encoder("HGETALL").key(key).result
+  }
+
+  private final class HgetallRecord(key: Key)
+    extends AbstractRedisCommand[Opt[Record]](flatMultiBulkRecordOpt) with NodeCommand {
     val encoded: Encoded = encoder("HGETALL").key(key).result
   }
 
@@ -119,6 +135,11 @@ trait HashesApi extends ApiSubset {
     override def immediateResult: Opt[Unit] = whenEmpty(fieldValues, ())
   }
 
+  private final class HmsetRecord(key: Key, data: Record) extends RedisUnitCommand with NodeCommand {
+    val encoded: Encoded = encoder("HMSET").key(key).dataPairs(data).result
+    override def immediateResult: Opt[Unit] = if (encoded.elements.size <= 2) Opt(()) else Opt.Empty
+  }
+
   private final class Hscan(key: Key, cursor: Cursor, matchPattern: Opt[Field], count: Opt[Int])
     extends RedisScanCommand[(Field, Value)](flatMultiBulkSeq[Field, Value]) with NodeCommand {
     val encoded: Encoded = encoder("HSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
@@ -127,6 +148,11 @@ trait HashesApi extends ApiSubset {
   private final class Hset(key: Key, fieldValues: Iterable[(Field, Value)]) extends RedisIntCommand with NodeCommand {
     val encoded: Encoded = encoder("HSET").key(key).dataPairs(fieldValues).result
     override def immediateResult: Opt[Int] = whenEmpty(fieldValues, 0)
+  }
+
+  private final class HsetRecord(key: Key, data: Record) extends RedisIntCommand with NodeCommand {
+    val encoded: Encoded = encoder("HSET").key(key).dataPairs(data).result
+    override def immediateResult: Opt[Int] = if (encoded.elements.size <= 2) Opt(0) else Opt.Empty
   }
 
   private final class Hsetnx(key: Key, field: Field, value: Value) extends RedisBooleanCommand with NodeCommand {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hyperLogLog.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hyperLogLog.scala
@@ -27,15 +27,15 @@ trait HyperLogLogApi extends ApiSubset {
     execute(new Pfmerge(destkey, sourcekeys))
 
   private final class Pfadd(key: Key, elements: Iterable[Value]) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("PFADD").key(key).datas(elements).result
+    val encoded: Encoded = encoder("PFADD").key(key).datas(elements).result
   }
 
   private final class Pfcount(keys: Iterable[Key]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("PFCOUNT").keys(keys).result
-    override def immediateResult = whenEmpty(keys, 0)
+    val encoded: Encoded = encoder("PFCOUNT").keys(keys).result
+    override def immediateResult: Opt[Long] = whenEmpty(keys, 0)
   }
 
   private final class Pfmerge(destkey: Key, sourcekeys: Iterable[Key]) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("PFMERGE").key(destkey).keys(sourcekeys).result
+    val encoded: Encoded = encoder("PFMERGE").key(destkey).keys(sourcekeys).result
   }
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hyperLogLog.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hyperLogLog.scala
@@ -3,7 +3,7 @@ package redis.commands
 
 import com.avsystem.commons.redis._
 
-trait HyperLogLogApi extends ValueApiSubset {
+trait HyperLogLogApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/pfadd PFADD]] */
   def pfadd(key: Key, elements: Value*): Result[Boolean] =
     execute(new Pfadd(key, elements))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hyperLogLog.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/hyperLogLog.scala
@@ -3,7 +3,7 @@ package redis.commands
 
 import com.avsystem.commons.redis._
 
-trait HyperLogLogApi extends ApiSubset {
+trait HyperLogLogApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/pfadd PFADD]] */
   def pfadd(key: Key, elements: Value*): Result[Boolean] =
     execute(new Pfadd(key, elements))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/keys.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/keys.scala
@@ -12,7 +12,7 @@ import com.avsystem.commons.redis.protocol._
   * Author: ghik
   * Created: 06/04/16.
   */
-trait KeyedKeysApi extends FieldValueApiSubset {
+trait KeyedKeysApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/del DEL]] */
   def del(key: Key): Result[Boolean] =
     execute(new Del(key.single).map(_ > 0))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/keys.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/keys.scala
@@ -85,16 +85,16 @@ trait KeyedKeysApi extends ApiSubset {
     execute(new Restore(key, ttl, dumpedValue, replace))
 
   /** Executes [[http://redis.io/commands/sort SORT]] */
-  def sort(key: Key, by: OptArg[SortPattern[Key, HashKey]] = OptArg.Empty, limit: OptArg[SortLimit] = OptArg.Empty,
+  def sort(key: Key, by: OptArg[SortPattern[Key, Field]] = OptArg.Empty, limit: OptArg[SortLimit] = OptArg.Empty,
     sortOrder: OptArg[SortOrder] = OptArg.Empty, alpha: Boolean = false): Result[Seq[Value]] =
     execute(new Sort(key, by.toOpt, limit.toOpt, sortOrder.toOpt, alpha))
   /** Executes [[http://redis.io/commands/sort SORT]] */
-  def sortGet(key: Key, gets: Seq[SortPattern[Key, HashKey]], by: OptArg[SortPattern[Key, HashKey]] = OptArg.Empty, limit: OptArg[SortLimit] = OptArg.Empty,
+  def sortGet(key: Key, gets: Seq[SortPattern[Key, Field]], by: OptArg[SortPattern[Key, Field]] = OptArg.Empty, limit: OptArg[SortLimit] = OptArg.Empty,
     sortOrder: OptArg[SortOrder] = OptArg.Empty, alpha: Boolean = false): Result[Seq[Seq[Opt[Value]]]] =
     execute(new SortGet(key, gets, by.toOpt, limit.toOpt, sortOrder.toOpt, alpha))
   /** Executes [[http://redis.io/commands/sort SORT]] */
-  def sortStore(key: Key, destination: Key, by: OptArg[SortPattern[Key, HashKey]] = OptArg.Empty, limit: OptArg[SortLimit] = OptArg.Empty,
-    gets: Seq[SortPattern[Key, HashKey]] = Nil, sortOrder: OptArg[SortOrder] = OptArg.Empty, alpha: Boolean = false): Result[Long] =
+  def sortStore(key: Key, destination: Key, by: OptArg[SortPattern[Key, Field]] = OptArg.Empty, limit: OptArg[SortLimit] = OptArg.Empty,
+    gets: Seq[SortPattern[Key, Field]] = Nil, sortOrder: OptArg[SortOrder] = OptArg.Empty, alpha: Boolean = false): Result[Long] =
     execute(new SortStore(key, destination, by.toOpt, limit.toOpt, gets, sortOrder.toOpt, alpha))
 
   /** Executes [[http://redis.io/commands/touch TOUCH]] */
@@ -222,8 +222,8 @@ trait KeyedKeysApi extends ApiSubset {
   }
 
   private abstract class AbstractSort[T](decoder: ReplyDecoder[T])
-    (key: Key, by: Opt[SortPattern[Key, HashKey]], limit: Opt[SortLimit],
-      gets: Seq[SortPattern[Key, HashKey]], sortOrder: Opt[SortOrder], alpha: Boolean, destination: Opt[Key])
+    (key: Key, by: Opt[SortPattern[Key, Field]], limit: Opt[SortLimit],
+      gets: Seq[SortPattern[Key, Field]], sortOrder: Opt[SortOrder], alpha: Boolean, destination: Opt[Key])
     extends AbstractRedisCommand[T](decoder) with NodeCommand {
     val encoded = {
       val enc = encoder("SORT").key(key).optAdd("BY", by).optAdd("LIMIT", limit)
@@ -232,14 +232,14 @@ trait KeyedKeysApi extends ApiSubset {
     }
   }
 
-  private final class Sort(key: Key, by: Opt[SortPattern[Key, HashKey]], limit: Opt[SortLimit], sortOrder: Opt[SortOrder], alpha: Boolean)
+  private final class Sort(key: Key, by: Opt[SortPattern[Key, Field]], limit: Opt[SortLimit], sortOrder: Opt[SortOrder], alpha: Boolean)
     extends AbstractSort[Seq[Value]](multiBulkSeq[Value])(key, by, limit, Nil, sortOrder, alpha, Opt.Empty)
 
-  private final class SortGet(key: Key, gets: Seq[SortPattern[Key, HashKey]], by: Opt[SortPattern[Key, HashKey]], limit: Opt[SortLimit], sortOrder: Opt[SortOrder], alpha: Boolean)
+  private final class SortGet(key: Key, gets: Seq[SortPattern[Key, Field]], by: Opt[SortPattern[Key, Field]], limit: Opt[SortLimit], sortOrder: Opt[SortOrder], alpha: Boolean)
     extends AbstractSort[Seq[Seq[Opt[Value]]]](groupedMultiBulk(gets.size min 1, nullBulkOr[Value]))(
       key, by, limit, gets, sortOrder, alpha, Opt.Empty)
 
-  private final class SortStore(key: Key, destination: Key, by: Opt[SortPattern[Key, HashKey]], limit: Opt[SortLimit], gets: Seq[SortPattern[Key, HashKey]], sortOrder: Opt[SortOrder], alpha: Boolean)
+  private final class SortStore(key: Key, destination: Key, by: Opt[SortPattern[Key, Field]], limit: Opt[SortLimit], gets: Seq[SortPattern[Key, Field]], sortOrder: Opt[SortOrder], alpha: Boolean)
     extends AbstractSort[Long](integerLong)(key, by, limit, gets, sortOrder, alpha, Opt(destination))
 
   private final class Touch(keys: Iterable[Key]) extends RedisIntCommand with NodeCommand {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/keys.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/keys.scala
@@ -236,7 +236,7 @@ trait KeyedKeysApi extends ApiSubset {
     extends AbstractSort[Seq[Value]](multiBulkSeq[Value])(key, by, limit, Nil, sortOrder, alpha, Opt.Empty)
 
   private final class SortGet(key: Key, gets: Seq[SortPattern[Key, Field]], by: Opt[SortPattern[Key, Field]], limit: Opt[SortLimit], sortOrder: Opt[SortOrder], alpha: Boolean)
-    extends AbstractSort[Seq[Seq[Opt[Value]]]](groupedMultiBulk(gets.size min 1, nullBulkOr[Value]))(
+    extends AbstractSort[Seq[Seq[Opt[Value]]]](multiBulkGroupedSeq(gets.size min 1, nullBulkOr[Value]))(
       key, by, limit, gets, sortOrder, alpha, Opt.Empty)
 
   private final class SortStore(key: Key, destination: Key, by: Opt[SortPattern[Key, Field]], limit: Opt[SortLimit], gets: Seq[SortPattern[Key, Field]], sortOrder: Opt[SortOrder], alpha: Boolean)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
@@ -27,7 +27,7 @@ trait ListsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/lpush LPUSH]]
     * or [[http://redis.io/commands/llen LLEN]] when `values` is empty */
   def lpushOrLlen(key: Key, values: Iterable[Value]): Result[Long] =
-    if(values.nonEmpty) lpush(key, values) else llen(key)
+    if (values.nonEmpty) lpush(key, values) else llen(key)
   /** Executes [[http://redis.io/commands/lpushx LPUSHX]] */
   def lpushx(key: Key, value: Value, values: Value*): Result[Long] =
     execute(new Lpushx(key, value +:: values))
@@ -37,7 +37,7 @@ trait ListsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/lpush LPUSHX]]
     * or [[http://redis.io/commands/llen LLEN]] when `values` is empty */
   def lpushxOrLlen(key: Key, values: Iterable[Value]): Result[Long] =
-    if(values.nonEmpty) lpushx(key, values) else llen(key)
+    if (values.nonEmpty) lpushx(key, values) else llen(key)
   /** Executes [[http://redis.io/commands/lrange LRANGE]] */
   def lrange(key: Key, start: Long = 0, stop: Long = -1): Result[Seq[Value]] =
     execute(new Lrange(key, start, stop))
@@ -66,7 +66,7 @@ trait ListsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/lpush RPUSH]]
     * or [[http://redis.io/commands/llen LLEN]] when `values` is empty */
   def rpushOrLlen(key: Key, values: Iterable[Value]): Result[Long] =
-    if(values.nonEmpty) rpush(key, values) else llen(key)
+    if (values.nonEmpty) rpush(key, values) else llen(key)
   /** Executes [[http://redis.io/commands/rpushx RPUSHX]] */
   def rpushx(key: Key, value: Value, values: Value*): Result[Long] =
     execute(new Rpushx(key, value +:: values))
@@ -76,7 +76,7 @@ trait ListsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/lpush RPUSHX]]
     * or [[http://redis.io/commands/llen LLEN]] when `values` is empty */
   def rpushxOrLlen(key: Key, values: Iterable[Value]): Result[Long] =
-    if(values.nonEmpty) rpushx(key, values) else llen(key)
+    if (values.nonEmpty) rpushx(key, values) else llen(key)
 
   private final class Lindex(key: Key, index: Long) extends RedisOptDataCommand[Value] with NodeCommand {
     val encoded: Encoded = encoder("LINDEX").key(key).add(index).result
@@ -191,7 +191,11 @@ trait BlockingListsApi extends ApiSubset {
   }
 }
 
-class RemCount private(val raw: Long) extends AnyVal
+class RemCount private(val raw: Long) extends AnyVal {
+  def count: Long = math.abs(raw)
+  def fromHead: Boolean = raw > 0
+  def fromTail: Boolean = raw < 0
+}
 object RemCount {
   def apply(count: Long, fromHead: Boolean): RemCount = {
     require(count > 0, "Count must be positive")

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
@@ -79,61 +79,61 @@ trait ListsApi extends ApiSubset {
     if(values.nonEmpty) rpushx(key, values) else llen(key)
 
   private final class Lindex(key: Key, index: Long) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("LINDEX").key(key).add(index).result
+    val encoded: Encoded = encoder("LINDEX").key(key).add(index).result
   }
 
   private final class Linsert(key: Key, before: Boolean, pivot: Value, value: Value)
     extends RedisPositiveLongCommand with NodeCommand {
-    val encoded = encoder("LINSERT").key(key).add(if (before) "BEFORE" else "AFTER").data(pivot).data(value).result
+    val encoded: Encoded = encoder("LINSERT").key(key).add(if (before) "BEFORE" else "AFTER").data(pivot).data(value).result
   }
 
   private final class Llen(key: Key) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("LLEN").key(key).result
+    val encoded: Encoded = encoder("LLEN").key(key).result
   }
 
   private final class Lpop(key: Key) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("LPOP").key(key).result
+    val encoded: Encoded = encoder("LPOP").key(key).result
   }
 
   private final class Lpush(key: Key, values: Iterable[Value]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("LPUSH").key(key).datas(values).result
+    val encoded: Encoded = encoder("LPUSH").key(key).datas(values).result
   }
 
   private final class Lpushx(key: Key, values: Iterable[Value]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("LPUSHX").key(key).datas(values).result
+    val encoded: Encoded = encoder("LPUSHX").key(key).datas(values).result
   }
 
   private final class Lrange(key: Key, start: Long, stop: Long)
     extends RedisDataSeqCommand[Value] with NodeCommand {
-    val encoded = encoder("LRANGE").key(key).add(start).add(stop).result
+    val encoded: Encoded = encoder("LRANGE").key(key).add(start).add(stop).result
   }
 
   private final class Lrem(key: Key, count: RemCount, value: Value) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("LREM").key(key).add(count.raw).data(value).result
+    val encoded: Encoded = encoder("LREM").key(key).add(count.raw).data(value).result
   }
 
   private final class Lset(key: Key, index: Long, value: Value) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("LSET").key(key).add(index).data(value).result
+    val encoded: Encoded = encoder("LSET").key(key).add(index).data(value).result
   }
 
   private final class Ltrim(key: Key, start: Long, stop: Long) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("LTRIM").key(key).add(start).add(stop).result
+    val encoded: Encoded = encoder("LTRIM").key(key).add(start).add(stop).result
   }
 
   private final class Rpop(key: Key) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("RPOP").key(key).result
+    val encoded: Encoded = encoder("RPOP").key(key).result
   }
 
   private final class Rpoplpush(source: Key, destination: Key) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("RPOPLPUSH").key(source).key(destination).result
+    val encoded: Encoded = encoder("RPOPLPUSH").key(source).key(destination).result
   }
 
   private final class Rpush(key: Key, values: Iterable[Value]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("RPUSH").key(key).datas(values).result
+    val encoded: Encoded = encoder("RPUSH").key(key).datas(values).result
   }
 
   private final class Rpushx(key: Key, values: Iterable[Value]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("RPUSHX").key(key).datas(values).result
+    val encoded: Encoded = encoder("RPUSHX").key(key).datas(values).result
   }
 }
 
@@ -177,17 +177,17 @@ trait BlockingListsApi extends ApiSubset {
 
   private final class Blpop(keys: Iterable[Key], timeout: Int)
     extends AbstractRedisCommand[Opt[(Key, Value)]](nullMultiBulkOr(multiBulkPair(bulk[Key], bulk[Value]))) with ConnectionCommand {
-    val encoded = encoder("BLPOP").keys(keys).add(timeout).result
+    val encoded: Encoded = encoder("BLPOP").keys(keys).add(timeout).result
   }
 
   private final class Brpop(keys: Iterable[Key], timeout: Int)
     extends AbstractRedisCommand[Opt[(Key, Value)]](nullMultiBulkOr(multiBulkPair(bulk[Key], bulk[Value]))) with ConnectionCommand {
-    val encoded = encoder("BRPOP").keys(keys).add(timeout).result
+    val encoded: Encoded = encoder("BRPOP").keys(keys).add(timeout).result
   }
 
   private final class Brpoplpush(source: Key, destination: Key, timeout: Int)
     extends AbstractRedisCommand[Opt[Value]](nullMultiBulkOr(bulk[Value])) with ConnectionCommand {
-    val encoded = encoder("BRPOPLPUSH").key(source).key(destination).add(timeout).result
+    val encoded: Encoded = encoder("BRPOPLPUSH").key(source).key(destination).add(timeout).result
   }
 }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
@@ -4,7 +4,7 @@ package redis.commands
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait ListsApi extends ValueApiSubset {
+trait ListsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/lindex LINDEX]] */
   def lindex(key: Key, index: Long): Result[Opt[Value]] =
     execute(new Lindex(key, index))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/lists.scala
@@ -4,7 +4,7 @@ package redis.commands
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait ListsApi extends ApiSubset {
+trait ListsApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/lindex LINDEX]] */
   def lindex(key: Key, index: Long): Result[Opt[Value]] =
     execute(new Lindex(key, index))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/scripting.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/scripting.scala
@@ -28,12 +28,12 @@ trait KeyedScriptingApi extends ApiSubset {
 
   private final class Eval[T](script: RedisScript[T], keys: Seq[Key], args: Seq[Value])
     extends AbstractRedisCommand[T](script.decoder) with NodeCommand {
-    val encoded = encoder("EVAL").add(script.source).add(keys.size).keys(keys).datas(args).result
+    val encoded: Encoded = encoder("EVAL").add(script.source).add(keys.size).keys(keys).datas(args).result
   }
 
   private final class Evalsha[T](sha1: Sha1, decoder: PartialFunction[ValidRedisMsg, T], keys: Seq[Key], args: Seq[Value])
     extends AbstractRedisCommand[T](decoder) with NodeCommand {
-    val encoded = encoder("EVALSHA").add(sha1.raw).add(keys.size).keys(keys).datas(args).result
+    val encoded: Encoded = encoder("EVALSHA").add(sha1.raw).add(keys.size).keys(keys).datas(args).result
   }
 }
 
@@ -73,20 +73,20 @@ trait NodeScriptingApi extends KeyedScriptingApi {
 
   private final class ScriptExists(hashes: Iterable[Sha1])
     extends RedisSeqCommand[Boolean](integerBoolean) with NodeCommand {
-    val encoded = encoder("SCRIPT", "EXISTS").add(hashes).result
+    val encoded: Encoded = encoder("SCRIPT", "EXISTS").add(hashes).result
   }
 
   private object ScriptFlush extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("SCRIPT", "FLUSH").result
+    val encoded: Encoded = encoder("SCRIPT", "FLUSH").result
   }
 
   private object ScriptKill extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("SCRIPT", "KILL").result
+    val encoded: Encoded = encoder("SCRIPT", "KILL").result
   }
 
   private final class ScriptLoad(script: RedisScript[Any])
     extends AbstractRedisCommand[Sha1](bulkSha1) with NodeCommand {
-    val encoded = encoder("SCRIPT", "LOAD").add(script.source).result
+    val encoded: Encoded = encoder("SCRIPT", "LOAD").add(script.source).result
   }
 }
 
@@ -96,7 +96,7 @@ trait ConnectionScriptingApi extends NodeScriptingApi {
     execute(new ScriptDebug(mode))
 
   private final class ScriptDebug(mode: DebugMode) extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("SCRIPT", "DEBUG").add(mode).result
+    val encoded: Encoded = encoder("SCRIPT", "DEBUG").add(mode).result
   }
 }
 
@@ -108,12 +108,12 @@ trait RedisScript[+A] {
 object RedisScript {
   def apply[A](script: String)(replyDecoder: ReplyDecoder[A]): RedisScript[A] =
     new RedisScript[A] {
-      def source = script
-      def decoder = replyDecoder
+      def source: String = script
+      def decoder: ReplyDecoder[A] = replyDecoder
     }
 }
 case class Sha1(raw: String) extends AnyVal {
-  override def toString = raw
+  override def toString: String = raw
 }
 object Sha1 {
   @silent

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/scripting.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/scripting.scala
@@ -12,7 +12,7 @@ import com.avsystem.commons.redis.protocol.ValidRedisMsg
 import com.github.ghik.silencer.silent
 import com.google.common.hash.Hashing
 
-trait KeyedScriptingApi extends ValueApiSubset {
+trait KeyedScriptingApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/eval EVAL]] */
   def eval[T](script: RedisScript[T], keys: Seq[Key], args: Seq[Value]): Result[T] =
     execute(new Eval(script, keys, args))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/scripting.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/scripting.scala
@@ -12,7 +12,7 @@ import com.avsystem.commons.redis.protocol.ValidRedisMsg
 import com.github.ghik.silencer.silent
 import com.google.common.hash.Hashing
 
-trait KeyedScriptingApi extends ApiSubset {
+trait KeyedScriptingApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/eval EVAL]] */
   def eval[T](script: RedisScript[T], keys: Seq[Key], args: Seq[Value]): Result[T] =
     execute(new Eval(script, keys, args))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
@@ -8,7 +8,7 @@ import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.protocol.BulkStringMsg
 
-trait NodeServerApi extends ApiSubset {
+trait NodeServerApi extends KeyedApiSubset {
   /** Executes [[http://redis.io/commands/bgrewriteaof BGREWRITEAOF]] */
   def bgrewriteaof: Result[String] =
     execute(Bgrewriteaof)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
@@ -8,7 +8,7 @@ import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.protocol.BulkStringMsg
 
-trait NodeServerApi extends KeyedApiSubset {
+trait NodeServerApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/bgrewriteaof BGREWRITEAOF]] */
   def bgrewriteaof: Result[String] =
     execute(Bgrewriteaof)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
@@ -126,23 +126,23 @@ trait NodeServerApi extends ApiSubset {
     execute(Time)
 
   private object Bgrewriteaof extends RedisSimpleStringCommand with NodeCommand {
-    val encoded = encoder("BGREWRITEAOF").result
+    val encoded: Encoded = encoder("BGREWRITEAOF").result
   }
 
   private final class Bgsave(schedule: Boolean) extends RedisSimpleStringCommand with NodeCommand {
-    val encoded = encoder("BGSAVE").addFlag("SCHEDULE", schedule).result
+    val encoded: Encoded = encoder("BGSAVE").addFlag("SCHEDULE", schedule).result
   }
 
   private object ClientId extends AbstractRedisCommand[ClientId](integerClientId) with NodeCommand {
-    val encoded = encoder("CLIENT", "ID").result
+    val encoded: Encoded = encoder("CLIENT", "ID").result
   }
 
   private final class ClientKill(address: ClientAddress) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLIENT", "KILL").add(address.toString).result
+    val encoded: Encoded = encoder("CLIENT", "KILL").add(address.toString).result
   }
 
   private final class ClientKillFiltered(filters: Seq[ClientFilter]) extends RedisIntCommand with NodeCommand {
-    val encoded = {
+    val encoded: Encoded = {
       val enc = encoder("CLIENT", "KILL")
       if (filters.nonEmpty) {
         enc.add(filters)
@@ -155,93 +155,93 @@ trait NodeServerApi extends ApiSubset {
   }
 
   private object ClientList extends AbstractRedisCommand[Seq[ClientInfo]](bulkClientInfos) with NodeCommand {
-    val encoded = encoder("CLIENT", "LIST").result
+    val encoded: Encoded = encoder("CLIENT", "LIST").result
   }
 
   private final class ClientPause(timeout: Long) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CLIENT", "PAUSE").add(timeout).result
+    val encoded: Encoded = encoder("CLIENT", "PAUSE").add(timeout).result
   }
 
   private final class ClientUnblock(clientId: ClientId, modifier: Opt[UnblockModifier])
     extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("CLIENT", "UNBLOCK").add(clientId.raw).optAdd(modifier).result
+    val encoded: Encoded = encoder("CLIENT", "UNBLOCK").add(clientId.raw).optAdd(modifier).result
   }
 
   private abstract class AbstractCommandInfoCommand
     extends AbstractRedisCommand[Seq[CommandInfo]](multiBulkSeq(multiBulkCommandInfo)) with NodeCommand
 
   private object Command extends AbstractCommandInfoCommand {
-    val encoded = encoder("COMMAND").result
+    val encoded: Encoded = encoder("COMMAND").result
   }
 
   private object CommandCount extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("COMMAND", "COUNT").result
+    val encoded: Encoded = encoder("COMMAND", "COUNT").result
   }
 
   private final class CommandGetkeys(command: TraversableOnce[ByteString]) extends RedisDataSeqCommand[Key] with NodeCommand {
-    val encoded = encoder("COMMAND", "GETKEYS").add(command).result
+    val encoded: Encoded = encoder("COMMAND", "GETKEYS").add(command).result
   }
 
   private final class CommandInfoCommand(commandNames: Iterable[String]) extends AbstractCommandInfoCommand {
-    val encoded = encoder("COMMAND", "INFO").add(commandNames).result
+    val encoded: Encoded = encoder("COMMAND", "INFO").add(commandNames).result
   }
 
   private final class ConfigGet(parameter: String)
     extends AbstractRedisCommand[Seq[(String, String)]](pairedMultiBulk(bulkUTF8, bulkUTF8)) with NodeCommand {
-    val encoded = encoder("CONFIG", "GET").add(parameter).result
+    val encoded: Encoded = encoder("CONFIG", "GET").add(parameter).result
   }
 
   private object ConfigResetstat extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CONFIG", "RESETSTAT").result
+    val encoded: Encoded = encoder("CONFIG", "RESETSTAT").result
   }
 
   private object ConfigRewrite extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CONFIG", "REWRITE").result
+    val encoded: Encoded = encoder("CONFIG", "REWRITE").result
   }
 
   private final class ConfigSet(parameter: String, value: String) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("CONFIG", "SET").add(parameter).add(value).result
+    val encoded: Encoded = encoder("CONFIG", "SET").add(parameter).add(value).result
   }
 
   private object Dbsize extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("DBSIZE").result
+    val encoded: Encoded = encoder("DBSIZE").result
   }
 
   private object DebugSegfault extends RedisNothingCommand with NodeCommand {
-    val encoded = encoder("DEBUG", "SEGFAULT").result
+    val encoded: Encoded = encoder("DEBUG", "SEGFAULT").result
   }
 
   private final class Flushall(async: Boolean) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("FLUSHALL").addFlag("ASYNC", async).result
+    val encoded: Encoded = encoder("FLUSHALL").addFlag("ASYNC", async).result
   }
 
   private final class Flushdb(async: Boolean) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("FLUSHDB").addFlag("ASYNC", async).result
+    val encoded: Encoded = encoder("FLUSHDB").addFlag("ASYNC", async).result
   }
 
   private final class Info[T >: FullRedisInfo <: RedisInfo](section: RedisInfoSection[T], implicitDefault: Boolean)
     extends AbstractRedisCommand[T](bulk(bs => new FullRedisInfo(bs.utf8String))) with NodeCommand {
-    val encoded = encoder("INFO").setup(e => if (!implicitDefault || section != DefaultRedisInfo) e.add(section.name)).result
+    val encoded: Encoded = encoder("INFO").setup(e => if (!implicitDefault || section != DefaultRedisInfo) e.add(section.name)).result
   }
 
   private object Lastsave extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("LASTSAVE").result
+    val encoded: Encoded = encoder("LASTSAVE").result
   }
 
   private object Role extends AbstractRedisCommand[RedisRole](multiBulkRedisRole) with NodeCommand {
-    val encoded = encoder("ROLE").result
+    val encoded: Encoded = encoder("ROLE").result
   }
 
   private object Save extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("SAVE").result
+    val encoded: Encoded = encoder("SAVE").result
   }
 
   private final class Shutdown(modifier: Opt[ShutdownModifier]) extends RedisNothingCommand with NodeCommand {
-    val encoded = encoder("SHUTDOWN").optAdd(modifier).result
+    val encoded: Encoded = encoder("SHUTDOWN").optAdd(modifier).result
   }
 
   private final class Slaveof(newMaster: Opt[NodeAddress]) extends RedisUnitCommand with NodeCommand {
-    val encoded = {
+    val encoded: Encoded = {
       val enc = encoder("SLAVEOF")
       newMaster match {
         case Opt.Empty => enc.add("NO").add("ONE")
@@ -253,19 +253,19 @@ trait NodeServerApi extends ApiSubset {
 
   private final class SlowlogGet(count: Opt[Int])
     extends RedisSeqCommand[SlowlogEntry](multiBulkSlowlogEntry) with NodeCommand {
-    val encoded = encoder("SLOWLOG", "GET").optAdd(count).result
+    val encoded: Encoded = encoder("SLOWLOG", "GET").optAdd(count).result
   }
 
   private object SlowlogLen extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("SLOWLOG", "LEN").result
+    val encoded: Encoded = encoder("SLOWLOG", "LEN").result
   }
 
   private object SlowlogReset extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("SLOWLOG", "RESET").result
+    val encoded: Encoded = encoder("SLOWLOG", "RESET").result
   }
 
   private object Time extends AbstractRedisCommand[RedisTimestamp](multiBulkRedisTimestamp) with NodeCommand {
-    val encoded = encoder("TIME").result
+    val encoded: Encoded = encoder("TIME").result
   }
 }
 
@@ -278,11 +278,11 @@ trait ConnectionServerApi extends NodeServerApi {
     execute(new ClientSetname(connectionName))
 
   private object ClientGetname extends RedisOptStringCommand with ConnectionCommand {
-    val encoded = encoder("CLIENT", "GETNAME").result
+    val encoded: Encoded = encoder("CLIENT", "GETNAME").result
   }
 
   private final class ClientSetname(connectionName: String) extends RedisUnitCommand with ConnectionCommand {
-    val encoded = encoder("CLIENT", "SETNAME").add(connectionName).result
+    val encoded: Encoded = encoder("CLIENT", "SETNAME").add(connectionName).result
   }
 }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/server.scala
@@ -187,7 +187,7 @@ trait NodeServerApi extends ApiSubset {
   }
 
   private final class ConfigGet(parameter: String)
-    extends AbstractRedisCommand[Seq[(String, String)]](pairedMultiBulk(bulkUTF8, bulkUTF8)) with NodeCommand {
+    extends AbstractRedisCommand[Seq[(String, String)]](flatMultiBulkSeq(bulkUTF8, bulkUTF8)) with NodeCommand {
     val encoded: Encoded = encoder("CONFIG", "GET").add(parameter).result
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sets.scala
@@ -4,7 +4,7 @@ package redis.commands
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait SetsApi extends ValueApiSubset {
+trait SetsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/sadd SADD]] */
   def sadd(key: Key, member: Value): Result[Boolean] =
     execute(new Sadd(key, member.single).map(_ > 0))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sets.scala
@@ -4,7 +4,7 @@ package redis.commands
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait SetsApi extends ApiSubset {
+trait SetsApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/sadd SADD]] */
   def sadd(key: Key, member: Value): Result[Boolean] =
     execute(new Sadd(key, member.single).map(_ > 0))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sets.scala
@@ -98,80 +98,80 @@ trait SetsApi extends ApiSubset {
     execute(new Sunionstore(destination, keys))
 
   private final class Sadd(key: Key, members: Iterable[Value]) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("SADD").key(key).datas(members).result
-    override def immediateResult = whenEmpty(members, 0)
+    val encoded: Encoded = encoder("SADD").key(key).datas(members).result
+    override def immediateResult: Opt[Int] = whenEmpty(members, 0)
   }
 
   private final class Scard(key: Key) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("SCARD").key(key).result
+    val encoded: Encoded = encoder("SCARD").key(key).result
   }
 
   private final class Sdiff(source: Key, keys: Iterable[Key]) extends RedisDataSetCommand[Value] with NodeCommand {
-    val encoded = encoder("SDIFF").key(source).keys(keys).result
+    val encoded: Encoded = encoder("SDIFF").key(source).keys(keys).result
   }
 
   private final class Sdiffstore(destination: Key, source: Key, keys: Iterable[Key]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("SDIFFSTORE").key(destination).key(source).keys(keys).result
+    val encoded: Encoded = encoder("SDIFFSTORE").key(destination).key(source).keys(keys).result
   }
 
   private final class Sinter(keys: Iterable[Key]) extends RedisDataSetCommand[Value] with NodeCommand {
-    val encoded = encoder("SINTER").keys(keys).result
+    val encoded: Encoded = encoder("SINTER").keys(keys).result
   }
 
   private final class Sinterstore(destination: Key, keys: Iterable[Key]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("SINTERSTORE").key(destination).keys(keys).result
+    val encoded: Encoded = encoder("SINTERSTORE").key(destination).keys(keys).result
   }
 
   private final class Sismember(key: Key, member: Value) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("SISMEMBER").key(key).data(member).result
+    val encoded: Encoded = encoder("SISMEMBER").key(key).data(member).result
   }
 
   private final class Smembers(key: Key) extends RedisDataSetCommand[Value] with NodeCommand {
-    val encoded = encoder("SMEMBERS").key(key).result
+    val encoded: Encoded = encoder("SMEMBERS").key(key).result
   }
 
   private final class Smove(source: Key, destination: Key, member: Value) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("SMOVE").key(source).key(destination).data(member).result
+    val encoded: Encoded = encoder("SMOVE").key(source).key(destination).data(member).result
   }
 
   private final class Spop(key: Key) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("SPOP").key(key).result
+    val encoded: Encoded = encoder("SPOP").key(key).result
   }
 
   private final class SpopCount(key: Key, count: Int) extends RedisDataSetCommand[Value] with NodeCommand {
-    val encoded = encoder("SPOP").key(key).add(count).result
+    val encoded: Encoded = encoder("SPOP").key(key).add(count).result
   }
 
   private final class Srandmember(key: Key) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("SRANDMEMBER").key(key).result
+    val encoded: Encoded = encoder("SRANDMEMBER").key(key).result
   }
 
   private final class SrandmemberCount(key: Key, count: Int) extends RedisDataSeqCommand[Value] with NodeCommand {
     require(count >= 0, "count cannot be negative")
-    val encoded = encoder("SRANDMEMBER").key(key).add(-count).result
+    val encoded: Encoded = encoder("SRANDMEMBER").key(key).add(-count).result
   }
 
   private final class SrandmemberCountDistinct(key: Key, count: Int) extends RedisDataSetCommand[Value] with NodeCommand {
     require(count >= 0, "count cannot be negative")
-    val encoded = encoder("SRANDMEMBER").key(key).add(count).result
+    val encoded: Encoded = encoder("SRANDMEMBER").key(key).add(count).result
   }
 
   private final class Srem(key: Key, members: Iterable[Value]) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("SREM").key(key).datas(members).result
-    override def immediateResult = whenEmpty(members, 0)
+    val encoded: Encoded = encoder("SREM").key(key).datas(members).result
+    override def immediateResult: Opt[Int] = whenEmpty(members, 0)
   }
 
   private final class Sscan(key: Key, cursor: Cursor, matchPattern: Opt[Value], count: Opt[Int])
     extends RedisScanCommand[Value](multiBulkSeq[Value]) with NodeCommand {
-    val encoded = encoder("SSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
+    val encoded: Encoded = encoder("SSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
   }
 
   private final class Sunion(keys: Iterable[Key]) extends RedisDataSetCommand[Value] with NodeCommand {
-    val encoded = encoder("SUNION").keys(keys).result
-    override def immediateResult = whenEmpty(keys, Set.empty)
+    val encoded: Encoded = encoder("SUNION").keys(keys).result
+    override def immediateResult: Opt[BSet[Value]] = whenEmpty(keys, Set.empty)
   }
 
   private final class Sunionstore(destination: Key, keys: Iterable[Key]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("SUNIONSTORE").key(destination).keys(keys).result
+    val encoded: Encoded = encoder("SUNIONSTORE").key(destination).keys(keys).result
   }
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
@@ -285,6 +285,37 @@ trait SortedSetsApi extends ApiSubset {
   }
 }
 
+trait BlockingSortedSetsApi extends ApiSubset {
+  /** Executes [[http://redis.io/commands/bzpopmax BZPOPMAX]] */
+  def bzpopmax(timeout: Int, key: Key, keys: Key*): Result[Opt[(Key, Value, Double)]] =
+    execute(new Bzpopmax(key +:: keys, timeout))
+  /** Executes [[http://redis.io/commands/bzpopmax BZPOPMAX]] */
+  def bzpopmax(keys: Iterable[Key], timeout: Int): Result[Opt[(Key, Value, Double)]] =
+    execute(new Bzpopmax(keys, timeout))
+  /** Executes [[http://redis.io/commands/bzpopmin BZPOPMIN]] */
+  def bzpopmin(timeout: Int, key: Key, keys: Key*): Result[Opt[(Key, Value, Double)]] =
+    execute(new Bzpopmin(key +:: keys, timeout))
+  /** Executes [[http://redis.io/commands/bzpopmin BZPOPMIN]] */
+  def bzpopmin(keys: Iterable[Key], timeout: Int): Result[Opt[(Key, Value, Double)]] =
+    execute(new Bzpopmin(keys, timeout))
+
+  private final class Bzpopmax(keys: Iterable[Key], timeout: Int)
+    extends AbstractRedisCommand[Opt[(Key, Value, Double)]](multiBulkZTriple[Key, Value]) with NodeCommand {
+    val encoded: Encoded = encoder("BZPOPMAX").keys(keys).add(timeout).result
+
+    override def immediateResult: Opt[Opt[(Key, Value, Double)]] =
+      if (keys.isEmpty) Opt(Opt.Empty) else Opt.Empty
+  }
+
+  private final class Bzpopmin(keys: Iterable[Key], timeout: Int)
+    extends AbstractRedisCommand[Opt[(Key, Value, Double)]](multiBulkZTriple[Key, Value]) with NodeCommand {
+    val encoded: Encoded = encoder("BZPOPMIN").keys(keys).add(timeout).result
+
+    override def immediateResult: Opt[Opt[(Key, Value, Double)]] =
+      if (keys.isEmpty) Opt(Opt.Empty) else Opt.Empty
+  }
+}
+
 case class ScoreLimit(value: Double, inclusive: Boolean) {
   def repr: String = (if (!inclusive) "(" else "") + (value match {
     case Double.NegativeInfinity => "-inf"

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
@@ -8,7 +8,7 @@ import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.util.SingletonSeq
 
-trait SortedSetsApi extends ValueApiSubset {
+trait SortedSetsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/zadd ZADD]] */
   def zadd(key: Key, memberScore: (Value, Double), memberScores: (Value, Double)*): Result[Int] =
     zadd(key, memberScore +:: memberScores)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
@@ -8,7 +8,7 @@ import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.util.SingletonSeq
 
-trait SortedSetsApi extends ApiSubset {
+trait SortedSetsApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/zadd ZADD]] */
   def zadd(key: Key, memberScore: (Value, Double), memberScores: (Value, Double)*): Result[Int] =
     zadd(key, memberScore +:: memberScores)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/sortedSets.scala
@@ -200,12 +200,12 @@ trait SortedSetsApi extends ApiSubset {
   }
 
   private final class Zpopmin(key: Key, count: Opt[Long])
-    extends AbstractRedisCommand[Seq[(Value, Double)]](pairedMultiBulk(bulk[Value], bulkDouble)) with NodeCommand {
+    extends AbstractRedisCommand[Seq[(Value, Double)]](flatMultiBulkSeq(bulk[Value], bulkDouble)) with NodeCommand {
     val encoded: Encoded = encoder("ZPOPMIN").key(key).optAdd(count).result
   }
 
   private final class Zpopmax(key: Key, count: Opt[Long])
-    extends AbstractRedisCommand[Seq[(Value, Double)]](pairedMultiBulk(bulk[Value], bulkDouble)) with NodeCommand {
+    extends AbstractRedisCommand[Seq[(Value, Double)]](flatMultiBulkSeq(bulk[Value], bulkDouble)) with NodeCommand {
     val encoded: Encoded = encoder("ZPOPMAX").key(key).optAdd(count).result
   }
 
@@ -213,7 +213,7 @@ trait SortedSetsApi extends ApiSubset {
     extends AbstractZrange[Value]("ZRANGE", multiBulkSeq[Value])(key, start, stop, withscores = false)
 
   private final class ZrangeWithscores(key: Key, start: Long, stop: Long)
-    extends AbstractZrange[(Value, Double)]("ZRANGE", pairedMultiBulk(bulk[Value], bulkDouble))(
+    extends AbstractZrange[(Value, Double)]("ZRANGE", flatMultiBulkSeq(bulk[Value], bulkDouble))(
       key, start, stop, withscores = true)
 
   private final class Zrangebylex(key: Key, min: LexLimit[Value], max: LexLimit[Value], limit: Opt[Limit])
@@ -234,7 +234,7 @@ trait SortedSetsApi extends ApiSubset {
     extends AbstractZrangebyscore[Value]("ZRANGEBYSCORE", multiBulkSeq[Value])(key, min, max, withscores = false, limit)
 
   private final class ZrangebyscoreWithscores(key: Key, min: ScoreLimit, max: ScoreLimit, limit: Opt[Limit])
-    extends AbstractZrangebyscore[(Value, Double)]("ZRANGEBYSCORE", pairedMultiBulk(bulk[Value], bulkDouble))(
+    extends AbstractZrangebyscore[(Value, Double)]("ZRANGEBYSCORE", flatMultiBulkSeq(bulk[Value], bulkDouble))(
       key, min, max, withscores = true, limit)
 
   private final class Zrank(key: Key, member: Value) extends RedisOptLongCommand with NodeCommand {
@@ -265,7 +265,7 @@ trait SortedSetsApi extends ApiSubset {
     extends AbstractZrange[Value]("ZREVRANGE", multiBulkSeq[Value])(key, start, stop, withscores = false)
 
   private final class ZrevrangeWithscores(key: Key, start: Long, stop: Long)
-    extends AbstractZrange[(Value, Double)]("ZREVRANGE", pairedMultiBulk(bulk[Value], bulkDouble))(key, start, stop, withscores = true)
+    extends AbstractZrange[(Value, Double)]("ZREVRANGE", flatMultiBulkSeq(bulk[Value], bulkDouble))(key, start, stop, withscores = true)
 
   private final class Zrevrangebylex(key: Key, max: LexLimit[Value], min: LexLimit[Value], limit: Opt[Limit])
     extends RedisDataSeqCommand[Value] with NodeCommand {
@@ -276,7 +276,7 @@ trait SortedSetsApi extends ApiSubset {
     extends AbstractZrangebyscore[Value]("ZREVRANGEBYSCORE", multiBulkSeq[Value])(key, max, min, withscores = false, limit)
 
   private final class ZrevrangebyscoreWithscores(key: Key, max: ScoreLimit, min: ScoreLimit, limit: Opt[Limit])
-    extends AbstractZrangebyscore[(Value, Double)]("ZREVRANGEBYSCORE", pairedMultiBulk(bulk[Value], bulkDouble))(
+    extends AbstractZrangebyscore[(Value, Double)]("ZREVRANGEBYSCORE", flatMultiBulkSeq(bulk[Value], bulkDouble))(
       key, max, min, withscores = true, limit)
 
   private final class Zrevrank(key: Key, member: Value) extends RedisOptLongCommand with NodeCommand {
@@ -284,7 +284,7 @@ trait SortedSetsApi extends ApiSubset {
   }
 
   private final class Zscan(key: Key, cursor: Cursor, matchPattern: Opt[Value], count: Opt[Int])
-    extends RedisScanCommand[(Value, Double)](pairedMultiBulk(bulk[Value], bulkDouble)) with NodeCommand {
+    extends RedisScanCommand[(Value, Double)](flatMultiBulkSeq(bulk[Value], bulkDouble)) with NodeCommand {
     val encoded: Encoded = encoder("ZSCAN").key(key).add(cursor.raw).optData("MATCH", matchPattern).optAdd("COUNT", count).result
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -4,9 +4,204 @@ package redis.commands
 import com.avsystem.commons.redis.CommandEncoder.CommandArg
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.protocol.ValidRedisMsg
+import com.avsystem.commons.redis.util.SingletonSeq
 import com.avsystem.commons.redis.{AbstractRedisCommand, ApiSubset, NodeCommand, RedisBooleanCommand, RedisDataCodec, RedisIntCommand, RedisLongCommand, RedisSeqCommand, RedisUnitCommand}
 
 trait StreamsApi extends ApiSubset {
+  /** Executes [[http://redis.io/commands/xack XACK]] */
+  def xack(key: Key, group: XGroup, id: XEntryId): Result[Boolean] =
+    execute(new Xack(key, group, new SingletonSeq(id)).map(_ > 0))
+  /** Executes [[http://redis.io/commands/xack XACK]] */
+  def xack(key: Key, group: XGroup, id: XEntryId, ids: XEntryId*): Result[Int] =
+    execute(new Xack(key, group, id +:: ids))
+  /** Executes [[http://redis.io/commands/xack XACK]] */
+  def xack(key: Key, group: XGroup, ids: Iterable[XEntryId]): Result[Int] =
+    execute(new Xack(key, group, ids))
+
+  /** Executes [[http://redis.io/commands/xadd XADD]] */
+  def xadd(key: Key, fieldValue: (Field, Value), fieldValues: (Field, Value)*): Result[XEntryId] =
+    execute(new Xadd(key, Opt.Empty, Opt.Empty, fieldValue +:: fieldValues))
+
+  /** Executes [[http://redis.io/commands/xadd XADD]] */
+  def xadd(
+    key: Key,
+    fieldValues: Iterable[(Field, Value)],
+    id: OptArg[XEntryId] = OptArg.Empty,
+    maxlen: OptArg[XMaxlen] = OptArg.Empty
+  ): Result[XEntryId] =
+    execute(new Xadd(key, maxlen.toOpt, id.toOpt, fieldValues))
+
+  /** Executes [[http://redis.io/commands/xadd XADD]] */
+  def xaddEntry(key: Key, entry: XEntry[Field, Value], maxlen: OptArg[XMaxlen] = OptArg.Empty): Result[XEntryId] =
+    execute(new Xadd(key, maxlen.toOpt, entry.id.opt, entry.data))
+
+  /** Executes [[http://redis.io/commands/xclaim XCLAIM]] */
+  def xclaimSingle(
+    key: Key,
+    group: XGroup,
+    consumer: XConsumer,
+    minIdleTime: Long,
+    id: XEntryId,
+    idle: OptArg[Long] = OptArg.Empty,
+    msUnixTime: OptArg[Long] = OptArg.Empty,
+    retrycount: OptArg[Int] = OptArg.Empty,
+    force: Boolean = false
+  ): Result[Opt[XEntry[Field, Value]]] =
+    execute(new Xclaim(
+      key, group, consumer, minIdleTime, new SingletonSeq(id),
+      idle.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
+    ).map(_.headOpt))
+
+  /** Executes [[http://redis.io/commands/xclaim XCLAIM]] */
+  def xclaim(
+    key: Key,
+    group: XGroup,
+    consumer: XConsumer,
+    minIdleTime: Long,
+    ids: Iterable[XEntryId],
+    idle: OptArg[Long] = OptArg.Empty,
+    msUnixTime: OptArg[Long] = OptArg.Empty,
+    retrycount: OptArg[Int] = OptArg.Empty,
+    force: Boolean = false
+  ): Result[Seq[XEntry[Field, Value]]] =
+    execute(new Xclaim(
+      key, group, consumer, minIdleTime, ids,
+      idle.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
+    ))
+
+  /** Executes [[http://redis.io/commands/xclaim XCLAIM]] */
+  def xclaimJustid(
+    key: Key,
+    group: XGroup,
+    consumer: XConsumer,
+    minIdleTime: Long,
+    ids: Iterable[XEntryId],
+    idle: OptArg[Long] = OptArg.Empty,
+    msUnixTime: OptArg[Long] = OptArg.Empty,
+    retrycount: OptArg[Int] = OptArg.Empty,
+    force: Boolean = false
+  ): Result[Seq[XEntryId]] =
+    execute(new XclaimJustid(
+      key, group, consumer, minIdleTime, ids,
+      idle.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
+    ))
+
+  /** Executes [[http://redis.io/commands/xdel XDEL]] */
+  def xdel(key: Key, id: XEntryId): Result[Boolean] =
+    execute(new Xdel(key, new SingletonSeq(id)).map(_ > 0))
+  /** Executes [[http://redis.io/commands/xdel XDEL]] */
+  def xdel(key: Key, id: XEntryId, ids: XEntryId*): Result[Long] =
+    execute(new Xdel(key, id +:: ids))
+  /** Executes [[http://redis.io/commands/xdel XDEL]] */
+  def xdel(key: Key, ids: Iterable[XEntryId]): Result[Long] =
+    execute(new Xdel(key, ids))
+
+  /** Executes [[http://redis.io/commands/xgroup XGROUP CREATE]] */
+  def xgroupCreate(key: Key, group: XGroup, id: OptArg[XEntryId] = OptArg.Empty, mkstream: Boolean = false): Result[Unit] =
+    execute(new XgroupCreate(key, group, id.toOpt, mkstream))
+  /** Executes [[http://redis.io/commands/xgroup XGROUP DELCONSUMER]] */
+  def xgroupDelconsumer(key: Key, group: XGroup, consumer: XConsumer): Result[Boolean] =
+    execute(new XgroupDelconsumer(key, group, consumer))
+  /** Executes [[http://redis.io/commands/xgroup XGROUP DESTROY]] */
+  def xgroupDestroy(key: Key, group: XGroup): Result[Boolean] =
+    execute(new XgroupDestroy(key, group))
+  /** Executes [[http://redis.io/commands/xgroup XGROUP SETID]] */
+  def xgroupSetid(key: Key, group: XGroup, id: OptArg[XEntryId] = OptArg.Empty): Result[Unit] =
+    execute(new XgroupSetid(key, group, id.toOpt))
+
+  /** Executes [[http://redis.io/commands/xinfo XINFO CONSUMERS]] */
+  def xinfoConsumers(key: Key, group: XGroup): Result[Seq[XConsumerInfo]] =
+    execute(new XinfoConsumers(key, group))
+  /** Executes [[http://redis.io/commands/xinfo XINFO GROUPS]] */
+  def xinfoGroups(key: Key): Result[Seq[XGroupInfo]] =
+    execute(new XinfoGroups(key))
+  /** Executes [[http://redis.io/commands/xinfo XINFO STREAM]] */
+  def xinfoStream(key: Key): Result[XStreamInfo[Field, Value]] =
+    execute(new XinfoStream(key))
+
+  /** Executes [[http://redis.io/commands/xlen XLEN]] */
+  def xlen(key: Key): Result[Long] =
+    execute(new Xlen(key))
+
+  /** Executes [[http://redis.io/commands/xpending XPENDING]] */
+  def xpending(key: Key, group: XGroup): Result[XPendingOverview] =
+    execute(new Xpending(key, group))
+  /** Executes [[http://redis.io/commands/xpending XPENDING]] */
+  def xpendingEntries(
+    key: Key,
+    group: XGroup,
+    count: Int,
+    start: OptArg[XEntryId] = OptArg.Empty,
+    end: OptArg[XEntryId] = OptArg.Empty,
+    consumer: OptArg[XConsumer] = OptArg.Empty
+  ): Result[Seq[XPendingEntry]] =
+    execute(new XpendingEntries(key, group, start.toOpt, end.toOpt, count, consumer.toOpt))
+
+  /** Executes [[http://redis.io/commands/xrange XRANGE]] */
+  def xrange(
+    key: Key,
+    start: OptArg[XEntryId] = OptArg.Empty,
+    end: OptArg[XEntryId] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty
+  ): Result[Seq[XEntry[Field, Value]]] =
+    execute(new Xrange(key, start.toOpt, end.toOpt, count.toOpt))
+
+  /** Executes [[http://redis.io/commands/xread XREAD]] */
+  def xreadSingle(
+    key: Key,
+    id: Opt[XEntryId],
+    blockMillis: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty,
+  ): Result[Seq[XEntry[Field, Value]]] =
+    execute(new Xread(count.toOpt, blockMillis.toOpt, Iterator(key), Iterator(id)).map(_.apply(key)))
+
+  /** Executes [[http://redis.io/commands/xread XREAD]] */
+  def xread(
+    streams: Iterable[(Key, Opt[XEntryId])],
+    blockMillis: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty,
+  ): Result[BMap[Key, Seq[XEntry[Field, Value]]]] =
+    execute(new Xread(count.toOpt, blockMillis.toOpt, streams.iterator.map(_._1), streams.iterator.map(_._2)))
+
+  /** Executes [[http://redis.io/commands/xreadgroup XREADGROUP]] */
+  def xreadgroupSingle(
+    group: XGroup,
+    consumer: XConsumer,
+    key: Key,
+    id: Opt[XEntryId],
+    blockMillis: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty,
+  ): Result[Seq[XEntry[Field, Value]]] =
+    execute(new Xreadgroup(group, consumer, count.toOpt, blockMillis.toOpt,
+      Iterator(key), Iterator(id)).map(_.apply(key)))
+
+  /** Executes [[http://redis.io/commands/xreadgroup XREADGROUP]] */
+  def xreadgroup(
+    group: XGroup,
+    consumer: XConsumer,
+    streams: Iterable[(Key, Opt[XEntryId])],
+    blockMillis: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty,
+  ): Result[BMap[Key, Seq[XEntry[Field, Value]]]] =
+    execute(new Xreadgroup(group, consumer, count.toOpt, blockMillis.toOpt,
+      streams.iterator.map(_._1), streams.iterator.map(_._2)))
+
+  /** Executes [[http://redis.io/commands/xrevrange XREVRANGE]] */
+  def xrevrange(
+    key: Key,
+    end: OptArg[XEntryId] = OptArg.Empty,
+    start: OptArg[XEntryId] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty
+  ): Result[Seq[XEntry[Field, Value]]] =
+    execute(new Xrevrange(key, end.toOpt, start.toOpt, count.toOpt))
+
+  /** Executes [[http://redis.io/commands/xtrim XTRIM]] */
+  def xtrim(key: Key, maxlen: Long, approx: Boolean = true): Result[Long] =
+    execute(new Xtrim(key, XMaxlen(maxlen, approx)))
+  /** Executes [[http://redis.io/commands/xtrim XTRIM]] */
+  def xtrim(key: Key, maxlen: XMaxlen): Result[Long] =
+    execute(new Xtrim(key, maxlen))
+
   private final class Xack(key: Key, group: XGroup, ids: Iterable[XEntryId])
     extends RedisIntCommand with NodeCommand {
     val encoded: Encoded = encoder("XACK").key(key).add(group).add(ids).result
@@ -55,9 +250,9 @@ trait StreamsApi extends ApiSubset {
       .optAdd(id, "$").addFlag("MKSTREAM", mkstream).result
   }
 
-  private final class XgroupSetid(key: Key, group: XGroup, id: Opt[XEntryId])
-    extends RedisUnitCommand with NodeCommand {
-    val encoded: Encoded = encoder("XGROUP", "SETID").key(key).add(group).optAdd(id, "$").result
+  private final class XgroupDelconsumer(key: Key, group: XGroup, consumer: XConsumer)
+    extends RedisBooleanCommand with NodeCommand {
+    val encoded: Encoded = encoder("XGROUP", "DELCONSUMER").key(key).add(group).add(consumer).result
   }
 
   private final class XgroupDestroy(key: Key, group: XGroup)
@@ -65,9 +260,9 @@ trait StreamsApi extends ApiSubset {
     val encoded: Encoded = encoder("XGROUP", "DESTROY").key(key).add(group).result
   }
 
-  private final class XgroupDelconsumer(key: Key, group: XGroup, consumer: XConsumer)
-    extends RedisBooleanCommand with NodeCommand {
-    val encoded: Encoded = encoder("XGROUP", "DELCONSUMER").key(key).add(group).add(consumer).result
+  private final class XgroupSetid(key: Key, group: XGroup, id: Opt[XEntryId])
+    extends RedisUnitCommand with NodeCommand {
+    val encoded: Encoded = encoder("XGROUP", "SETID").key(key).add(group).optAdd(id, "$").result
   }
 
   private final class XinfoConsumers(key: Key, group: XGroup)
@@ -111,33 +306,34 @@ trait StreamsApi extends ApiSubset {
     extends AbstractRedisCommand[BMap[Key, Seq[XEntry[Field, Value]]]](
       multiBulkXEntriesByKey[Key, Field, Value]) with NodeCommand {
 
-    def streams: Iterable[(Key, _)]
+    def streamKeys: Iterator[Key]
+    def streamIds: Iterator[Opt[XEntryId]]
     def blockMillis: Opt[Int]
 
     override def immediateResult: Opt[BMap[Key, Seq[XEntry[Field, Value]]]] =
-      whenEmpty(streams, Map.empty)
+      whenEmpty(streamKeys, Map.empty)
     override def maxBlockingMillis: Int =
       blockMillis.map(m => if (m <= 0) Int.MaxValue else m).getOrElse(0)
   }
 
   private final class Xread(
-    count: Opt[Int], val blockMillis: Opt[Int], val streams: Iterable[(Key, XEntryId)]
+    count: Opt[Int], val blockMillis: Opt[Int],
+    val streamKeys: Iterator[Key], val streamIds: Iterator[Opt[XEntryId]]
   ) extends AbstractXread {
-
     val encoded: Encoded = encoder("XREAD")
       .optAdd("COUNT", count).optAdd("BLOCK", blockMillis)
-      .add("STREAMS").keys(streams.iterator.map(_._1)).add(streams.iterator.map(_._2))
+      .add("STREAMS").keys(streamKeys).add(streamIds.map(_.fold("$")(_.toString)))
       .result
   }
 
   private final class Xreadgroup(
     group: XGroup, consumer: XConsumer,
-    count: Opt[Int], val blockMillis: Opt[Int], val streams: Iterable[(Key, Opt[XEntryId])]
+    count: Opt[Int], val blockMillis: Opt[Int],
+    val streamKeys: Iterator[Key], val streamIds: Iterator[Opt[XEntryId]]
   ) extends AbstractXread {
-
     val encoded: Encoded = encoder("XREADGROUP").add("GROUP").add(group).add(consumer)
       .optAdd("COUNT", count).optAdd("BLOCK", blockMillis)
-      .add("STREAMS").keys(streams.iterator.map(_._1)).add(streams.iterator.map(_._2.fold(">")(_.toString)))
+      .add("STREAMS").keys(streamKeys).add(streamIds.map(_.fold(">")(_.toString)))
       .result
   }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -172,14 +172,14 @@ trait StreamsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/xreadgroup XREADGROUP]] */
   def xreadgroupSingle(
     key: Key,
-    id: Opt[XEntryId],
     group: XGroup,
     consumer: XConsumer,
+    id: OptArg[XEntryId] = OptArg.Empty,
     blockMillis: OptArg[Int] = OptArg.Empty,
     count: OptArg[Int] = OptArg.Empty,
   ): Result[Seq[XEntry]] =
     execute(new Xreadgroup(group, consumer, count.toOpt, blockMillis.toOpt,
-      Iterator(key), Iterator(id)).map(_.getOrElse(key, Nil)))
+      Iterator(key), Iterator(id.toOpt)).map(_.getOrElse(key, Nil)))
 
   /** Executes [[http://redis.io/commands/xreadgroup XREADGROUP]] */
   def xreadgroup(
@@ -431,6 +431,7 @@ case class XGroupInfo(raw: BMap[String, ValidRedisMsg]) {
   def name: XGroup = bulkXGroup(raw("name"))
   def consumers: Int = integerInt(raw("consumers"))
   def pending: Int = integerInt(raw("pending"))
+  def lastDeliveredId: XEntryId = bulkXEntryId(raw("last-delivered-id"))
 }
 
 case class XConsumerInfo(raw: BMap[String, ValidRedisMsg]) {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -1,0 +1,108 @@
+package com.avsystem.commons
+package redis.commands
+
+import com.avsystem.commons.redis.CommandEncoder.CommandArg
+import com.avsystem.commons.redis.commands.ReplyDecoders._
+import com.avsystem.commons.redis.{AbstractRedisCommand, ApiSubset, NodeCommand, RedisBooleanCommand, RedisIntCommand, RedisLongCommand, RedisUnitCommand}
+
+trait StreamsApi extends ApiSubset {
+  private final class Xack(key: Key, group: XGroup, ids: Iterable[XEntryId])
+    extends RedisIntCommand with NodeCommand {
+    val encoded: Encoded = encoder("XACK").key(key).add(group).add(ids).result
+
+    override def immediateResult: Opt[Int] = whenEmpty(ids, 0)
+  }
+
+  private final class Xadd(key: Key, maxlen: Opt[XMaxlen], id: Opt[XEntryId], fieldValues: Iterable[(Field, Value)])
+    extends AbstractRedisCommand[XEntryId](bulkXEntryId) with NodeCommand {
+    val encoded: Encoded = encoder("XADD").key(key).optAdd("MAXLEN", maxlen)
+      .add(id.fold("*")(_.toString)).dataPairs(fieldValues).result
+  }
+
+  private abstract class AbstractXclaim[A](entryDecoder: ReplyDecoder[A])(
+    key: Key, group: XGroup, consumer: XConsumer, minIdleTime: Long, ids: Iterable[XEntryId],
+    idle: Opt[Long], msUnixTime: Opt[Long], retrycount: Opt[Int], force: Boolean, justid: Boolean
+  ) extends AbstractRedisCommand[Seq[A]](multiBulkSeq(entryDecoder)) with NodeCommand {
+    val encoded: Encoded = encoder("XCLAIM").key(key).add(group).add(consumer).add(minIdleTime)
+      .add(ids).optAdd("IDLE", idle).optAdd("TIME", msUnixTime).optAdd("RETRYCOUNT", retrycount)
+      .addFlag("FORCE", force).addFlag("JUSTID", justid).result
+
+    override def immediateResult: Opt[Seq[A]] = whenEmpty(ids, Seq.empty)
+  }
+
+  private final class Xclaim(
+    key: Key, group: XGroup, consumer: XConsumer, minIdleTime: Long, ids: Iterable[XEntryId],
+    idle: Opt[Long], msUnixTime: Opt[Long], retrycount: Opt[Int], force: Boolean
+  ) extends AbstractXclaim[(XEntryId, BMap[Field, Value])](multiBulkPair(bulkXEntryId, mapMultiBulk[Field, Value]))(
+    key, group, consumer, minIdleTime, ids, idle, msUnixTime, retrycount, force, justid = false)
+
+  private final class XclaimJustid(
+    key: Key, group: XGroup, consumer: XConsumer, minIdleTime: Long, ids: Iterable[XEntryId],
+    idle: Opt[Long], msUnixTime: Opt[Long], retrycount: Opt[Int], force: Boolean
+  ) extends AbstractXclaim[XEntryId](bulkXEntryId)(
+    key, group, consumer, minIdleTime, ids, idle, msUnixTime, retrycount, force, justid = true)
+
+  private final class Xdel(key: Key, ids: Iterable[XEntryId]) extends RedisLongCommand with NodeCommand {
+    val encoded: Encoded = encoder("XDEL").key(key).add(ids).result
+
+    override def immediateResult: Opt[Long] = whenEmpty(ids, 0)
+  }
+
+  private final class XgroupCreate(key: Key, group: XGroup, id: Opt[XEntryId], mkstream: Boolean)
+    extends RedisUnitCommand with NodeCommand {
+    val encoded: Encoded = encoder("XGROUP", "CREATE").key(key).add(group)
+      .add(id.fold("$")(_.toString)).addFlag("MKSTREAM", mkstream).result
+  }
+
+  private final class XgroupSetid(key: Key, group: XGroup, id: Opt[XEntryId])
+    extends RedisUnitCommand with NodeCommand {
+    val encoded: Encoded = encoder("XGROUP", "SETID").key(key).add(group).add(id.fold("$")(_.toString)).result
+  }
+
+  private final class XgroupDestroy(key: Key, group: XGroup)
+    extends RedisBooleanCommand with NodeCommand {
+    val encoded: Encoded = encoder("XGROUP", "DESTROY").key(key).add(group).result
+  }
+
+  private final class XgroupDelconsumer(key: Key, group: XGroup, consumer: XConsumer)
+    extends RedisBooleanCommand with NodeCommand {
+    val encoded: Encoded = encoder("XGROUP", "DELCONSUMER").key(key).add(group).add(consumer).result
+  }
+
+  // TODO: XINFO
+
+  private final class Xlen(key: Key) extends RedisLongCommand with NodeCommand {
+    val encoded: Encoded = encoder("XLEN").key(key).result
+  }
+}
+
+final case class XEntryId(tstamp: Long, seq: OptArg[Long] = OptArg.Empty) {
+  override def toString: String = s"$tstamp${seq.fold("")("-" + _)}"
+}
+object XEntryId {
+  final val Zero: XEntryId = XEntryId(0)
+
+  def parse(str: String): XEntryId = str.indexOf('-') match {
+    case -1 => XEntryId(str.toLong, OptArg.Empty)
+    case i => XEntryId(str.substring(0, i).toLong, OptArg(str.substring(i + 1).toLong))
+  }
+
+  implicit val commandArg: CommandArg[XEntryId] = CommandArg((enc, eid) => enc.add(eid.toString))
+}
+
+case class XMaxlen(maxlen: Long, approx: Boolean = true)
+object XMaxlen {
+  implicit val commandArg: CommandArg[XMaxlen] = CommandArg {
+    case (enc, XMaxlen(maxlen, approx)) => enc.addFlag("~", approx).add(maxlen)
+  }
+}
+
+final case class XGroup(raw: String) extends AnyVal
+object XGroup {
+  implicit val commandArg: CommandArg[XGroup] = CommandArg((e, v) => e.add(v.raw))
+}
+
+final case class XConsumer(raw: String) extends AnyVal
+object XConsumer {
+  implicit val commandArg: CommandArg[XConsumer] = CommandArg((e, v) => e.add(v.raw))
+}

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -2,10 +2,10 @@ package com.avsystem.commons
 package redis.commands
 
 import com.avsystem.commons.redis.CommandEncoder.CommandArg
+import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.protocol.ValidRedisMsg
 import com.avsystem.commons.redis.util.SingletonSeq
-import com.avsystem.commons.redis.{AbstractRedisCommand, FieldValueApiSubset, NodeCommand, RecordApiSubset, RedisBooleanCommand, RedisIntCommand, RedisLongCommand, RedisRecordCodec, RedisSeqCommand, RedisUnitCommand}
 
 trait StreamsApi extends FieldValueApiSubset with RecordApiSubset {
   type XEntry = redis.commands.XEntry[Record]

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -165,10 +165,10 @@ trait StreamsApi extends ApiSubset {
 
   /** Executes [[http://redis.io/commands/xreadgroup XREADGROUP]] */
   def xreadgroupSingle(
-    group: XGroup,
-    consumer: XConsumer,
     key: Key,
     id: Opt[XEntryId],
+    group: XGroup,
+    consumer: XConsumer,
     blockMillis: OptArg[Int] = OptArg.Empty,
     count: OptArg[Int] = OptArg.Empty,
   ): Result[Seq[XEntry[Field, Value]]] =
@@ -304,7 +304,7 @@ trait StreamsApi extends ApiSubset {
 
   private abstract class AbstractXread(noStreams: Boolean)
     extends AbstractRedisCommand[BMap[Key, Seq[XEntry[Field, Value]]]](
-      multiBulkXEntriesByKey[Key, Field, Value]) with NodeCommand {
+      multiBulkXEntriesMap[Key, Field, Value]) with NodeCommand {
 
     def blockMillis: Opt[Int]
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -5,13 +5,13 @@ import com.avsystem.commons.redis.CommandEncoder.CommandArg
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.protocol.ValidRedisMsg
 import com.avsystem.commons.redis.util.SingletonSeq
-import com.avsystem.commons.redis.{AbstractRedisCommand, ApiSubset, NodeCommand, RedisBooleanCommand, RedisIntCommand, RedisLongCommand, RedisSeqCommand, RedisUnitCommand}
+import com.avsystem.commons.redis.{AbstractRedisCommand, FieldValueApiSubset, NodeCommand, RecordApiSubset, RedisBooleanCommand, RedisIntCommand, RedisLongCommand, RedisRecordCodec, RedisSeqCommand, RedisUnitCommand}
 
-trait StreamsApi extends ApiSubset {
-  type XEntry = redis.commands.XEntry[Field, Value]
+trait StreamsApi extends FieldValueApiSubset with RecordApiSubset {
+  type XEntry = redis.commands.XEntry[Record]
   object XEntry {
-    def apply(id: XEntryId, data: Seq[(Field, Value)]): XEntry = redis.commands.XEntry(id, data)
-    def unapply(entry: XEntry): Opt[(XEntryId, Seq[(Field, Value)])] = Opt((entry.id, entry.data))
+    def apply(id: XEntryId, data: Record): XEntry = redis.commands.XEntry(id, data)
+    def unapply(entry: XEntry): Opt[(XEntryId, Record)] = Opt((entry.id, entry.data))
   }
 
   /** Executes [[http://redis.io/commands/xack XACK]] */
@@ -25,17 +25,13 @@ trait StreamsApi extends ApiSubset {
     execute(new Xack(key, group, ids))
 
   /** Executes [[http://redis.io/commands/xadd XADD]] */
-  def xadd(key: Key, fieldValue: (Field, Value), fieldValues: (Field, Value)*): Result[XEntryId] =
-    execute(new Xadd(key, Opt.Empty, Opt.Empty, fieldValue +:: fieldValues))
-
-  /** Executes [[http://redis.io/commands/xadd XADD]] */
   def xadd(
     key: Key,
-    fieldValues: Iterable[(Field, Value)],
+    data: Record,
     id: OptArg[XEntryId] = OptArg.Empty,
     maxlen: OptArg[XMaxlen] = OptArg.Empty
   ): Result[XEntryId] =
-    execute(new Xadd(key, maxlen.toOpt, id.toOpt, fieldValues))
+    execute(new Xadd(key, maxlen.toOpt, id.toOpt, data))
 
   /** Executes [[http://redis.io/commands/xadd XADD]] */
   def xaddEntry(key: Key, entry: XEntry, maxlen: OptArg[XMaxlen] = OptArg.Empty): Result[XEntryId] =
@@ -122,7 +118,7 @@ trait StreamsApi extends ApiSubset {
   def xinfoGroups(key: Key): Result[Seq[XGroupInfo]] =
     execute(new XinfoGroups(key))
   /** Executes [[http://redis.io/commands/xinfo XINFO STREAM]] */
-  def xinfoStream(key: Key): Result[XStreamInfo[XEntry]] =
+  def xinfoStream(key: Key): Result[XStreamInfo[Record]] =
     execute(new XinfoStream(key))
 
   /** Executes [[http://redis.io/commands/xlen XLEN]] */
@@ -215,10 +211,10 @@ trait StreamsApi extends ApiSubset {
     override def immediateResult: Opt[Int] = whenEmpty(ids, 0)
   }
 
-  private final class Xadd(key: Key, maxlen: Opt[XMaxlen], id: Opt[XEntryId], fieldValues: Iterable[(Field, Value)])
+  private final class Xadd(key: Key, maxlen: Opt[XMaxlen], id: Opt[XEntryId], data: Record)
     extends AbstractRedisCommand[XEntryId](bulkXEntryId) with NodeCommand {
     val encoded: Encoded = encoder("XADD").key(key).optAdd("MAXLEN", maxlen)
-      .optAdd(id, "*").dataPairs(fieldValues).result
+      .optAdd(id, "*").dataPairs(data).result
   }
 
   private abstract class AbstractXclaim[A](entryDecoder: ReplyDecoder[A])(
@@ -282,7 +278,7 @@ trait StreamsApi extends ApiSubset {
   }
 
   private final class XinfoStream(key: Key)
-    extends AbstractRedisCommand[XStreamInfo[XEntry]](multiBulkXStreamInfo(multiBulkXEntry[Field, Value])) with NodeCommand {
+    extends AbstractRedisCommand[XStreamInfo[Record]](multiBulkXStreamInfo[Record]) with NodeCommand {
     val encoded: Encoded = encoder("XINFO", "STREAM").key(key).result
   }
 
@@ -303,14 +299,14 @@ trait StreamsApi extends ApiSubset {
   }
 
   private final class Xrange(key: Key, start: Opt[XEntryId], end: Opt[XEntryId], count: Opt[Int])
-    extends RedisSeqCommand[XEntry](multiBulkXEntry[Field, Value]) with NodeCommand {
+    extends RedisSeqCommand[XEntry](multiBulkXEntry[Record]) with NodeCommand {
     val encoded: Encoded = encoder("XRANGE").key(key)
       .optAdd(start, "-").optAdd(end, "+").optAdd("COUNT", count).result
   }
 
   private abstract class AbstractXread(noStreams: Boolean)
     extends AbstractRedisCommand[BMap[Key, Seq[XEntry]]](
-      multiBulkXEntriesMap[Key, Field, Value]) with NodeCommand {
+      multiBulkXEntriesMap[Key, Record]) with NodeCommand {
 
     def blockMillis: Opt[Int]
 
@@ -342,7 +338,7 @@ trait StreamsApi extends ApiSubset {
   }
 
   private final class Xrevrange(key: Key, end: Opt[XEntryId], start: Opt[XEntryId], count: Opt[Int])
-    extends RedisSeqCommand[XEntry](multiBulkXEntry[Field, Value]) with NodeCommand {
+    extends RedisSeqCommand[XEntry](multiBulkXEntry[Record]) with NodeCommand {
     val encoded: Encoded = encoder("XREVRANGE").key(key)
       .optAdd(end, "+").optAdd(start, "-").optAdd("COUNT", count).result
   }
@@ -391,9 +387,7 @@ object XEntryId {
     CommandArg((enc, eid) => enc.add(eid.toString))
 }
 
-case class XEntry[Field, Value](id: XEntryId, data: Seq[(Field, Value)]) {
-  lazy val map: Map[Field, Value] = data.toMap
-}
+case class XEntry[Record](id: XEntryId, data: Record)
 
 case class XMaxlen(maxlen: Long, approx: Boolean = true)
 object XMaxlen {
@@ -442,12 +436,12 @@ case class XConsumerInfo(raw: BMap[String, ValidRedisMsg]) {
   def idle: Long = integerLong(raw("idle"))
 }
 
-case class XStreamInfo[Entry <: XEntry[_, _]](raw: BMap[String, ValidRedisMsg])(entryDecoder: ReplyDecoder[Entry]) {
+case class XStreamInfo[Record: RedisRecordCodec](raw: BMap[String, ValidRedisMsg]) {
   def length: Long = integerLong(raw("length"))
   def radixTreeKeys: Int = integerInt(raw("radis-tree-keys"))
   def radixTreeNodes: Int = integerInt(raw("radis-tree-nodes"))
   def groups: Int = integerInt(raw("groups"))
   def lastGeneratedId: XEntryId = bulkXEntryId(raw("last-generated-id"))
-  def firstEntry: Entry = entryDecoder(raw("first-entry"))
-  def lastEntry: Entry = entryDecoder(raw("last-entry"))
+  def firstEntry: XEntry[Record] = ReplyDecoders.multiBulkXEntry[Record].apply(raw("first-entry"))
+  def lastEntry: XEntry[Record] = ReplyDecoders.multiBulkXEntry[Record].apply(raw("last-entry"))
 }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -157,7 +157,7 @@ trait StreamsApi extends ApiSubset {
     key: Key,
     id: Opt[XEntryId],
     blockMillis: OptArg[Int] = OptArg.Empty,
-    count: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty
   ): Result[Seq[XEntry]] =
     execute(new Xread(count.toOpt, blockMillis.toOpt, Iterator(key), Iterator(id)).map(_.getOrElse(key, Nil)))
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -165,7 +165,7 @@ trait StreamsApi extends ApiSubset {
   def xread(
     streams: Iterable[(Key, Opt[XEntryId])],
     blockMillis: OptArg[Int] = OptArg.Empty,
-    count: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty
   ): Result[BMap[Key, Seq[XEntry]]] =
     execute(new Xread(count.toOpt, blockMillis.toOpt, streams.iterator.map(_._1), streams.iterator.map(_._2)))
 
@@ -176,7 +176,7 @@ trait StreamsApi extends ApiSubset {
     consumer: XConsumer,
     id: OptArg[XEntryId] = OptArg.Empty,
     blockMillis: OptArg[Int] = OptArg.Empty,
-    count: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty
   ): Result[Seq[XEntry]] =
     execute(new Xreadgroup(group, consumer, count.toOpt, blockMillis.toOpt,
       Iterator(key), Iterator(id.toOpt)).map(_.getOrElse(key, Nil)))
@@ -187,7 +187,7 @@ trait StreamsApi extends ApiSubset {
     consumer: XConsumer,
     streams: Iterable[(Key, Opt[XEntryId])],
     blockMillis: OptArg[Int] = OptArg.Empty,
-    count: OptArg[Int] = OptArg.Empty,
+    count: OptArg[Int] = OptArg.Empty
   ): Result[BMap[Key, Seq[XEntry]]] =
     execute(new Xreadgroup(group, consumer, count.toOpt, blockMillis.toOpt,
       streams.iterator.map(_._1), streams.iterator.map(_._2)))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -46,16 +46,16 @@ trait StreamsApi extends ApiSubset {
     key: Key,
     group: XGroup,
     consumer: XConsumer,
-    minIdleTime: Long,
+    minIdleMillis: Long,
     id: XEntryId,
-    idle: OptArg[Long] = OptArg.Empty,
+    idleMillis: OptArg[Long] = OptArg.Empty,
     msUnixTime: OptArg[Long] = OptArg.Empty,
     retrycount: OptArg[Int] = OptArg.Empty,
     force: Boolean = false
   ): Result[Opt[XEntry]] =
     execute(new Xclaim(
-      key, group, consumer, minIdleTime, new SingletonSeq(id),
-      idle.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
+      key, group, consumer, minIdleMillis, new SingletonSeq(id),
+      idleMillis.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
     ).map(_.headOpt))
 
   /** Executes [[http://redis.io/commands/xclaim XCLAIM]] */
@@ -63,16 +63,16 @@ trait StreamsApi extends ApiSubset {
     key: Key,
     group: XGroup,
     consumer: XConsumer,
-    minIdleTime: Long,
+    minIdleMillis: Long,
     ids: Iterable[XEntryId],
-    idle: OptArg[Long] = OptArg.Empty,
+    idleMillis: OptArg[Long] = OptArg.Empty,
     msUnixTime: OptArg[Long] = OptArg.Empty,
     retrycount: OptArg[Int] = OptArg.Empty,
     force: Boolean = false
   ): Result[Seq[XEntry]] =
     execute(new Xclaim(
-      key, group, consumer, minIdleTime, ids,
-      idle.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
+      key, group, consumer, minIdleMillis, ids,
+      idleMillis.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
     ))
 
   /** Executes [[http://redis.io/commands/xclaim XCLAIM]] */
@@ -80,16 +80,16 @@ trait StreamsApi extends ApiSubset {
     key: Key,
     group: XGroup,
     consumer: XConsumer,
-    minIdleTime: Long,
+    minIdleMillis: Long,
     ids: Iterable[XEntryId],
-    idle: OptArg[Long] = OptArg.Empty,
+    idleMillis: OptArg[Long] = OptArg.Empty,
     msUnixTime: OptArg[Long] = OptArg.Empty,
     retrycount: OptArg[Int] = OptArg.Empty,
     force: Boolean = false
   ): Result[Seq[XEntryId]] =
     execute(new XclaimJustid(
-      key, group, consumer, minIdleTime, ids,
-      idle.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
+      key, group, consumer, minIdleMillis, ids,
+      idleMillis.toOpt, msUnixTime.toOpt, retrycount.toOpt, force
     ))
 
   /** Executes [[http://redis.io/commands/xdel XDEL]] */
@@ -159,7 +159,7 @@ trait StreamsApi extends ApiSubset {
     blockMillis: OptArg[Int] = OptArg.Empty,
     count: OptArg[Int] = OptArg.Empty,
   ): Result[Seq[XEntry]] =
-    execute(new Xread(count.toOpt, blockMillis.toOpt, Iterator(key), Iterator(id)).map(_.apply(key)))
+    execute(new Xread(count.toOpt, blockMillis.toOpt, Iterator(key), Iterator(id)).map(_.getOrElse(key, Nil)))
 
   /** Executes [[http://redis.io/commands/xread XREAD]] */
   def xread(
@@ -179,7 +179,7 @@ trait StreamsApi extends ApiSubset {
     count: OptArg[Int] = OptArg.Empty,
   ): Result[Seq[XEntry]] =
     execute(new Xreadgroup(group, consumer, count.toOpt, blockMillis.toOpt,
-      Iterator(key), Iterator(id)).map(_.apply(key)))
+      Iterator(key), Iterator(id)).map(_.getOrElse(key, Nil)))
 
   /** Executes [[http://redis.io/commands/xreadgroup XREADGROUP]] */
   def xreadgroup(

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -10,8 +10,8 @@ import com.avsystem.commons.redis.{AbstractRedisCommand, ApiSubset, NodeCommand,
 trait StreamsApi extends ApiSubset {
   type XEntry = redis.commands.XEntry[Field, Value]
   object XEntry {
-    def apply(id: XEntryId, data: BMap[Field, Value]): XEntry = redis.commands.XEntry(id, data)
-    def unapply(entry: XEntry): Opt[(XEntryId, BMap[Field, Value])] = Opt((entry.id, entry.data))
+    def apply(id: XEntryId, data: Seq[(Field, Value)]): XEntry = redis.commands.XEntry(id, data)
+    def unapply(entry: XEntry): Opt[(XEntryId, Seq[(Field, Value)])] = Opt((entry.id, entry.data))
   }
 
   /** Executes [[http://redis.io/commands/xack XACK]] */
@@ -391,7 +391,9 @@ object XEntryId {
     CommandArg((enc, eid) => enc.add(eid.toString))
 }
 
-case class XEntry[Field, Value](id: XEntryId, data: BMap[Field, Value])
+case class XEntry[Field, Value](id: XEntryId, data: Seq[(Field, Value)]) {
+  lazy val map: Map[Field, Value] = data.toMap
+}
 
 case class XMaxlen(maxlen: Long, approx: Boolean = true)
 object XMaxlen {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala
@@ -7,7 +7,7 @@ import com.avsystem.commons.redis.commands.ReplyDecoders._
 import com.avsystem.commons.redis.protocol.ValidRedisMsg
 import com.avsystem.commons.redis.util.SingletonSeq
 
-trait StreamsApi extends FieldValueApiSubset with RecordApiSubset {
+trait StreamsApi extends ApiSubset {
   type XEntry = redis.commands.XEntry[Record]
   object XEntry {
     def apply(id: XEntryId, data: Record): XEntry = redis.commands.XEntry(id, data)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/strings.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/strings.scala
@@ -6,7 +6,7 @@ import com.avsystem.commons.redis.CommandEncoder.CommandArg
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait StringsApi extends ApiSubset {
+trait StringsApi extends ValueApiSubset {
   /** Executes [[http://redis.io/commands/append APPEND]] */
   def append(key: Key, value: Value): Result[Int] =
     execute(new Append(key, value))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/strings.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/strings.scala
@@ -108,11 +108,11 @@ trait StringsApi extends ApiSubset {
     execute(new Strlen(key))
 
   private final class Append(key: Key, value: Value) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("APPEND").key(key).data(value).result
+    val encoded: Encoded = encoder("APPEND").key(key).data(value).result
   }
 
   private final class Bitcount(key: Key, range: Opt[(Int, Int)]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("BITCOUNT").key(key).optAdd(range).result
+    val encoded: Encoded = encoder("BITCOUNT").key(key).optAdd(range).result
   }
 
   private final class Bitfield(key: Key, ops: Iterable[BitFieldOp])
@@ -148,93 +148,93 @@ trait StringsApi extends ApiSubset {
   private final class Bitop(bitop: BitOp, destkey: Key, keys: Seq[Key]) extends RedisIntCommand with NodeCommand {
     require(keys.nonEmpty, "BITOP requires at least one source key")
     require(bitop != BitOp.Not || keys.size == 1, "BITOP NOT requires exactly one source key")
-    val encoded = encoder("BITOP").add(bitop).key(destkey).keys(keys).result
+    val encoded: Encoded = encoder("BITOP").add(bitop).key(destkey).keys(keys).result
   }
 
   private final class Bitpos(key: Key, bit: Boolean, range: Opt[SemiRange]) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("BITPOS").key(key).add(bit).optAdd(range).result
+    val encoded: Encoded = encoder("BITPOS").key(key).add(bit).optAdd(range).result
   }
 
   private final class Decr(key: Key) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("DECR").key(key).result
+    val encoded: Encoded = encoder("DECR").key(key).result
   }
 
   private final class Decrby(key: Key, decrement: Long) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("DECRBY").key(key).add(decrement).result
+    val encoded: Encoded = encoder("DECRBY").key(key).add(decrement).result
   }
 
   private final class Get(key: Key) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("GET").key(key).result
+    val encoded: Encoded = encoder("GET").key(key).result
   }
 
   private final class Getbit(key: Key, offset: Int) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("GETBIT").key(key).add(offset).result
+    val encoded: Encoded = encoder("GETBIT").key(key).add(offset).result
   }
 
   private final class Getrange(key: Key, start: Int, end: Int) extends RedisDataCommand[Value] with NodeCommand {
-    val encoded = encoder("GETRANGE").key(key).add(start).add(end).result
+    val encoded: Encoded = encoder("GETRANGE").key(key).add(start).add(end).result
   }
 
   private final class Getset(key: Key, value: Value) extends RedisOptDataCommand[Value] with NodeCommand {
-    val encoded = encoder("GETSET").key(key).data(value).result
+    val encoded: Encoded = encoder("GETSET").key(key).data(value).result
   }
 
   private final class Incr(key: Key) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("INCR").key(key).result
+    val encoded: Encoded = encoder("INCR").key(key).result
   }
 
   private final class Incrby(key: Key, increment: Long) extends RedisLongCommand with NodeCommand {
-    val encoded = encoder("INCRBY").key(key).add(increment).result
+    val encoded: Encoded = encoder("INCRBY").key(key).add(increment).result
   }
 
   private final class Incrbyfloat(key: Key, increment: Double) extends RedisDoubleCommand with NodeCommand {
-    val encoded = encoder("INCRBYFLOAT").key(key).add(increment).result
+    val encoded: Encoded = encoder("INCRBYFLOAT").key(key).add(increment).result
   }
 
   private final class Mget(keys: Iterable[Key]) extends RedisOptDataSeqCommand[Value] with NodeCommand {
-    val encoded = encoder("MGET").keys(keys).result
+    val encoded: Encoded = encoder("MGET").keys(keys).result
     override def immediateResult = whenEmpty(keys, Seq.empty)
   }
 
   private final class Mset(keyValues: Iterable[(Key, Value)]) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("MSET").keyDatas(keyValues).result
+    val encoded: Encoded = encoder("MSET").keyDatas(keyValues).result
     override def immediateResult = whenEmpty(keyValues, ())
   }
 
   private final class Msetnx(keyValues: Iterable[(Key, Value)]) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("MSETNX").keyDatas(keyValues).result
+    val encoded: Encoded = encoder("MSETNX").keyDatas(keyValues).result
     override def immediateResult = whenEmpty(keyValues, true)
   }
 
   private final class Psetex(key: Key, milliseconds: Long, value: Value) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("PSETEX").key(key).add(milliseconds).data(value).result
+    val encoded: Encoded = encoder("PSETEX").key(key).add(milliseconds).data(value).result
   }
 
   private final class Set(key: Key, value: Value, expiration: Opt[Expiration], existence: Opt[Boolean])
     extends AbstractRedisCommand[Boolean](nullBulkOrSimpleOkBoolean) with NodeCommand {
 
-    val encoded = encoder("SET").key(key).data(value).optAdd(expiration)
+    val encoded: Encoded = encoder("SET").key(key).data(value).optAdd(expiration)
       .optAdd(existence.map(v => if (v) "XX" else "NX")).result
   }
 
   private final class Setbit(key: Key, offset: Long, value: Boolean) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("SETBIT").key(key).add(offset).add(value).result
+    val encoded: Encoded = encoder("SETBIT").key(key).add(offset).add(value).result
   }
 
   private final class Setex(key: Key, seconds: Long, value: Value) extends RedisUnitCommand with NodeCommand {
-    val encoded = encoder("SETEX").key(key).add(seconds).data(value).result
+    val encoded: Encoded = encoder("SETEX").key(key).add(seconds).data(value).result
   }
 
   private final class Setnx(key: Key, value: Value) extends RedisBooleanCommand with NodeCommand {
-    val encoded = encoder("SETNX").key(key).data(value).result
+    val encoded: Encoded = encoder("SETNX").key(key).data(value).result
   }
 
   private final class Setrange(key: Key, offset: Int, value: Value) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("SETRANGE").key(key).add(offset).data(value).result
+    val encoded: Encoded = encoder("SETRANGE").key(key).add(offset).data(value).result
   }
 
   private final class Strlen(key: Key) extends RedisIntCommand with NodeCommand {
-    val encoded = encoder("STRLEN").key(key).result
+    val encoded: Encoded = encoder("STRLEN").key(key).result
   }
 }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/strings.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/strings.scala
@@ -6,7 +6,7 @@ import com.avsystem.commons.redis.CommandEncoder.CommandArg
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.commands.ReplyDecoders._
 
-trait StringsApi extends ValueApiSubset {
+trait StringsApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/append APPEND]] */
   def append(key: Key, value: Value): Result[Int] =
     execute(new Append(key, value))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
@@ -17,7 +17,7 @@ trait TransactionApi extends ApiSubset {
     execute(Unwatch)
 
   private final class Watch(keys: Iterable[Key]) extends RedisUnitCommand with OperationCommand {
-    val encoded = encoder("WATCH").keys(keys).result
+    val encoded: Encoded = encoder("WATCH").keys(keys).result
     override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
       case RedisMsg.Ok => state.watching = true
       case _ =>
@@ -26,7 +26,7 @@ trait TransactionApi extends ApiSubset {
   }
 
   private object Unwatch extends RedisUnitCommand with OperationCommand {
-    val encoded = encoder("UNWATCH").result
+    val encoded: Encoded = encoder("UNWATCH").result
     override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
       case RedisMsg.Ok => state.watching = false
       case _ =>
@@ -35,11 +35,11 @@ trait TransactionApi extends ApiSubset {
 }
 
 private[redis] object Multi extends UnsafeCommand {
-  val encoded = encoder("MULTI").result
+  val encoded: Encoded = encoder("MULTI").result
 }
 
 private[redis] object Exec extends UnsafeCommand {
-  val encoded = encoder("EXEC").result
+  val encoded: Encoded = encoder("EXEC").result
   override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
     case _: ArrayMsg[RedisMsg] | NullArrayMsg => state.watching = false
     case err: ErrorMsg if err.errorCode == "EXECABORT" => state.watching = false
@@ -48,7 +48,7 @@ private[redis] object Exec extends UnsafeCommand {
 }
 
 private[redis] object Discard extends UnsafeCommand {
-  val encoded = encoder("DISCARD").result
+  val encoded: Encoded = encoder("DISCARD").result
   override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
     case RedisMsg.Ok => state.watching = false
     case _ =>

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
@@ -18,16 +18,16 @@ trait TransactionApi extends ApiSubset {
 
   private final class Watch(keys: Iterable[Key]) extends RedisUnitCommand with OperationCommand {
     val encoded: Encoded = encoder("WATCH").keys(keys).result
-    override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
+    override def updateWatchState(message: RedisMsg, state: WatchState): Unit = message match {
       case RedisMsg.Ok => state.watching = true
       case _ =>
     }
-    override def immediateResult = whenEmpty(keys, ())
+    override def immediateResult: Opt[Unit] = whenEmpty(keys, ())
   }
 
   private object Unwatch extends RedisUnitCommand with OperationCommand {
     val encoded: Encoded = encoder("UNWATCH").result
-    override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
+    override def updateWatchState(message: RedisMsg, state: WatchState): Unit = message match {
       case RedisMsg.Ok => state.watching = false
       case _ =>
     }
@@ -40,7 +40,7 @@ private[redis] object Multi extends UnsafeCommand {
 
 private[redis] object Exec extends UnsafeCommand {
   val encoded: Encoded = encoder("EXEC").result
-  override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
+  override def updateWatchState(message: RedisMsg, state: WatchState): Unit = message match {
     case _: ArrayMsg[RedisMsg] | NullArrayMsg => state.watching = false
     case err: ErrorMsg if err.errorCode == "EXECABORT" => state.watching = false
     case _ =>
@@ -49,7 +49,7 @@ private[redis] object Exec extends UnsafeCommand {
 
 private[redis] object Discard extends UnsafeCommand {
   val encoded: Encoded = encoder("DISCARD").result
-  override def updateWatchState(message: RedisMsg, state: WatchState) = message match {
+  override def updateWatchState(message: RedisMsg, state: WatchState): Unit = message match {
     case RedisMsg.Ok => state.watching = false
     case _ =>
   }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
@@ -2,9 +2,9 @@ package com.avsystem.commons
 package redis.commands
 
 import com.avsystem.commons.redis.protocol.{ArrayMsg, ErrorMsg, NullArrayMsg, RedisMsg}
-import com.avsystem.commons.redis.{ApiSubset, OperationCommand, RedisUnitCommand, UnsafeCommand, WatchState}
+import com.avsystem.commons.redis.{KeyedApiSubset, OperationCommand, RedisUnitCommand, UnsafeCommand, WatchState}
 
-trait TransactionApi extends ApiSubset {
+trait TransactionApi extends KeyedApiSubset {
   /** Executes [[http://redis.io/commands/watch WATCH]] */
   def watch(key: Key, keys: Key*): Result[Unit] =
     execute(new Watch(key +:: keys))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/transactions.scala
@@ -2,9 +2,9 @@ package com.avsystem.commons
 package redis.commands
 
 import com.avsystem.commons.redis.protocol.{ArrayMsg, ErrorMsg, NullArrayMsg, RedisMsg}
-import com.avsystem.commons.redis.{KeyedApiSubset, OperationCommand, RedisUnitCommand, UnsafeCommand, WatchState}
+import com.avsystem.commons.redis.{ApiSubset, OperationCommand, RedisUnitCommand, UnsafeCommand, WatchState}
 
-trait TransactionApi extends KeyedApiSubset {
+trait TransactionApi extends ApiSubset {
   /** Executes [[http://redis.io/commands/watch WATCH]] */
   def watch(key: Key, keys: Key*): Result[Unit] =
     execute(new Watch(key +:: keys))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/ExecutionConfig.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/ExecutionConfig.scala
@@ -10,14 +10,15 @@ import scala.concurrent.duration._
   * Additional options for executing a [[com.avsystem.commons.redis.RedisBatch RedisBatch]] on a
   * [[com.avsystem.commons.redis.RedisExecutor RedisExecutor]]
   *
-  * @param timeout  execution timeout
-  * @param decodeOn execution context on which Redis response to a batch will be decoded. Normally this is happening
-  *                 on one of the connection actor threads. This is ok for simple Redis commands but may introduce
-  *                 performance bottleneck for large batches with more heavy decoding. In such case it may be
-  *                 beneficial to delegate that work to some external executor.
+  * @param responseTimeout Redis server response timeout. If executing a batch involves retries (e.g. because of
+  *                        cluster redirections) then timeout is applied independently on every retry.
+  * @param decodeOn        execution context on which Redis response to a batch will be decoded. Normally this is happening
+  *                        on one of the connection actor threads. This is ok for simple Redis commands but may introduce
+  *                        performance bottleneck for large batches with more heavy decoding. In such case it may be
+  *                        beneficial to delegate that work to some external executor.
   */
 case class ExecutionConfig(
-  timeout: Timeout = 10.seconds,
+  responseTimeout: Timeout = 10.seconds,
   decodeOn: ExecutionContext = RunNowEC
 )
 object ExecutionConfig {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
@@ -3,34 +3,68 @@ package redis.config
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-trait RetryStrategy {
+trait RetryStrategy { self =>
   /**
-    * Determines a delay that will be waited before restarting a failed Redis connection.
-    * If this method returns `Opt.Empty`, the connection will not be restarted and will remain in a broken state.
-    *
-    * @param retry indicates which consecutive reconnection retry it is after the connection was lost, starting from 0
+    * Determines a delay that will be waited before retrying some operation that failed (e.g. Redis connection attempt)
+    * and also returns next retry strategy that should be used if that retry itself also fails.
+    * If this method returns `Opt.Empty`, the operation will not be retried and failure should be reported.
     */
-  def retryDelay(retry: Int): Opt[FiniteDuration]
+  def nextRetry: Opt[(FiniteDuration, RetryStrategy)]
+
+  def andThen(otherStrategy: RetryStrategy): RetryStrategy =
+    RetryStrategy(self.nextRetry match {
+      case Opt((delay, nextStrat)) => Opt((delay, nextStrat andThen otherStrategy))
+      case Opt.Empty => otherStrategy.nextRetry
+    })
+
+  def maxDelay(duration: FiniteDuration): RetryStrategy =
+    RetryStrategy(self.nextRetry.map { case (delay, retry) => (delay min duration, retry.maxDelay(duration)) })
+
+  def maxTotal(duration: FiniteDuration): RetryStrategy =
+    RetryStrategy(self.nextRetry.collect {
+      case (delay, nextStrat) =>
+        if (delay <= duration) (delay, nextStrat.maxTotal(duration - delay))
+        else (duration, RetryStrategy.never)
+    })
+
+  def maxRetries(retries: Int): RetryStrategy =
+    if (retries <= 0) RetryStrategy.never
+    else RetryStrategy(self.nextRetry.map { case (delay, nextStrat) => (delay, nextStrat.maxRetries(retries - 1)) })
+
+  def randomized(minFactor: Double, maxFactor: Double): RetryStrategy =
+    RetryStrategy(self.nextRetry.flatMap { case (delay, nextStrat) =>
+      val factor = minFactor + (maxFactor - minFactor) * math.random()
+      delay * factor match {
+        case fd: FiniteDuration => Opt((fd, nextStrat.randomized(minFactor, maxFactor)))
+        case _ => Opt.Empty
+      }
+    })
 }
+object RetryStrategy {
+  def apply(nextRetryThunk: => Opt[(FiniteDuration, RetryStrategy)]): RetryStrategy =
+    new RetryStrategy {
+      def nextRetry: Opt[(FiniteDuration, RetryStrategy)] = nextRetryThunk
+    }
 
-case class ExponentialBackoff(firstDelay: FiniteDuration, maxDelay: FiniteDuration)
-  extends RetryStrategy {
+  def never: RetryStrategy =
+    apply(Opt.Empty)
 
-  private def expDelay(retry: Int): FiniteDuration =
-    firstDelay * (1 << (retry - 1))
+  def immediately: RetryStrategy =
+    once(Duration.Zero)
 
-  private val maxRetry =
-    Iterator.from(1).find(i => expDelay(i) >= maxDelay).getOrElse(Int.MaxValue)
+  def once(delay: FiniteDuration): RetryStrategy =
+    apply(Opt((delay, never)))
 
-  def retryDelay(retry: Int) = Opt {
-    if (retry == 0) Duration.Zero
-    else if (retry >= maxRetry) maxDelay
-    else expDelay(retry)
+  def continually(delay: FiniteDuration): RetryStrategy =
+    apply(Opt((delay, continually(delay))))
+
+  def exponentially(firstDelay: FiniteDuration, factor: Double = 2): RetryStrategy = apply {
+    val nextStrat = firstDelay * factor match {
+      case fd: FiniteDuration => exponentially(fd, factor)
+      case _ => never
+    }
+    Opt((firstDelay, nextStrat))
   }
-}
-
-case object NoRetryStrategy extends RetryStrategy {
-  def retryDelay(retry: Int): Opt[FiniteDuration] = Opt.Empty
 }
 
 object ConfigDefaults {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
@@ -39,6 +39,9 @@ trait RetryStrategy { self =>
         case _ => Opt.Empty
       }
     })
+
+  def next: RetryStrategy =
+    nextRetry.fold(RetryStrategy.never) { case (_, n) => n }
 }
 object RetryStrategy {
   def apply(nextRetryThunk: => Opt[(FiniteDuration, RetryStrategy)]): RetryStrategy =
@@ -51,6 +54,9 @@ object RetryStrategy {
 
   def immediately: RetryStrategy =
     once(Duration.Zero)
+
+  def times(count: Int, duration: FiniteDuration = Duration.Zero): RetryStrategy =
+    if (count <= 0) never else apply(Opt(duration, times(count - 1, duration)))
 
   def once(delay: FiniteDuration): RetryStrategy =
     apply(Opt((delay, never)))

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
@@ -33,7 +33,7 @@ trait RetryStrategy { self =>
 
   def randomized(minFactor: Double, maxFactor: Double): RetryStrategy =
     RetryStrategy(self.nextRetry.flatMap { case (delay, nextStrat) =>
-      val factor = minFactor + (maxFactor - minFactor) * math.random()
+      val factor = minFactor + (maxFactor - minFactor) * math.random
       delay * factor match {
         case fd: FiniteDuration => Opt((fd, nextStrat.randomized(minFactor, maxFactor)))
         case _ => Opt.Empty

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/RetryStrategy.scala
@@ -16,7 +16,7 @@ trait RetryStrategy {
 case class ExponentialBackoff(firstDelay: FiniteDuration, maxDelay: FiniteDuration)
   extends RetryStrategy {
 
-  private def expDelay(retry: Int) =
+  private def expDelay(retry: Int): FiniteDuration =
     firstDelay * (1 << (retry - 1))
 
   private val maxRetry =
@@ -30,7 +30,7 @@ case class ExponentialBackoff(firstDelay: FiniteDuration, maxDelay: FiniteDurati
 }
 
 case object NoRetryStrategy extends RetryStrategy {
-  def retryDelay(retry: Int) = Opt.Empty
+  def retryDelay(retry: Int): Opt[FiniteDuration] = Opt.Empty
 }
 
 object ConfigDefaults {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -28,9 +28,11 @@ import scala.concurrent.duration._
   * @param nodesToQueryForState        function that determines how many randomly selected masters should be queried
   *                                    for cluster state during routine state refresh operation. The function takes
   *                                    current number of known masters as its argument.
-  * @param maxRedirections             maximum number of consecutive redirections automatically handled by
-  *                                    [[com.avsystem.commons.redis.RedisClusterClient RedisClusterClient]].
-  *                                    When set to 0, redirections are not handled at all.
+  * @param redirectionStrategy         [[RetryStrategy]] that controls Redis Cluster redirection handling
+  *                                    (`MOVED` and `ASK` responses).
+  * @param tryagainStrategy            [[RetryStrategy]] that controls retrying commands which failed with
+  *                                    `TRYAGAIN` error which may be returned for multikey commands during
+  *                                    cluster slot migration.
   * @param nodeClientCloseDelay        Delay after which [[com.avsystem.commons.redis.RedisNodeClient RedisNodeClient]]
   *                                    is closed when it's master leaves cluster state (goes down or becomes a slave).
   *                                    Note that the node client is NOT operational during that delay. Trying to
@@ -48,7 +50,7 @@ case class ClusterConfig(
   autoRefreshInterval: FiniteDuration = 5.seconds,
   minRefreshInterval: FiniteDuration = 1.seconds,
   nodesToQueryForState: Int => Int = _ min 5,
-  redirectionRetryStrategy: RetryStrategy = RetryStrategy.times(3),
+  redirectionStrategy: RetryStrategy = RetryStrategy.times(3),
   tryagainStrategy: RetryStrategy = exponentially(10.millis).maxDelay(5.seconds).maxTotal(1.minute),
   nodeClientCloseDelay: FiniteDuration = 1.seconds,
   fallbackToSingleNode: Boolean = false

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -68,6 +68,12 @@ case class ClusterConfig(
   * commands because these other commands may be delayed by the blocking command. Therefore
   * they require their own, dynamically resizable connection pool. Maximum size of that pool
   * is the limit of possible concurrent blocking commands that can be executed at the same time.
+  * @param maxBlockingIdleTime
+  * Maximum amount of time a blocking connection may be idle before being closed and removed from
+  * the pool.
+  * @param blockingCleanupInterval
+  * Time interval between periodic blocking connection cleanup events,
+  * with respect to [[maxBlockingIdleTime]].
   * @param initOp
   * A [[com.avsystem.commons.redis.RedisOp RedisOp]] executed by this client upon initialization.
   * This may be useful for things like script loading, especially when using cluster client which
@@ -83,6 +89,8 @@ case class ClusterConfig(
 case class NodeConfig(
   poolSize: Int = 1,
   maxBlockingPoolSize: Int = 4096,
+  maxBlockingIdleTime: Duration = 1.minute,
+  blockingCleanupInterval: FiniteDuration = 1.second,
   initOp: RedisOp[Any] = RedisOp.unit,
   initTimeout: Timeout = Timeout(10.seconds),
   connectionConfigs: Int => ConnectionConfig = _ => ConnectionConfig(),

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -48,7 +48,7 @@ case class ClusterConfig(
   autoRefreshInterval: FiniteDuration = 5.seconds,
   minRefreshInterval: FiniteDuration = 1.seconds,
   nodesToQueryForState: Int => Int = _ min 5,
-  maxRedirections: Int = 3,
+  redirectionRetryStrategy: RetryStrategy = RetryStrategy.times(3),
   tryagainStrategy: RetryStrategy = exponentially(10.millis).maxDelay(5.seconds).maxTotal(1.minute),
   nodeClientCloseDelay: FiniteDuration = 1.seconds,
   fallbackToSingleNode: Boolean = false

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -6,6 +6,7 @@ import java.net.InetSocketAddress
 import akka.io.Inet
 import akka.util.Timeout
 import com.avsystem.commons.redis.actor.RedisConnectionActor.{DebugListener, DevNullListener}
+import com.avsystem.commons.redis.config.RetryStrategy._
 import com.avsystem.commons.redis.{NodeAddress, RedisBatch, RedisOp}
 
 import scala.concurrent.duration._
@@ -48,6 +49,7 @@ case class ClusterConfig(
   minRefreshInterval: FiniteDuration = 1.seconds,
   nodesToQueryForState: Int => Int = _ min 5,
   maxRedirections: Int = 3,
+  tryagainStrategy: RetryStrategy = exponentially(10.millis).maxDelay(5.seconds).maxTotal(1.minute),
   nodeClientCloseDelay: FiniteDuration = 1.seconds,
   fallbackToSingleNode: Boolean = false
 )
@@ -140,7 +142,6 @@ case class ConnectionConfig(
   socketOptions: List[Inet.SocketOption] = Nil,
   connectTimeout: OptArg[FiniteDuration] = OptArg.Empty,
   maxWriteSizeHint: OptArg[Int] = 50000,
-  reconnectionStrategy: RetryStrategy = ExponentialBackoff(1.seconds, 32.seconds),
+  reconnectionStrategy: RetryStrategy = immediately.andThen(exponentially(1.seconds)).maxDelay(8.seconds),
   debugListener: DebugListener = DevNullListener
 )
-

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/exception/RedisException.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/exception/RedisException.scala
@@ -82,6 +82,13 @@ class ForbiddenCommandException(cmd: RawCommand, client: String)
   extends RedisException(s"This command cannot be executed on $client: $cmd")
 
 /**
+  * Thrown when there is too many concurrent blocking commands being executed on a node
+  * client and blocking connection pool is exhausted.
+  */
+class TooManyConnectionsException(maxPoolSize: Int)
+  extends RedisException(s"Maximum number of blocking connections ($maxPoolSize) was reached")
+
+/**
   * Thrown when [[com.avsystem.commons.redis.RedisClusterClient RedisClusterClient]] is unable to fetch initial
   * cluster state from any of the seed nodes. This happens e.g. when none of the seed nodes can be contacted or when
   * they aren't Redis Cluster members.

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/exception/RedisException.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/exception/RedisException.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package redis.exception
 
 import com.avsystem.commons.redis.protocol.ErrorMsg
-import com.avsystem.commons.redis.{NodeAddress, RawCommand, Redirection}
+import com.avsystem.commons.redis.{NodeAddress, RawCommand, Redirection, RedisCommand}
 
 class RedisException(msg: String = null, cause: Throwable = null)
   extends RuntimeException(msg, cause)
@@ -29,8 +29,10 @@ class UnexpectedReplyException(msg: String = null)
 /**
   * Thrown when Redis server replies with an error.
   */
-class ErrorReplyException(val reply: ErrorMsg)
-  extends RedisException(reply.errorString.utf8String)
+class ErrorReplyException(val reply: ErrorMsg, val command: RedisCommand[_])
+  extends RedisException(s"${reply.errorString.utf8String}, for command $command") {
+  def errorStr: String = reply.errorString.utf8String
+}
 
 class RedisIOException(msg: String = null, cause: Throwable = null)
   extends RedisException(msg, cause)

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/exception/RedisException.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/exception/RedisException.scala
@@ -30,7 +30,7 @@ class UnexpectedReplyException(msg: String = null)
   * Thrown when Redis server replies with an error.
   */
 class ErrorReplyException(val reply: ErrorMsg, val command: RedisCommand[_])
-  extends RedisException(s"${reply.errorString.utf8String}, for command $command") {
+  extends RedisException(s"Redis replied with error: ${reply.errorString.utf8String}, command: $command") {
   def errorStr: String = reply.errorString.utf8String
 }
 

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/protocol/messages.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/protocol/messages.scala
@@ -50,7 +50,7 @@ object ErrorMsg {
 final case class IntegerMsg(value: Long) extends ValidRedisMsg
 case object NullBulkStringMsg extends ValidRedisMsg
 sealed case class BulkStringMsg(string: ByteString) extends ValidRedisMsg {
-  override def toString = s"$productPrefix(${RedisMsg.escape(string)})"
+  override def toString: String = s"$productPrefix(${RedisMsg.escape(string)})"
   def isCommandKey: Boolean = false
 }
 final class CommandKeyMsg(key: ByteString) extends BulkStringMsg(key) {
@@ -58,7 +58,7 @@ final class CommandKeyMsg(key: ByteString) extends BulkStringMsg(key) {
 }
 object CommandKeyMsg {
   def apply(key: ByteString): CommandKeyMsg = new CommandKeyMsg(key)
-  def unapply(keyBulkStringMsg: CommandKeyMsg): Opt[CommandKeyMsg] = Opt(keyBulkStringMsg)
+  def unapply(keyBulkStringMsg: CommandKeyMsg): Opt[ByteString] = Opt(keyBulkStringMsg.string)
 }
 case object NullArrayMsg extends ValidRedisMsg
 final case class ArrayMsg[+E <: RedisMsg](elements: IndexedSeq[E]) extends ValidRedisMsg
@@ -74,6 +74,7 @@ object SimpleStringStr {
 object RedisMsg {
   val Ok = SimpleStringMsg(ByteString("OK"))
   val Queued = SimpleStringMsg(ByteString("QUEUED"))
+  val Nokey = SimpleStringMsg(ByteString("NOKEY"))
 
   def escape(bs: ByteString, quote: Boolean = true): String = {
     val sb = new StringBuilder(if (quote) "\"" else "")

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/raw.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/raw.scala
@@ -45,16 +45,16 @@ trait RawCommand extends RawCommandPack with RawCommands with ReplyPreprocessor 
 }
 
 trait UnsafeCommand extends RawCommand {
-  def level: Level = Level.Unsafe
+  final def level: Level = Level.Unsafe
 }
 trait ConnectionCommand extends RawCommand {
-  def level: Level = Level.Connection
+  final def level: Level = Level.Connection
 }
 trait OperationCommand extends RawCommand {
-  def level: Level = Level.Operation
+  final def level: Level = Level.Operation
 }
 trait NodeCommand extends RawCommand {
-  def level: Level = Level.Node
+  final def level: Level = Level.Node
 }
 
 object RawCommand {

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/util/DelayedFuture.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/util/DelayedFuture.scala
@@ -1,0 +1,17 @@
+package com.avsystem.commons
+package redis.util
+
+import akka.actor.ActorSystem
+import com.avsystem.commons.concurrent.RunNowEC
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+object DelayedFuture {
+  def apply(delay: FiniteDuration)(implicit system: ActorSystem): Future[Unit] =
+    if (delay <= Duration.Zero) Future.unit
+    else {
+      val promise = Promise[Unit]()
+      system.scheduler.scheduleOnce(delay)(promise.success(()))(RunNowEC)
+      promise.future
+    }
+}

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/util/HeadIterable.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/util/HeadIterable.scala
@@ -5,7 +5,7 @@ final class HeadIterable[+A](head: A, tail: Iterable[A]) extends Iterable[A] {
   def iterator = new HeadIterator(head, tail.iterator)
 
   override def isEmpty = false
-  override def foreach[U](f: A => U) = {
+  override def foreach[U](f: A => U): Unit = {
     f(head)
     tail.foreach(f)
   }
@@ -13,8 +13,8 @@ final class HeadIterable[+A](head: A, tail: Iterable[A]) extends Iterable[A] {
 
 final class HeadIterator[+A](head: A, tail: Iterator[A]) extends Iterator[A] {
   private[this] var atHead = true
-  def hasNext = atHead || tail.hasNext
-  def next() =
+  def hasNext: Boolean = atHead || tail.hasNext
+  def next(): A =
     if (atHead) {
       atHead = false
       head

--- a/commons-redis/src/test/resources/application.conf
+++ b/commons-redis/src/test/resources/application.conf
@@ -1,1 +1,1 @@
-akka.loglevel = INFO
+akka.loglevel = DEBUG

--- a/commons-redis/src/test/resources/application.conf
+++ b/commons-redis/src/test/resources/application.conf
@@ -1,1 +1,1 @@
-akka.loglevel = DEBUG
+akka.loglevel = INFO

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/ApiTypecheckingTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/ApiTypecheckingTest.scala
@@ -48,10 +48,11 @@ object ApiTypecheckingTest {
   }
 
   locally {
-    val api = RedisApi.Batches.StringTyped.valueType[Int]
+    val ser = RedisSerialization.Strings.valueType[Int]
+    val api = RedisApi.Batches[ser.type]
     import api._
     val transactionOp: RedisOp[Unit] = for {
-    // we're sending WATCH and GET commands in a single batch
+      // we're sending WATCH and GET commands in a single batch
       value <- watch("number") *> get("number").map(_.getOrElse(1))
       // SET command is wrapped in MULTI-EXEC block
       _ <- set("number", value * 3).transaction
@@ -59,7 +60,8 @@ object ApiTypecheckingTest {
   }
 
   locally {
-    val api = RedisApi.Batches.StringTyped.valueType[Encoding]
+    val ser = RedisSerialization.Strings.valueType[Encoding]
+    val api = RedisApi.Batches[ser.type]
     api.set("lol", Encoding.HashTable)
   }
 

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/ClusterUtils.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/ClusterUtils.scala
@@ -10,7 +10,7 @@ import scala.io.Source
   * Created: 28/06/16.
   */
 object ClusterUtils {
-  val SlotKeys =
+  final val SlotKeys =
     Source.fromInputStream(getClass.getResourceAsStream("/slotkeys.txt"))
       .getLines().toArray
 

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/CommandsSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/CommandsSuite.scala
@@ -3,12 +3,13 @@ package redis
 
 import akka.util.{ByteString, ByteStringBuilder}
 import com.avsystem.commons.misc.SourceInfo
+import com.avsystem.commons.redis.config.{ClusterConfig, ConnectionConfig, NodeConfig}
 import org.scalactic.source.Position
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, Matchers, Tag}
 
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 /**
   * Author: ghik
@@ -16,7 +17,7 @@ import scala.concurrent.Await
   */
 trait ByteStringInterpolation {
   implicit class bsInterpolation(sc: StringContext) {
-    def bs(args: Any*) = {
+    def bs(args: Any*): ByteString = {
       val bsb = new ByteStringBuilder
       bsb.append(ByteString(sc.parts.head))
       (sc.parts.tail zip args).foreach {
@@ -68,7 +69,7 @@ trait CommandsSuite extends FunSuite with ScalaFutures with Matchers with UsesAc
   }
 
   protected implicit class BatchOps[T](batch: RedisBatch[T]) {
-    def get: T = Await.result(exec, patienceConfig.timeout.totalNanos.nanos)
+    def get: T = exec.futureValue
     def exec: Future[T] = executor.executeBatch(batch)
     def assert(pred: T => Boolean)(implicit pos: Position): Unit = CommandsSuite.this.assert(pred(get))
     def assertEquals(t: T)(implicit pos: Position): Unit = assertResult(t)(get)
@@ -87,7 +88,7 @@ trait CommandsSuite extends FunSuite with ScalaFutures with Matchers with UsesAc
 abstract class RedisClusterCommandsSuite extends FunSuite with UsesPreconfiguredCluster with UsesRedisClusterClient with CommandsSuite {
   def executor: RedisKeyedExecutor = redisClient
 
-  override def clusterConfig =
+  override def clusterConfig: ClusterConfig =
     super.clusterConfig |> { cc =>
       cc.copy(
         nodeConfigs = a => cc.nodeConfigs(a) |> { nc =>
@@ -100,7 +101,7 @@ abstract class RedisClusterCommandsSuite extends FunSuite with UsesPreconfigured
       )
     }
 
-  override protected def afterEach() = {
+  override protected def afterEach(): Unit = {
     val futures = redisClient.currentState.masters.values.map(_.executeBatch(cleanupBatch))
     Await.ready(Future.sequence(futures), Duration.Inf)
     super.afterEach()
@@ -108,9 +109,9 @@ abstract class RedisClusterCommandsSuite extends FunSuite with UsesPreconfigured
 }
 
 abstract class RedisNodeCommandsSuite extends FunSuite with UsesRedisNodeClient with CommandsSuite {
-  def executor = redisClient
+  def executor: RedisNodeClient = redisClient
 
-  override def nodeConfig =
+  override def nodeConfig: NodeConfig =
     super.nodeConfig |> { nc =>
       nc.copy(
         poolSize = 4,
@@ -119,19 +120,19 @@ abstract class RedisNodeCommandsSuite extends FunSuite with UsesRedisNodeClient 
       )
     }
 
-  override protected def afterEach() = {
+  override protected def afterEach(): Unit = {
     Await.ready(executor.executeBatch(cleanupBatch), Duration.Inf)
     super.afterEach()
   }
 }
 
 abstract class RedisConnectionCommandsSuite extends FunSuite with UsesRedisConnectionClient with CommandsSuite {
-  def executor = redisClient
+  def executor: RedisConnectionClient = redisClient
 
-  override def connectionConfig =
+  override def connectionConfig: ConnectionConfig =
     super.connectionConfig.copy(debugListener = listener)
 
-  override protected def afterEach() = {
+  override protected def afterEach(): Unit = {
     Await.ready(executor.executeBatch(cleanupBatch), Duration.Inf)
     super.afterEach()
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/CommandsSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/CommandsSuite.scala
@@ -69,7 +69,7 @@ trait CommandsSuite extends FunSuite with ScalaFutures with Matchers with UsesAc
   }
 
   protected implicit class BatchOps[T](batch: RedisBatch[T]) {
-    def get: T = exec.futureValue
+    def get: T = Await.result(exec, patienceConfig.timeout.totalNanos.nanos)
     def exec: Future[T] = executor.executeBatch(batch)
     def assert(pred: T => Boolean)(implicit pos: Position): Unit = CommandsSuite.this.assert(pred(get))
     def assertEquals(t: T)(implicit pos: Position): Unit = assertResult(t)(get)

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisClusterClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisClusterClientTest.scala
@@ -91,7 +91,7 @@ class RedisClusterClientInitDuringFailureTest extends FunSuite
 
     val client = createClient(ports.head, ports.head + 1)
     client.initialized.futureValue shouldBe client
-    client.executeBatch(get(slotKey(0)), ExecutionConfig(timeout = 120.seconds)).futureValue shouldBe Opt.Empty
+    client.executeBatch(get(slotKey(0)), ExecutionConfig(responseTimeout = 120.seconds)).futureValue shouldBe Opt.Empty
   }
 }
 

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisClusterClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisClusterClientTest.scala
@@ -8,17 +8,17 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{FunSuite, Matchers}
 
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class RedisClusterClientNonClusteredInitTest extends FunSuite
   with Matchers with ScalaFutures with UsesActorSystem with UsesRedisServer {
 
   import RedisApi.Batches.StringTyped._
 
-  override def password = "pass".opt
+  override def password: Opt[String] = "pass".opt
 
-  def createClient(port: Int, pass: String, fallbackToSingleNode: Boolean = false) = {
+  def createClient(port: Int, pass: String, fallbackToSingleNode: Boolean = false): RedisClusterClient = {
     val connConfig = ConnectionConfig(initCommands = auth(pass))
     val nodeConfig = NodeConfig(connectionConfigs = _ => connConfig)
     val config = ClusterConfig(
@@ -59,9 +59,8 @@ class RedisClusterClientInitTest extends FunSuite
 
   import RedisApi.Batches.StringTyped._
 
-  def createClient(ports: Int*) = {
+  def createClient(ports: Int*): RedisClusterClient =
     new RedisClusterClient(ports.map(p => NodeAddress(port = p)))
-  }
 
   test("client init test") {
     val client = createClient(ports.head)
@@ -154,9 +153,10 @@ class ClusterRedirectionHandlingTest extends RedisClusterCommandsSuite {
   import RedisApi.Batches.StringTyped._
 
   // don't refresh cluster state
-  override def clusterConfig = super.clusterConfig.copy(minRefreshInterval = Int.MaxValue.seconds)
+  override def clusterConfig: ClusterConfig =
+    super.clusterConfig.copy(minRefreshInterval = Int.MaxValue.seconds)
 
-  override protected def beforeAll() = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     Await.result(migrateSlot(0, 7000), Duration.Inf)
     Await.result(migrateSlot(1, 7000, incomplete = true), Duration.Inf)
@@ -187,6 +187,17 @@ class ClusterRedirectionHandlingTest extends RedisClusterCommandsSuite {
     val batch = slots.map(s => get(slotKey(s))).sequence
     batch.assertEquals(slots.map(_ => Opt.Empty))
   }
+
+  test("tryagain handling test") {
+    val k1 = s"{${slotKey(1)}}1"
+    val k2 = s"{${slotKey(1)}}2"
+    val mgetFut = mget(k1, k2).exec
+    val txFut = (get(k1), get(k2)).sequence.transaction.exec
+    Thread.sleep(500)
+    (set(k1, "v1"), set(k2, "v2")).sequence.get
+    assert(mgetFut.futureValue == Seq("v1".opt, "v2".opt))
+    assert(txFut.futureValue == ("v1".opt, "v2".opt))
+  }
 }
 
 class ClusterFailoverHandlingTest extends RedisClusterCommandsSuite {
@@ -194,9 +205,9 @@ class ClusterFailoverHandlingTest extends RedisClusterCommandsSuite {
   import RedisApi.Batches.StringTyped._
 
   // don't refresh cluster state
-  override def clusterConfig = super.clusterConfig.copy(minRefreshInterval = Int.MaxValue.seconds)
+  override def clusterConfig: ClusterConfig = super.clusterConfig.copy(minRefreshInterval = Int.MaxValue.seconds)
 
-  override protected def beforeAll() = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     val slaveClient = new RedisConnectionClient(NodeAddress(port = 9001))
     def failover(delay: FiniteDuration = Duration.Zero): Future[Unit] = for {

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisClusterClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisClusterClientTest.scala
@@ -160,8 +160,6 @@ class ClusterRedirectionHandlingTest extends RedisClusterCommandsSuite {
     super.beforeAll()
     Await.result(migrateSlot(0, 7000), Duration.Inf)
     Await.result(migrateSlot(1, 7000, incomplete = true), Duration.Inf)
-    Await.result(set(s"{${slotKey(2)}}1", "v1").exec, Duration.Inf)
-    Await.result(migrateSlot(2, 7000, incomplete = true, withoutData = true), Duration.Inf)
   }
 
   test("redirection handling after migration") {
@@ -203,6 +201,9 @@ class ClusterRedirectionHandlingTest extends RedisClusterCommandsSuite {
   }
 
   test("TRYAGAIN before redirection") {
+    Await.result(set(s"{${slotKey(2)}}1", "v1").exec, Duration.Inf)
+    Await.result(migrateSlot(2, 7000, incomplete = true, withoutData = true), Duration.Inf)
+
     val k1 = s"{${slotKey(2)}}1"
     val k2 = s"{${slotKey(2)}}2"
     val mgetFut = mget(k1, k2).exec

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisConnectionClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisConnectionClientTest.scala
@@ -14,20 +14,20 @@ import org.scalatest.{FunSuite, Matchers}
 class RedisConnectionClientTest extends FunSuite
   with Matchers with ScalaFutures with UsesActorSystem with UsesRedisServer with ByteStringInterpolation {
 
-  def createClient(initCommands: RedisBatch[Any]) =
+  def createClient(initCommands: RedisBatch[Any]): RedisConnectionClient =
     new RedisConnectionClient(address, config = ConnectionConfig(initCommands))
 
   test("client initialization test") {
     import RedisApi.Batches.StringTyped._
     val client = createClient(select(0) *> clientSetname("name") *> ping)
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
     val f3 = client.executeBatch(clientGetname)
 
     client.initialized.futureValue shouldBe client
-    f1.futureValue shouldBe "LOL1"
-    f2.futureValue shouldBe "LOL2"
+    f1.futureValue shouldBe ByteString("LOL1")
+    f2.futureValue shouldBe ByteString("LOL2")
     f3.futureValue shouldBe "name".opt
   }
 
@@ -35,8 +35,8 @@ class RedisConnectionClientTest extends FunSuite
     import RedisApi.Batches.StringTyped._
     val client = new RedisConnectionClient(NodeAddress(port = 63498))
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
 
     client.initialized.failed.futureValue shouldBe a[ConnectionFailedException]
     f1.failed.futureValue shouldBe a[ConnectionFailedException]
@@ -47,8 +47,8 @@ class RedisConnectionClientTest extends FunSuite
     import RedisApi.Batches.StringTyped._
     val client = createClient(clusterInfo)
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
 
     client.initialized.failed.futureValue shouldBe a[ConnectionInitializationFailure]
     f1.failed.futureValue shouldBe a[ConnectionInitializationFailure]

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisNodeClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisNodeClientTest.scala
@@ -72,15 +72,15 @@ class RedisNodeClientTest extends FunSuite
   test("concurrent blocking commands test") {
     val client = createClient(RedisBatch.unit, RedisOp.unit)
     val api = RedisApi.Node.Async.StringTyped(client)
-    def fut: Future[Seq[Opt[String]]] = Future.traverse(Seq.fill(100)(()))(_ => api.blpop("LOL", 1))
+    def fut: Future[Seq[Opt[String]]] = Future.sequence(Seq.fill(100)(api.blpop("LOL", 1)))
     fut.futureValue shouldBe Seq.fill(100)(Opt.Empty)
     fut.futureValue shouldBe Seq.fill(100)(Opt.Empty)
   }
 
   test("too many concurrent blocking commands test") {
-    val client = createClient(RedisBatch.unit, RedisOp.unit)
+    val client = createClient(RedisBatch.unit, RedisOp.unit).initialized.futureValue
     val api = RedisApi.Node.Async.StringTyped(client)
-    val fut = Future.traverse(Seq.fill(100)(()))(_ => api.blpop("LOL", 1))
+    val fut = Future.sequence(Seq.fill(100)(api.blpop("LOL", 1)))
     val failingFut = api.blpop("LOL", 1)
     fut.futureValue shouldBe Seq.fill(100)(Opt.Empty)
     failingFut.failed.futureValue shouldBe a[TooManyConnectionsException]

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisNodeClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisNodeClientTest.scala
@@ -80,7 +80,7 @@ class RedisNodeClientTest extends FunSuite
   test("too many concurrent blocking commands test") {
     val client = createClient(RedisBatch.unit, RedisOp.unit)
     val api = RedisApi.Node.Async.StringTyped(client)
-    def fut: Future[Seq[Opt[String]]] = Future.traverse(Seq.fill(100)(()))(_ => api.blpop("LOL", 1))
+    val fut = Future.traverse(Seq.fill(100)(()))(_ => api.blpop("LOL", 1))
     val failingFut = api.blpop("LOL", 1)
     fut.futureValue shouldBe Seq.fill(100)(Opt.Empty)
     failingFut.failed.futureValue shouldBe a[TooManyConnectionsException]

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisNodeClientTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisNodeClientTest.scala
@@ -1,6 +1,7 @@
 package com.avsystem.commons
 package redis
 
+import akka.util.ByteString
 import com.avsystem.commons.redis.config.{ConnectionConfig, NodeConfig}
 import com.avsystem.commons.redis.exception.{ConnectionFailedException, ConnectionInitializationFailure, NodeInitializationFailure, TooManyConnectionsException}
 import org.scalatest.concurrent.ScalaFutures
@@ -25,20 +26,20 @@ class RedisNodeClientTest extends FunSuite
     import RedisApi.Batches.StringTyped._
     val client = createClient(select(0) *> ping, ping.operation)
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
 
     client.initialized.futureValue shouldBe client
-    f1.futureValue shouldBe "LOL1"
-    f2.futureValue shouldBe "LOL2"
+    f1.futureValue shouldBe ByteString("LOL1")
+    f2.futureValue shouldBe ByteString("LOL2")
   }
 
   test("client connection failure test") {
     import RedisApi.Batches.StringTyped._
     val client = new RedisConnectionClient(NodeAddress(port = 63498))
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
 
     client.initialized.failed.futureValue shouldBe a[ConnectionFailedException]
     f1.failed.futureValue shouldBe a[ConnectionFailedException]
@@ -49,8 +50,8 @@ class RedisNodeClientTest extends FunSuite
     import RedisApi.Batches.StringTyped._
     val client = createClient(clusterInfo, RedisOp.unit)
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
 
     client.initialized.failed.futureValue shouldBe a[ConnectionInitializationFailure]
     f1.failed.futureValue shouldBe a[ConnectionInitializationFailure]
@@ -61,8 +62,8 @@ class RedisNodeClientTest extends FunSuite
     import RedisApi.Batches.StringTyped._
     val client = createClient(RedisBatch.unit, clusterInfo.operation)
 
-    val f1 = client.executeBatch(echo("LOL1"))
-    val f2 = client.executeBatch(echo("LOL2"))
+    val f1 = client.executeBatch(echo(ByteString("LOL1")))
+    val f2 = client.executeBatch(echo(ByteString("LOL2")))
 
     client.initialized.failed.futureValue shouldBe a[NodeInitializationFailure]
     f1.failed.futureValue shouldBe a[NodeInitializationFailure]

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisProcessUtils.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/RedisProcessUtils.scala
@@ -12,9 +12,11 @@ import scala.sys.process._
   * Created: 27/06/16.
   */
 trait RedisProcessUtils extends UsesActorSystem { this: Suite =>
-  def redisHome = sys.env.getOpt("REDIS_HOME")
-  def inRedisHome(cmd: String) = redisHome.fold(cmd)(_ + "/" + cmd)
-  def password = Opt.empty[String]
+  def redisHome: Opt[String] = sys.env.getOpt("REDIS_HOME")
+  def inRedisHome(cmd: String): String = redisHome.fold(cmd)(_ + "/" + cmd)
+  def password: Opt[String] = Opt.empty[String]
+  def runCommand: List[String] =
+    if (System.getProperty("os.name") == "Windows 10") List("ubuntu", "run") else Nil
 
   private val NodeLogRegex = ".*Node configuration loaded, I'm ([0-9a-f]+)$".r
 
@@ -25,28 +27,27 @@ trait RedisProcessUtils extends UsesActorSystem { this: Suite =>
     var pid = 0
     var nodeId: Opt[NodeId] = Opt.Empty
     val passArgs = password.fold(Seq.empty[String])(p => Seq("--requirepass", p))
-    val process = (inRedisHome("redis-server") +: arguments ++: passArgs).run(ProcessLogger { line =>
-      actorSystem.log.debug(line)
-      line match {
-        case NodeLogRegex(rawNodeId) =>
-          nodeId = NodeId(rawNodeId).opt
-        case _ =>
-      }
-      if (line.contains("* Ready to accept connections")) {
-        pid = line.split(":", 2).head.toInt
-        promise.success(())
-      }
-    })
+    val process = (runCommand ++: inRedisHome("redis-server") +: arguments ++: passArgs).run(
+      ProcessLogger { line =>
+        actorSystem.log.debug(line)
+        line match {
+          case NodeLogRegex(rawNodeId) =>
+            nodeId = NodeId(rawNodeId).opt
+          case _ =>
+        }
+        if (line.contains("* Ready to accept connections")) {
+          pid = line.split(":", 2).head.toInt
+          promise.success(())
+        }
+      })
     promise.future.mapNow(_ => RedisProcess(process, pid, nodeId))
   }
-
-  private def scheduleSpawn(delay: FiniteDuration)(fun: => Unit) =
-    actorSystem.scheduler.scheduleOnce(delay)(fun)(SeparateThreadExecutionContext)
 
   def shutdownRedis(port: Int, process: RedisProcess): Future[Unit] =
     SeparateThreadExecutionContext.submit {
       actorSystem.log.info(s"Killing Redis process ${process.pid}")
-      s"kill -SIGKILL ${process.pid}".run(ProcessLogger(actorSystem.log.debug(_), actorSystem.log.error(_)))
+      (runCommand ++ List("kill", "-SIGKILL", process.pid.toString))
+        .run(ProcessLogger(actorSystem.log.debug(_), actorSystem.log.error(_)))
       process.process.exitValue()
       ()
     }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/TransactionTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/TransactionTest.scala
@@ -203,7 +203,7 @@ class TransactionTest extends RedisNodeCommandsSuite with CommunicationLogging {
   test("EXECABORT") {
     val badCommand: RedisBatch[Unit] =
       new RedisUnitCommand with NodeCommand {
-        val encoded = encoder("GET").result
+        val encoded: Encoded = encoder("GET").result
       }
 
     val batch = (get("key").failed, badCommand.failed).sequence.transaction

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/UsesRedisClusterClient.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/UsesRedisClusterClient.scala
@@ -43,12 +43,12 @@ trait UsesRedisClusterClient extends UsesClusterServers with UsesActorSystem { t
       } else Future.successful(())
     }
 
-  override protected def beforeAll() = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
     redisClient = new RedisClusterClient(addresses.take(1), clusterConfig)
   }
 
-  override protected def afterAll() = {
+  override protected def afterAll(): Unit = {
     redisClient.close()
     super.afterAll()
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/UsesRedisServer.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/UsesRedisServer.scala
@@ -16,7 +16,7 @@ trait UsesRedisServer extends BeforeAndAfterAll with RedisProcessUtils { this: S
 
   var redisProcess: RedisProcess = _
 
-  override protected def beforeAll() = {
+  override protected def beforeAll(): Unit = {
     super.beforeAll()
 
     redisProcess = Await.result(
@@ -28,7 +28,7 @@ trait UsesRedisServer extends BeforeAndAfterAll with RedisProcessUtils { this: S
     )
   }
 
-  override protected def afterAll() = {
+  override protected def afterAll(): Unit = {
     Await.result(shutdownRedis(port, redisProcess), 10.seconds)
     super.afterAll()
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ClusterApiTest.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ClusterApiTest.scala
@@ -1,13 +1,13 @@
 package com.avsystem.commons
 package redis.commands
 
-import com.avsystem.commons.redis.{ClusterUtils, NodeAddress, RedisApi, RedisClusterCommandsSuite}
+import com.avsystem.commons.redis.{ClusterUtils, NodeAddress, RedisApi, RedisClusterCommandsSuite, RedisNodeClient}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 class ClusterApiTest extends RedisClusterCommandsSuite {
-  override def executor = Await.result(redisClient.initializedCurrentState, Duration.Inf).mapping.head._2
+  override def executor: RedisNodeClient = Await.result(redisClient.initializedCurrentState, Duration.Inf).mapping.head._2
 
   import RedisApi.Batches.StringTyped._
 

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ConnectionApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ConnectionApiSuite.scala
@@ -1,8 +1,9 @@
 package com.avsystem.commons
 package redis.commands
 
+import akka.util.ByteString
 import com.avsystem.commons.redis.exception.ErrorReplyException
-import com.avsystem.commons.redis.{RedisConnectionCommandsSuite, RedisApi}
+import com.avsystem.commons.redis.{RedisApi, RedisConnectionCommandsSuite}
 
 /**
   * Author: ghik
@@ -13,7 +14,7 @@ trait ConnectionApiSuite extends RedisConnectionCommandsSuite {
   import RedisApi.Batches.StringTyped._
 
   apiTest("ECHO") {
-    echo("lol").assertEquals("lol")
+    echo(ByteString("lol")).assertEquals(ByteString("lol"))
   }
 
   apiTest("PING") {
@@ -30,7 +31,7 @@ trait ConnectionApiSuite extends RedisConnectionCommandsSuite {
 }
 
 class AuthenticationTest extends RedisConnectionCommandsSuite {
-  override def password = "hassword".opt
+  override def password: Opt[String] = "hassword".opt
 
   import RedisApi.Batches.StringTyped._
 

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/HashesApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/HashesApiSuite.scala
@@ -43,8 +43,8 @@ trait HashesApiSuite extends CommandsSuite {
   }
 
   apiTest("HINCRBYFLOAT") {
-    hincrbyfloat("key", "field", 3.14).assertEquals(3.14)
-    hincrbyfloat("key", "field", -2.0).assertEquals(1.14)
+    hincrbyfloat("key", "field", 3.25).assertEquals(3.25)
+    hincrbyfloat("key", "field", -2.0).assertEquals(1.25)
   }
 
   apiTest("HKEYS") {

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/KeysApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/KeysApiSuite.scala
@@ -180,13 +180,13 @@ trait NodeKeysApiSuite extends KeyedKeysApiSuite {
   }
 
   apiTest("SORT with GET") {
-    sortGet("somelist", Seq(HashFieldPattern("hash", "*")),
+    sortGet("somelist", Seq(FieldPattern("hash", "*")),
       SelfPattern, SortLimit(0, 1), SortOrder.Desc, alpha = true).assert(_.isEmpty)
   }
 
   apiTest("SORT with BY") {
     sort("somelist", by = SelfPattern).assert(_.isEmpty)
     sort("somelist", by = KeyPattern("sth_*")).assert(_.isEmpty)
-    sort("somelist", by = HashFieldPattern("hash_*", "sth_*")).assert(_.isEmpty)
+    sort("somelist", by = FieldPattern("hash_*", "sth_*")).assert(_.isEmpty)
   }
 }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ListsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ListsApiSuite.scala
@@ -142,11 +142,6 @@ trait ListsApiSuite extends CommandsSuite {
     rpushxOrLlen("key", Nil).assertEquals(1)
     lrange("key").assertEquals(Seq("a"))
   }
-}
-
-trait BlockingListsApiSuite extends CommandsSuite {
-
-  import RedisApi.Batches.StringTyped._
 
   apiTest("BLPOP") {
     setup(
@@ -154,10 +149,9 @@ trait BlockingListsApiSuite extends CommandsSuite {
       rpush("{key}1", "a1", "b1"),
       rpush("{key}2", "a2", "b2")
     )
-    blpop("key").assertEquals("a")
+    blpop("key", 1).assertEquals("a".opt)
     blpop("key", 1).assertEquals("b".opt)
     blpop("key", 1).assertEquals(Opt.Empty)
-    blpop("{key}1", "{key}2").assertEquals("{key}1", "a1")
     blpop(List("{key}2", "{key}1"), 1).assertEquals(("{key}2", "a2").opt)
     blpop(List("{???}1", "{???}2"), 1).assertEquals(Opt.Empty)
   }
@@ -168,10 +162,9 @@ trait BlockingListsApiSuite extends CommandsSuite {
       rpush("{key}1", "a1", "b1"),
       rpush("{key}2", "a2", "b2")
     )
-    brpop("key").assertEquals("b")
+    brpop("key", 1).assertEquals("b".opt)
     brpop("key", 1).assertEquals("a".opt)
     brpop("key", 1).assertEquals(Opt.Empty)
-    brpop("{key}1", "{key}2").assertEquals("{key}1", "b1")
     brpop(List("{key}2", "{key}1"), 1).assertEquals(("{key}2", "b2").opt)
     brpop(List("{???}1", "{???}2"), 1).assertEquals(Opt.Empty)
   }
@@ -181,7 +174,7 @@ trait BlockingListsApiSuite extends CommandsSuite {
       rpush("{key}1", "a1", "b1"),
       rpush("{key}2", "a2", "b2")
     )
-    brpoplpush("{key}1", "{key}2").assertEquals("b1")
+    brpoplpush("{key}1", "{key}2", 1).assertEquals("b1".opt)
     brpoplpush("{key}1", "{key}2", 1).assertEquals("a1".opt)
     brpoplpush("{key}1", "{key}2", 1).assertEquals(Opt.Empty)
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ServerApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ServerApiSuite.scala
@@ -107,7 +107,7 @@ trait ServerApiSuite extends CommandsSuite with UsesActorSystem {
     waitForPersistence()
     try save.get catch {
       // ignore spurious Redis failures
-      case e: ErrorReplyException if e.getMessage == "ERR Background save already in progress" =>
+      case e: ErrorReplyException if e.errorStr == "ERR Background save already in progress" =>
     }
   }
 

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ServerApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ServerApiSuite.scala
@@ -29,12 +29,22 @@ trait ServerApiSuite extends CommandsSuite with UsesActorSystem {
     bgrewriteaof.get
   }
 
+  apiTest("CLIENT ID") {
+    clientId.get
+  }
+
   apiTest("CLIENT LIST") {
     waitFor(clientList.exec)(_.nonEmpty, 100.millis).futureValue
   }
 
   apiTest("CLIENT PAUSE") {
     clientPause(10).get
+  }
+
+  apiTest("CLIENT UNBLOCK") {
+    clientUnblock(ClientId(0)).assertEquals(false)
+    clientUnblock(ClientId(0), UnblockModifier.Timeout).assertEquals(false)
+    clientUnblock(ClientId(0), UnblockModifier.Error).assertEquals(false)
   }
 
   apiTest("COMMAND") {

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ServerApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/ServerApiSuite.scala
@@ -115,6 +115,10 @@ trait ServerApiSuite extends CommandsSuite with UsesActorSystem {
     slaveofNoOne.get
   }
 
+  apiTest("REPLICAOF") {
+    replicaofNoOne.get
+  }
+
   apiTest("SLOWLOG GET") {
     slowlogGet.get
     slowlogGet(10).get

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
@@ -3,7 +3,6 @@ package redis.commands
 
 import com.avsystem.commons.redis._
 
-
 trait SortedSetsApiSuite extends CommandsSuite {
 
   import RedisApi.Batches.StringTyped._

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
@@ -77,6 +77,22 @@ trait SortedSetsApiSuite extends CommandsSuite {
     zlexcount("key", LexLimit.incl("a"), LexLimit.excl("c")).assertEquals(2)
   }
 
+  apiTest("ZPOPMAX") {
+    setup(zadd("key", "lol" -> 1.0, "fuu" -> 2.0, "bar" -> 3.0, "fag" -> 4.0))
+    zpopmax("???").assertEquals(Opt.Empty)
+    zpopmax("???", 2).assertEquals(Seq.empty)
+    zpopmax("key").assertEquals(Opt("fag" -> 4.0))
+    zpopmax("key", 2).assertEquals(Seq("bar" -> 3.0, "fuu" -> 2.0))
+  }
+
+  apiTest("ZPOPMIN") {
+    setup(zadd("key", "lol" -> 1.0, "fuu" -> 2.0, "bar" -> 3.0, "fag" -> 4.0))
+    zpopmin("???").assertEquals(Opt.Empty)
+    zpopmin("???", 2).assertEquals(Seq.empty)
+    zpopmin("key").assertEquals(Opt("lol" -> 1.0))
+    zpopmin("key", 2).assertEquals(Seq("fuu" -> 2.0, "bar" -> 3.0))
+  }
+
   apiTest("ZRANGE") {
     setup(zadd("key", "lol" -> 1.0, "fuu" -> 2.0))
     zrange("???").assertEquals(Seq.empty)

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
@@ -260,19 +260,14 @@ trait SortedSetsApiSuite extends CommandsSuite {
     zunionstoreWeights("key", "{key}1" -> 1.0, "{key}2" -> 2.0).assertEquals(3)
     zrangeWithscores("key").assertEquals(Seq("foo" -> 1.0, "bar" -> 8.0, "lol" -> 8.0))
   }
-}
-
-trait BlockingSortedSetsApiSuite extends CommandsSuite {
-
-  import RedisApi.Batches.StringTyped._
 
   apiTest("BZPOPMAX") {
     setup(
       zadd("{key}1", "foo" -> 1.0, "bar" -> 2.0),
       zadd("{key}2", "bar" -> 3.0, "lol" -> 4.0)
     )
-    bzpopmax(1, "???").assertEquals(Opt.Empty)
-    bzpopmax(1, "{key}0", "{key}1", "{key}2").assertEquals(Opt("{key}1", "bar", 2.0))
+    bzpopmax("???", 1).assertEquals(Opt.Empty)
+    bzpopmax(List("{key}0", "{key}1", "{key}2"), 1).assertEquals(Opt("{key}1", "bar", 2.0))
   }
 
   apiTest("BZPOPMIN") {
@@ -280,7 +275,7 @@ trait BlockingSortedSetsApiSuite extends CommandsSuite {
       zadd("{key}1", "foo" -> 1.0, "bar" -> 2.0),
       zadd("{key}2", "bar" -> 3.0, "lol" -> 4.0)
     )
-    bzpopmin(1, "???").assertEquals(Opt.Empty)
-    bzpopmin(1, "{key}0", "{key}1", "{key}2").assertEquals(Opt("{key}1", "foo", 1.0))
+    bzpopmin("???", 1).assertEquals(Opt.Empty)
+    bzpopmin(List("{key}0", "{key}1", "{key}2"), 1).assertEquals(Opt("{key}1", "foo", 1.0))
   }
 }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/SortedSetsApiSuite.scala
@@ -261,3 +261,26 @@ trait SortedSetsApiSuite extends CommandsSuite {
     zrangeWithscores("key").assertEquals(Seq("foo" -> 1.0, "bar" -> 8.0, "lol" -> 8.0))
   }
 }
+
+trait BlockingSortedSetsApiSuite extends CommandsSuite {
+
+  import RedisApi.Batches.StringTyped._
+
+  apiTest("BZPOPMAX") {
+    setup(
+      zadd("{key}1", "foo" -> 1.0, "bar" -> 2.0),
+      zadd("{key}2", "bar" -> 3.0, "lol" -> 4.0)
+    )
+    bzpopmax(1, "???").assertEquals(Opt.Empty)
+    bzpopmax(1, "{key}0", "{key}1", "{key}2").assertEquals(Opt("{key}1", "bar", 2.0))
+  }
+
+  apiTest("BZPOPMIN") {
+    setup(
+      zadd("{key}1", "foo" -> 1.0, "bar" -> 2.0),
+      zadd("{key}2", "bar" -> 3.0, "lol" -> 4.0)
+    )
+    bzpopmin(1, "???").assertEquals(Opt.Empty)
+    bzpopmin(1, "{key}0", "{key}1", "{key}2").assertEquals(Opt("{key}1", "foo", 1.0))
+  }
+}

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
@@ -9,7 +9,7 @@ trait StreamsApiSuite extends CommandsSuite {
 
   def id(i: Int): XEntryId = XEntryId(0, i.toLong)
   def ids(from: Int, to: Int): Seq[XEntryId] = (from to to).map(id)
-  def entry(i: Int): Entry = Entry(id(i), Map("f" -> s"v$i"))
+  def entry(i: Int): Entry = Entry(id(i), List("f" -> s"v$i"))
   def entries(from: Int, to: Int): Seq[Entry] = (from to to).map(entry)
 
   apiTest("XACK") {
@@ -30,7 +30,7 @@ trait StreamsApiSuite extends CommandsSuite {
     xlen("key").assertEquals(2)
     xadd("key", List("f1" -> "v1", "f2" -> "v2"), lastId.inc, XMaxlen(1)).assertEquals(lastId.inc)
     xlen("key").assert(_ >= 1)
-    val entry = XEntry(lastId.inc.inc, Map("f1" -> "v1", "f2" -> "v2"))
+    val entry = XEntry(lastId.inc.inc, List("f1" -> "v1", "f2" -> "v2"))
     xaddEntry("key", entry, XMaxlen(1, approx = false)).assertEquals(lastId.inc.inc)
     xlen("key").assertEquals(1)
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
@@ -1,0 +1,192 @@
+package com.avsystem.commons
+package redis.commands
+
+import com.avsystem.commons.redis.{CommandsSuite, RedisApi, RedisBatch}
+
+trait StreamsApiSuite extends CommandsSuite {
+
+  import RedisApi.Batches.StringTyped.{XEntry => Entry, _}
+
+  def id(i: Int): XEntryId = XEntryId(0, i.toLong)
+  def ids(from: Int, to: Int): Seq[XEntryId] = (from to to).map(id)
+  def entry(i: Int): Entry = Entry(id(i), Map("f" -> s"v$i"))
+  def entries(from: Int, to: Int): Seq[Entry] = (from to to).map(entry)
+
+  apiTest("XACK") {
+    setup(
+      xgroupCreate("key", XGroup("g"), mkstream = true),
+      RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))),
+      xreadgroupSingle("key", XGroup("g"), XConsumer("c"))
+    )
+    xack("key", XGroup("g"), id(1)).assertEquals(true)
+    xack("key", XGroup("g"), id(1)).assertEquals(false)
+    xack("key", XGroup("g"), id(1), id(2), id(3)).assertEquals(2)
+    xack("key", XGroup("g"), (1 to 10).map(id)).assertEquals(7)
+  }
+
+  apiTest("XADD") {
+    xadd("key", "f" -> "v").get
+    val lastId = xadd("key", "f1" -> "v1", "f2" -> "v2").get
+    xlen("key").assertEquals(2)
+    xadd("key", List("f1" -> "v1", "f2" -> "v2"), lastId.inc, XMaxlen(1)).assertEquals(lastId.inc)
+    xlen("key").assert(_ >= 1)
+    val entry = XEntry(lastId.inc.inc, Map("f1" -> "v1", "f2" -> "v2"))
+    xaddEntry("key", entry, XMaxlen(1, approx = false)).assertEquals(lastId.inc.inc)
+    xlen("key").assertEquals(1)
+  }
+
+  apiTest("XCLAIM") {
+    setup(
+      xgroupCreate("key", XGroup("g"), mkstream = true),
+      RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))),
+      xreadgroupSingle("key", XGroup("g"), XConsumer("c1"), count = 5)
+    )
+    // nonexistent id
+    xclaimSingle("key", XGroup("g"), XConsumer("c1"), 0, id(0)).assertEquals(Opt.Empty)
+    // existing id already claimed by self
+    xclaimSingle("key", XGroup("g"), XConsumer("c1"), 0, id(1)).assertEquals(Opt(entry(1)))
+    // existing id claimed by someone else
+    xclaimSingle("key", XGroup("g"), XConsumer("c2"), 0, id(1)).assertEquals(Opt(entry(1)))
+    // maxIdleTime not exceeded
+    xclaimSingle("key", XGroup("g"), XConsumer("c1"), 5000, id(1)).assertEquals(Opt.Empty)
+    // force set maxIdleTime and claim again
+    xclaimSingle("key", XGroup("g"), XConsumer("c1"), 0, id(1), idleMillis = 10000).assertEquals(Opt(entry(1)))
+    xclaimSingle("key", XGroup("g"), XConsumer("c2"), 5000, id(1)).assertEquals(Opt(entry(1)))
+    // force set msUnixTime and claim again
+    xclaimSingle("key", XGroup("g"), XConsumer("c2"), 0, id(1), msUnixTime = 0).assertEquals(Opt(entry(1)))
+    xclaimSingle("key", XGroup("g"), XConsumer("c1"), 5000, id(1)).assertEquals(Opt(entry(1)))
+    // retrycount
+    xclaimSingle("key", XGroup("g"), XConsumer("c2"), 0, id(1), retrycount = 42).assertEquals(Opt(entry(1)))
+    xpendingEntries("key", XGroup("g"), 1, id(1)).assert(_.headOpt.exists(_.deliveredCount == 42))
+    // unclaimed id
+    xclaimSingle("key", XGroup("g"), XConsumer("c1"), 0, id(6)).assertEquals(Opt.Empty)
+    xclaimSingle("key", XGroup("g"), XConsumer("c2"), 0, id(6), force = true).assertEquals(Opt(entry(6)))
+    // multiple ids
+    xclaim("key", XGroup("g"), XConsumer("c1"), 0, ids(1, 10)).assertEquals(entries(1, 6))
+    xclaimJustid("key", XGroup("g"), XConsumer("c1"), 0, ids(1, 10)).assertEquals(ids(1, 6))
+    xclaimJustid("key", XGroup("g"), XConsumer("c1"), 0, ids(1, 10), force = true).assertEquals(ids(1, 10))
+  }
+
+  apiTest("XDEL") {
+    setup(RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))))
+    xdel("key", id(0)).assertEquals(false)
+    xdel("key", id(1)).assertEquals(true)
+    xdel("key", id(1), id(2), id(3)).assertEquals(2)
+    xdel("key", ids(1, 10)).assertEquals(7)
+  }
+
+  apiTest("XGROUP") {
+    xgroupCreate("key", XGroup("g1"), mkstream = true).get
+    xgroupCreate("key", XGroup("g2"), id(1)).get
+    xgroupSetid("key", XGroup("g2"), id(2)).get
+    xgroupDestroy("key", XGroup("g1")).assertEquals(true)
+    xgroupDestroy("key", XGroup("g3")).assertEquals(false)
+    xgroupDelconsumer("key", XGroup("g2"), XConsumer("c")).assertEquals(false)
+    xaddEntry("key", entry(3)).get
+    xreadgroupSingle("key", XGroup("g2"), XConsumer("c")).get
+    xgroupDelconsumer("key", XGroup("g2"), XConsumer("c")).assertEquals(true)
+  }
+
+  apiTest("XINFO STREAM") {
+    setup(
+      xaddEntry("key", entry(1)),
+      xgroupCreate("key", XGroup("g"))
+    )
+    val xsi = xinfoStream("key").get
+    assert(xsi.length == 1)
+    assert(xsi.groups == 1)
+    assert(xsi.firstEntry == entry(1))
+    assert(xsi.lastEntry == entry(1))
+    assert(xsi.lastGeneratedId == id(1))
+  }
+
+  apiTest("XINFO GROUPS") {
+    setup(xgroupCreate("key", XGroup("g"), mkstream = true))
+    val Seq(xgi) = xinfoGroups("key").get
+    assert(xgi.name == XGroup("g"))
+    assert(xgi.consumers == 0)
+    assert(xgi.pending == 0)
+    assert(xgi.lastDeliveredId == id(0))
+  }
+
+  apiTest("XINFO CONSUMERS") {
+    setup(
+      xgroupCreate("key", XGroup("g"), mkstream = true),
+      xaddEntry("key", entry(1)),
+      xreadgroupSingle("key", XGroup("g"), XConsumer("c"))
+    )
+    val Seq(xci) = xinfoConsumers("key", XGroup("g")).get
+    assert(xci.name == XConsumer("c"))
+    assert(xci.pending == 1)
+  }
+
+  apiTest("XLEN") {
+    setup(RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))))
+    xlen("key").assertEquals(10)
+  }
+
+  apiTest("XPENDING") {
+    setup(
+      xgroupCreate("key", XGroup("g"), mkstream = true),
+      RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))),
+      xreadgroupSingle("key", XGroup("g"), XConsumer("c"))
+    )
+    xpending("key", XGroup("g")).assertEquals(XPendingOverview(10, id(1), id(10), Map(XConsumer("c") -> 10)))
+    val Seq(xpe) = xpendingEntries("key", XGroup("g"), 1).get
+    assert(xpe.id == id(1))
+    assert(xpe.consumer == XConsumer("c"))
+    assert(xpe.deliveredCount == 1)
+    xpendingEntries("key", XGroup("g"), 5, id(3), id(9), XConsumer("c")).map(_.map(_.id)).assertEquals(ids(3, 7))
+    xpendingEntries("key", XGroup("g"), 5, id(3), id(9), XConsumer("c2")).assertEquals(Seq.empty)
+  }
+
+  apiTest("XRANGE") {
+    setup(RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))))
+    xrange("key").assertEquals(entries(1, 10))
+    xrange("key", start = id(3)).assertEquals(entries(3, 10))
+    xrange("key", end = id(3)).assertEquals(entries(1, 3))
+    xrange("key", start = id(3), end = id(7)).assertEquals(entries(3, 7))
+    xrange("key", start = id(3), end = id(7), count = 2).assertEquals(entries(3, 4))
+  }
+
+  apiTest("XREAD") {
+    setup(RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))))
+    xreadSingle("key", Opt.Empty).assertEquals(Seq.empty)
+    xreadSingle("key", id(0).opt).assertEquals(entries(1, 10))
+    xreadSingle("key", id(5).opt).assertEquals(entries(6, 10))
+    xreadSingle("key", id(5).opt, count = 2).assertEquals(entries(6, 7))
+    xreadSingle("key", Opt.Empty, blockMillis = 10).assertEquals(Seq.empty)
+    xread(List("key" -> id(0).opt)).assertEquals(Map("key" -> entries(1, 10)))
+  }
+
+  apiTest("XREADGROUP") {
+    setup(
+      xgroupCreate("key", XGroup("g"), mkstream = true),
+      RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i)))
+    )
+    xreadgroupSingle("key", XGroup("g"), XConsumer("c"), count = 5).assertEquals(entries(1, 5))
+    xreadgroupSingle("key", XGroup("g"), XConsumer("c")).assertEquals(entries(6, 10))
+    xreadgroupSingle("key", XGroup("g"), XConsumer("c")).assertEquals(Seq.empty)
+    xreadgroupSingle("key", XGroup("g"), XConsumer("c"), id(5)).assertEquals(entries(6, 10))
+    xreadgroupSingle("key", XGroup("g"), XConsumer("c"), id(5), count = 10, blockMillis = 1000).assertEquals(entries(6, 10))
+    xreadgroupSingle("key", XGroup("g"), XConsumer("c"), blockMillis = 10).assertEquals(Seq.empty)
+    xreadgroup(XGroup("g"), XConsumer("c"), List("key" -> id(5).opt)).assertEquals(Map("key" -> entries(6, 10)))
+  }
+
+  apiTest("XREVRANGE") {
+    setup(RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))))
+    xrevrange("key").assertEquals(entries(1, 10).reverse)
+    xrevrange("key", start = id(3)).assertEquals(entries(3, 10).reverse)
+    xrevrange("key", end = id(3)).assertEquals(entries(1, 3).reverse)
+    xrevrange("key", end = id(7), start = id(3)).assertEquals(entries(3, 7).reverse)
+    xrevrange("key", end = id(7), start = id(3), count = 2).assertEquals(entries(6, 7).reverse)
+  }
+
+  apiTest("XTRIM") {
+    setup(RedisBatch.traverse(1 to 10)(i => xaddEntry("key", entry(i))))
+    xtrim("key", 5, approx = false).assertEquals(5)
+    xtrim("key", 4).assertEquals(0)
+    xtrim("key", XMaxlen(4)).assertEquals(0)
+    xtrim("key", XMaxlen(4, approx = false)).assertEquals(1)
+  }
+}

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
@@ -9,7 +9,7 @@ trait StreamsApiSuite extends CommandsSuite {
 
   def id(i: Int): XEntryId = XEntryId(0, i.toLong)
   def ids(from: Int, to: Int): Seq[XEntryId] = (from to to).map(id)
-  def entry(i: Int): Entry = Entry(id(i), List("f" -> s"v$i"))
+  def entry(i: Int): Entry = Entry(id(i), Map("f" -> s"v$i"))
   def entries(from: Int, to: Int): Seq[Entry] = (from to to).map(entry)
 
   apiTest("XACK") {
@@ -25,12 +25,12 @@ trait StreamsApiSuite extends CommandsSuite {
   }
 
   apiTest("XADD") {
-    xadd("key", "f" -> "v").get
-    val lastId = xadd("key", "f1" -> "v1", "f2" -> "v2").get
+    xadd("key", Map("f" -> "v")).get
+    val lastId = xadd("key", Map("f1" -> "v1", "f2" -> "v2")).get
     xlen("key").assertEquals(2)
-    xadd("key", List("f1" -> "v1", "f2" -> "v2"), lastId.inc, XMaxlen(1)).assertEquals(lastId.inc)
+    xadd("key", Map("f1" -> "v1", "f2" -> "v2"), lastId.inc, XMaxlen(1)).assertEquals(lastId.inc)
     xlen("key").assert(_ >= 1)
-    val entry = XEntry(lastId.inc.inc, List("f1" -> "v1", "f2" -> "v2"))
+    val entry = XEntry(lastId.inc.inc, Map("f1" -> "v1", "f2" -> "v2"))
     xaddEntry("key", entry, XMaxlen(1, approx = false)).assertEquals(lastId.inc.inc)
     xlen("key").assertEquals(1)
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala
@@ -1,15 +1,22 @@
 package com.avsystem.commons
 package redis.commands
 
+import com.avsystem.commons.redis.RedisApi.Batches
 import com.avsystem.commons.redis.{CommandsSuite, RedisApi, RedisBatch}
+import com.avsystem.commons.serialization.HasApplyUnapplyCodec
+
+case class Event(idx: Int, data: String)
+object Event extends HasApplyUnapplyCodec[Event]
 
 trait StreamsApiSuite extends CommandsSuite {
 
-  import RedisApi.Batches.StringTyped.{XEntry => Entry, _}
+  val api: Batches.StringTyped.WithRecord[Event] = RedisApi.Batches.StringTyped.recordType[Event]
+
+  import api.{XEntry => Entry, _}
 
   def id(i: Int): XEntryId = XEntryId(0, i.toLong)
   def ids(from: Int, to: Int): Seq[XEntryId] = (from to to).map(id)
-  def entry(i: Int): Entry = Entry(id(i), Map("f" -> s"v$i"))
+  def entry(i: Int): Entry = Entry(id(i), Event(i, s"value$i"))
   def entries(from: Int, to: Int): Seq[Entry] = (from to to).map(entry)
 
   apiTest("XACK") {
@@ -25,12 +32,12 @@ trait StreamsApiSuite extends CommandsSuite {
   }
 
   apiTest("XADD") {
-    xadd("key", Map("f" -> "v")).get
-    val lastId = xadd("key", Map("f1" -> "v1", "f2" -> "v2")).get
+    xadd("key", Event(42, "fuu")).get
+    val lastId = xadd("key", Event(42, "fag")).get
     xlen("key").assertEquals(2)
-    xadd("key", Map("f1" -> "v1", "f2" -> "v2"), lastId.inc, XMaxlen(1)).assertEquals(lastId.inc)
+    xadd("key", Event(42, "lel"), lastId.inc, XMaxlen(1)).assertEquals(lastId.inc)
     xlen("key").assert(_ >= 1)
-    val entry = XEntry(lastId.inc.inc, Map("f1" -> "v1", "f2" -> "v2"))
+    val entry = XEntry(lastId.inc.inc, Event(42, "dafuq"))
     xaddEntry("key", entry, XMaxlen(1, approx = false)).assertEquals(lastId.inc.inc)
     xlen("key").assertEquals(1)
   }

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/commandSuites.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/commandSuites.scala
@@ -15,6 +15,7 @@ trait KeyedFullApiSuite extends CommandsSuite
   with ListsApiSuite
   with SetsApiSuite
   with HyperLogLogApiSuite
+  with StreamsApiSuite
 
 trait NodeFullApiSuite extends KeyedFullApiSuite
   with NodeKeysApiSuite

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/commandSuites.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/commandSuites.scala
@@ -24,6 +24,7 @@ trait NodeFullApiSuite extends KeyedFullApiSuite
 trait ConnectionFullApiSuite extends NodeFullApiSuite
   with ConnectionScriptingApiSuite
   with BlockingListsApiSuite
+  with BlockingSortedSetsApiSuite
 
 class RedisClusterCommandsTest extends RedisClusterCommandsSuite with KeyedFullApiSuite
 class RedisNodeCommandsTest extends RedisNodeCommandsSuite with NodeFullApiSuite

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/commandSuites.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/commandSuites.scala
@@ -23,8 +23,6 @@ trait NodeFullApiSuite extends KeyedFullApiSuite
 
 trait ConnectionFullApiSuite extends NodeFullApiSuite
   with ConnectionScriptingApiSuite
-  with BlockingListsApiSuite
-  with BlockingSortedSetsApiSuite
 
 class RedisClusterCommandsTest extends RedisClusterCommandsSuite with KeyedFullApiSuite
 class RedisNodeCommandsTest extends RedisNodeCommandsSuite with NodeFullApiSuite

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ApiCustomizationExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ApiCustomizationExample.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.{ByteString, Timeout}
+import akka.util.ByteString
 import com.avsystem.commons.redis._
 import com.avsystem.commons.serialization.GenCodec
 
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
   * to represent keys, hash keys and values in Redis commands.
   */
 object ApiCustomizationExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   val client = new RedisNodeClient
   // By default, the driver provides textual and binary API variants, e.g.
@@ -38,7 +38,7 @@ object ApiCustomizationExample extends App {
     implicit val codec: GenCodec[Person] = GenCodec.materialize[Person]
   }
 
-  val personApi = new RedisApi.Node.Async[String, String, Person](client)
+  val personApi = new RedisApi.Node.Async[String, String, Person, Map[String, String]](client)
 
   def storePerson(person: Person): Future[Boolean] =
     personApi.set(person.name, person)

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ApiCustomizationExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ApiCustomizationExample.scala
@@ -38,7 +38,7 @@ object ApiCustomizationExample extends App {
     implicit val codec: GenCodec[Person] = GenCodec.materialize[Person]
   }
 
-  val personApi = new RedisApi.Node.Async[String, String, Person, Map[String, String]](client)
+  val personApi = RedisApi.Node.Async.StringTyped(client).valueType[Person]
 
   def storePerson(person: Person): Future[Boolean] =
     personApi.set(person.name, person)

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ClusterClientExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ClusterClientExample.scala
@@ -2,9 +2,10 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -12,7 +13,7 @@ import scala.concurrent.duration._
   * Basic example showing how to execute simple command on [[RedisClusterClient]].
   */
 object ClusterClientExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   // The cluster client asks seed nodes about cluster state (by default local Redis instance is the only seed node)
   // and then uses separate RedisNodeClients to connect individually to every master mentioned in cluster state

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ConnectionClientExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ConnectionClientExample.scala
@@ -2,9 +2,10 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -12,7 +13,7 @@ import scala.concurrent.duration._
   * Basic example showing how to execute simple command on [[RedisConnectionClient]].
   */
 object ConnectionClientExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   // Connection client only uses a single, non-reconnectable connection
   val client = new RedisConnectionClient

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ConnectionSetupExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/ConnectionSetupExample.scala
@@ -2,10 +2,11 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.config._
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -14,7 +15,7 @@ import scala.concurrent.duration._
   * are properly initialized, e.g. authentication is performed.
   */
 object ConnectionSetupExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   // In order to authenticate to Redis, every connection must send an AUTH command upon initializing.
   // We can specify "initialization commands" for a connection in ConnectionConfig:

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/MultiExecExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/MultiExecExample.scala
@@ -2,9 +2,10 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -13,7 +14,7 @@ import scala.concurrent.duration._
   * and `WATCH` command, see [[TransactionExample]].
   */
 object MultiExecExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   // Executing MULTI-EXEC blocks (without WATCH) is very similar to pipelining.
   // See PipeliningExample for more details.

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/NodeClientExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/NodeClientExample.scala
@@ -2,9 +2,10 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -13,7 +14,7 @@ import scala.concurrent.duration._
   */
 object NodeClientExample extends App {
   // The driver is implemented using Akka IO, so we need actor system
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
   // The client is the object that actually talks to Redis, but does not expose Redis API
   val client = new RedisNodeClient
   // API object exposes API to access individual Redis commands. The API variant we're using here is:

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/PipeliningExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/PipeliningExample.scala
@@ -2,9 +2,10 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -12,7 +13,7 @@ import scala.concurrent.duration._
   * Examples showing how to create and execute batches made of multiple Redis commands.
   */
 object PipeliningExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   // Pipelining is a technique in which multiple Redis commands are sent to server at once, without one command
   // waiting for previous one to finish. This allows sending multiple commands in a single network message, which

--- a/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/TransactionExample.scala
+++ b/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/TransactionExample.scala
@@ -2,10 +2,11 @@ package com.avsystem.commons
 package redis.examples
 
 import akka.actor.ActorSystem
-import akka.util.Timeout
 import com.avsystem.commons.redis._
 import com.avsystem.commons.redis.exception.{NodeRemovedException, OptimisticLockException}
 
+// Global execution context is used for the sake of simplicity of this example,
+// think well if this is what you actually want.
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
@@ -15,7 +16,7 @@ import scala.concurrent.duration._
   * `MULTI`-`EXEC` block (without optimistic locking), see [[PipeliningExample]] and [[MultiExecExample]].
   */
 object TransactionExample extends App {
-  implicit val actorSystem = ActorSystem()
+  implicit val actorSystem: ActorSystem = ActorSystem()
 
   // In order to execute Redis transaction with optimistic locking, one must execute at least two batches of
   // commands and ensure that they're all executed on the same Redis connection which is exclusively reserved
@@ -30,7 +31,7 @@ object TransactionExample extends App {
   val api = RedisApi.Batches.StringTyped.valueType[Int]
   // a transaction with optimistic locking which multiplies numeric value under key "key" by 3
   val transaction: RedisOp[Unit] = for {
-  // we send WATCH and GET commands in the same batch
+    // we send WATCH and GET commands in the same batch
     value <- api.watch("key") *> api.get("key").map(_.getOrElse(1))
     // SET command is wrapped in a MULTI-EXEC block
     _ <- api.set("key", value * 3).transaction

--- a/docs/RedisDriver.md
+++ b/docs/RedisDriver.md
@@ -2,11 +2,13 @@
 
 `commons-redis` - Scala driver for Redis
 
-**[API reference](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/redis/index.html)**
-
 ```scala
 libraryDependencies += "com.avsystem.commons" %% "commons-redis" % avsCommonsVersion
 ```
+
+**[API reference](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/redis/index.html)**
+
+**[Quickstart example](https://github.com/AVSystem/scala-commons/blob/master/commons-redis/src/test/scala/com/avsystem/commons/redis/examples/NodeClientExample.scala)**
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/docs/RedisDriver.md
+++ b/docs/RedisDriver.md
@@ -36,7 +36,7 @@ and characteristics are:
 * good performance
 
 Features: 
-* Redis 3.2 API support (except for pub/sub API and some unsafe or debugging commands like `MONITOR`)
+* Redis 5 API support, excluding pub/sub, `MEMORY` commands and some unsafe/debugging commands like `MONITOR`.
 * three client implementations: for single connection ([`RedisConnectionClient`](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/redis/RedisConnectionClient.html)), 
   connection pool to a single node ([`RedisNodeClient`](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/redis/RedisNodeClient.html)) 
   and for Redis Cluster ([`RedisClusterClient`](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/redis/RedisClusterClient.html)), 

--- a/docs/RedisDriver.md
+++ b/docs/RedisDriver.md
@@ -133,9 +133,9 @@ you are using. They can differ in following ways:
   method directly (without wrapping into a `Future`). There are also API variants which return command results as 
   "unexecuted" [`RedisBatch`](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/redis/RedisBatch.html) 
   objects that need to be manually passed to the client for execution.
-* representation of keys, hash keys and values
+* representation of keys, hash fields, values and records
 
-  Redis internally stores keys, hash keys and data as arbitrary byte sequences, but on Scala level we don't usually want
+  Redis internally stores keys, has fields and data as arbitrary byte sequences, but on Scala level we don't usually want
   to deal with raw binary data. Therefore, the driver allows you to use any types as long as you specify how they are 
   serialized to binary form. Every API object is bound to particular key type, hash key type and value type.
   


### PR DESCRIPTION
* Blocking commands (e.g. `BLPOP`) can now be executed by `RedisNodeClient` and `RedisClusterClient` - previously they could only be executed on `RedisConnectionClient`.
  In order to support that, every `RedisNodeClient` now maintains a [separate connection pool](https://github.com/AVSystem/scala-commons/blob/redis5/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala#L48) dedicated for blocking commands. Each blocking command reserves the connection until it's finished so that multiple concurrent blocking commands can be executed without waiting on each other to finish. Connections in the blocking pool are allocated as needed and reclaimed after a configurable period of being idle. `NodeConfig` is equipped with new options to control blocking connection pool.
* New sorted set commands: `ZPOPMIN`, `ZPOPMAX`, `BZPOPMIN`, `BZPOPMAX`
* New server commands: `CLIENT ID`, `CLIENT UNBLOCK`, `REPLICAOF` (political correctness)
* `HashKey` type member of `RedisApiSubset` renamed to `Field` so that it can serve both as the type of hash fields and stream entry fields.
* [Streams API](https://github.com/AVSystem/scala-commons/blob/redis5/commons-redis/src/main/scala/com/avsystem/commons/redis/commands/streams.scala) and a [test suite](https://github.com/AVSystem/scala-commons/blob/redis5/commons-redis/src/test/scala/com/avsystem/commons/redis/commands/StreamsApiSuite.scala) which is also a good demonstration of the API.
* Handling cluster `TRYAGAIN` errors by backing out and retrying after a delay.
* New, composable `RetryStrategy` - used for reconnecting, redirection handling and `TRYAGAIN` handling