### PR TITLE
Improve travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ sudo: false
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.coursier/cache
-    - $HOME/.sbt/boot/
-    - $HOME/.sbt/launchers/
+    - $HOME/.cache
+    - $HOME/.sbt
     - redis-$REDIS_VERSION
 
 before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt -name "*.lock" -delete
 


### PR DESCRIPTION
* coursier switched to using .cache/coursier
* .sbt can be cached as a whole
* remove sbt Ivy lock before caching