### PR TITLE
Fix of serialization and parsing of floats to/from JSON + more efficient implementation of indention during JSON serialization

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -674,19 +674,18 @@ object SharedExtensions extends SharedExtensions {
         private[this] val seen = new MHashSet[B]
         private[this] var nextDistinct = NOpt.empty[A]
 
-        @tailrec
-        override final def hasNext: Boolean = nextDistinct.nonEmpty || it.hasNext && {
+        @tailrec override final def hasNext: Boolean = nextDistinct.nonEmpty || it.hasNext && {
           nextDistinct = NOpt.some(it.next()).filter(a => seen.add(f(a)))
           hasNext
         }
 
-        override def next(): A =
+        override def next(): A = {
           if (hasNext) {
             val result = nextDistinct.get
             nextDistinct = NOpt.Empty
             result
-          }
-          else throw new NoSuchElementException
+          } else throw new NoSuchElementException
+        }
       }
 
     def distinct: Iterator[A] = distinctBy(identity)

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -59,6 +59,7 @@ class JsonStringInput(reader: JsonReader, options: JsonOptions = JsonOptions.Def
   def readBoolean(): Boolean = checkedValue[Boolean](JsonType.boolean)
   def readInt(): Int = matchNumericString(_.toInt)
   def readLong(): Long = matchNumericString(_.toLong)
+  override def readFloat(): Float = matchNumericString(_.toFloat)
   def readDouble(): Double = matchNumericString(_.toDouble)
   def readBigInt(): BigInt = matchNumericString(BigInt(_))
   def readBigDecimal(): BigDecimal = matchNumericString(BigDecimal(_, options.mathContext))

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
@@ -70,9 +70,14 @@ class JsonStringInputOutputTest extends FunSuite with SerializationTestUtils wit
 
   roundtrip("longs")(Int.MaxValue.toLong + 1, Long.MinValue, -783868188, 0, 783868188, Long.MaxValue)
 
+  roundtrip("floats")(
+    Float.MinPositiveValue, Float.MinValue, -1.75047014E9f, Float.MaxValue, Float.PositiveInfinity, Float.NegativeInfinity
+  )
+
   roundtrip("doubles")(
     Double.MinPositiveValue, Double.MinValue, -1.750470182E9, Double.MaxValue, Double.PositiveInfinity, Double.NegativeInfinity
   )
+
   roundtrip("booleans")(false, true)
 
   roundtrip("strings")("", "a።bc\u0676ąቢść➔Ĳ")
@@ -139,12 +144,8 @@ class JsonStringInputOutputTest extends FunSuite with SerializationTestUtils wit
   }
 
   test("NaN") {
-    val value = Double.NaN
-
-    val serialized = write(value)
-    val deserialized = read[Double](serialized)
-
-    assert(java.lang.Double.isNaN(deserialized))
+    assert(java.lang.Float.isNaN(read[Float](write(Float.NaN))))
+    assert(java.lang.Double.isNaN(read[Double](write(Double.NaN))))
   }
 
   test("scientific") {
@@ -154,6 +155,16 @@ class JsonStringInputOutputTest extends FunSuite with SerializationTestUtils wit
     val deserialized = serialized.map(read[Double](_))
 
     deserialized should contain only value
+  }
+
+  test("deserialize floats precisely") {
+    val values = Seq("1.199999988079071", "3.4028235677973366E38", "7.006492321624086E-46")
+    assert(values.map(read[Float](_)) == values.map(_.toFloat))
+  }
+
+  test("serialize floats succinctly") {
+    val values = Seq(1.1999999f, 3.4E38f, 1.4E-45f)
+    assert(values.map(write[Float](_)) == values.map(_.toString))
   }
 
   test("serialize and deserialize nested case classes") {


### PR DESCRIPTION
Currently most floats are stored and parsed as doubles:

https://github.com/AVSystem/scala-commons/blob/fed6f314f62cc817b1b32f95d555d6905d6f4f8b/commons-core/src/main/scala/com/avsystem/commons/serialization/InputOutput.scala#L87

https://github.com/AVSystem/scala-commons/blob/fed6f314f62cc817b1b32f95d555d6905d6f4f8b/commons-core/src/main/scala/com/avsystem/commons/serialization/InputOutput.scala#L229

It leads to wasting space and rounding errors.

This PR aim to fix that for JSON representation.

Also, binary representation should be fixed too, but it can require migration of already stored data or pairs of online counterparties where binary representation was used.