### PR TITLE
Codecs now have an ability to declare list or object size explicitly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ val previousCompatibleVersions = Set("1.34.8")
 
 val commonSettings = Seq(
   organization := "com.avsystem.commons",
-  crossScalaVersions := Seq("2.13.0", "2.12.8"),
+  crossScalaVersions := Seq("2.12.8", "2.13.0"),
   scalaVersion := crossScalaVersions.value.head,
   compileOrder := CompileOrder.Mixed,
   scalacOptions ++= Seq(

--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -521,7 +521,11 @@ object SharedExtensionsUtils extends SharedExtensions {
       * In Scala 2.13 this extension method is always be hidden by an actual method available on `IterableOnce`.
       */
     def knownSize: Int = coll match {
+      case c: BIterable[_] if c.isEmpty => 0
       case is: BIndexedSeq[_] => is.size
+      case _: IListMap[_, _] => -1
+      case m: BMap[_, _] => m.size
+      case s: BSet[_] => s.size
       case _ => -1
     }
 

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/DefaultCaseObjectInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/DefaultCaseObjectInput.scala
@@ -6,6 +6,8 @@ import com.avsystem.commons.serialization.GenCodec.ReadFailure
 final class DefaultCaseObjectInput(firstField: FieldInput, actualInput: ObjectInput, caseFieldName: String)
   extends ObjectInput {
 
+  override def knownSize: Int = actualInput.knownSize
+
   private[this] var atFirstField = true
 
   def hasNext: Boolean = atFirstField || actualInput.hasNext

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/GenCodec.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/GenCodec.scala
@@ -360,9 +360,7 @@ object GenCodec extends RecursiveAutoCodecs with TupleGenCodecs {
     o.sizePolicy match {
       case SizePolicy.Ignored =>
       case SizePolicy.Optional =>
-        if (coll.isEmpty) {
-          o.declareSize(0)
-        } else coll.knownSize match {
+        coll.knownSize match {
           case -1 =>
           case size => o.declareSize(size)
         }

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/GenCodec.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/GenCodec.scala
@@ -263,7 +263,7 @@ object GenCodec extends RecursiveAutoCodecs with TupleGenCodecs {
     def size(value: T): Int
 
     protected final def declareSizeFor(output: ObjectOutput, value: T): Unit =
-      if (output.sizePolicy != SizePolicy.Never) {
+      if (output.sizePolicy != SizePolicy.Ignored) {
         output.declareSize(size(value))
       }
 
@@ -358,15 +358,15 @@ object GenCodec extends RecursiveAutoCodecs with TupleGenCodecs {
 
   private def declareSize(o: SequentialOutput, coll: BIterable[_]): Unit =
     o.sizePolicy match {
-      case SizePolicy.Never =>
-      case SizePolicy.WhenCheap =>
+      case SizePolicy.Ignored =>
+      case SizePolicy.Optional =>
         if (coll.isEmpty) {
           o.declareSize(0)
         } else coll.knownSize match {
           case -1 =>
           case size => o.declareSize(size)
         }
-      case SizePolicy.Always =>
+      case SizePolicy.Required =>
         o.declareSize(coll.size)
     }
 

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/InputOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/InputOutput.scala
@@ -110,9 +110,9 @@ object SizePolicy extends AbstractValueEnumCompanion[SizePolicy] {
 trait SequentialOutput extends Any {
   /**
     * Gives the output explicit information about the number of elements or fields that will be written to this
-    * output by the codec. This method must be called only once, before any elements or fields have been written.
+    * output by the codec. This method must be called at most once, before any elements or fields have been written.
     * The codec is then required to write exactly the declared number of elements or fields.
-    * Whether the codec should or must call this method depends on [[sizePolicy]].
+    * Whether the codec should or must call this method depends on [[sizePolicy]] and the cost of computing the size.
     */
   def declareSize(size: Int): Unit = ()
 

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/PeekingObjectInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/PeekingObjectInput.scala
@@ -7,6 +7,8 @@ package serialization
 final class PeekingObjectInput(original: ObjectInput) extends ObjectInput {
   private[this] var peekedField: FieldInput = _
 
+  override def knownSize: Int = original.knownSize
+
   def peekNextFieldName: Opt[String] = peekedField match {
     case null if original.hasNext =>
       peekedField = original.nextField()

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/SimpleValueInputOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/SimpleValueInputOutput.scala
@@ -63,12 +63,14 @@ class SimpleValueOutput(
 
   def writeList(): ListOutput = new ListOutput {
     private val buffer = newListRepr
+    override def declareSize(size: Int): Unit = buffer.sizeHint(size)
     def writeElement() = new SimpleValueOutput(buffer += _, newObjectRepr, newListRepr)
     def finish(): Unit = consumer(buffer.result())
   }
 
   def writeObject(): ObjectOutput = new ObjectOutput {
     private val result = newObjectRepr
+    override def declareSize(size: Int): Unit = result.sizeHint(size)
     def writeField(key: String) = new SimpleValueOutput(v => result += ((key, v)), newObjectRepr, newListRepr)
     def finish(): Unit = consumer(result)
   }
@@ -109,6 +111,7 @@ class SimpleValueInput(value: Any) extends InputAndSimpleInput {
       private val it = map.iterator.map {
         case (k, v) => new SimpleValueFieldInput(k, v)
       }
+      override def knownSize: Int = if(map.isEmpty) 0 else map.knownSize
       def nextField(): SimpleValueFieldInput = it.next()
       override def peekField(name: String): Opt[SimpleValueFieldInput] =
         map.getOpt(name).map(new SimpleValueFieldInput(name, _))
@@ -117,7 +120,9 @@ class SimpleValueInput(value: Any) extends InputAndSimpleInput {
 
   def readList(): ListInput =
     new ListInput {
-      private val it = doRead[BSeq[Any]].iterator.map(new SimpleValueInput(_))
+      private val inputSeq: BSeq[Any] = doRead[BSeq[Any]]
+      private val it = inputSeq.iterator.map(new SimpleValueInput(_))
+      override def knownSize: Int = if(inputSeq.isEmpty) 0 else inputSeq.knownSize
       def nextElement(): SimpleValueInput = it.next()
       def hasNext: Boolean = it.hasNext
     }

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
@@ -280,6 +280,7 @@ class StreamOutput(os: DataOutputStream) extends OutputAndSimpleOutput {
 }
 
 private class StreamListOutput(os: DataOutputStream, output: StreamOutput) extends ListOutput {
+  override def sizePolicy: SizePolicy = SizePolicy.Never
 
   def writeElement(): Output = output
 
@@ -289,6 +290,7 @@ private class StreamListOutput(os: DataOutputStream, output: StreamOutput) exten
 }
 
 private class StreamObjectOutput(os: DataOutputStream, output: StreamOutput) extends ObjectOutput {
+  override def sizePolicy: SizePolicy = SizePolicy.Never
 
   def writeField(key: String): Output = {
     output.writeString(key)

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
@@ -280,7 +280,7 @@ class StreamOutput(os: DataOutputStream) extends OutputAndSimpleOutput {
 }
 
 private class StreamListOutput(os: DataOutputStream, output: StreamOutput) extends ListOutput {
-  override def sizePolicy: SizePolicy = SizePolicy.Never
+  override def sizePolicy: SizePolicy = SizePolicy.Ignored
 
   def writeElement(): Output = output
 
@@ -290,7 +290,7 @@ private class StreamListOutput(os: DataOutputStream, output: StreamOutput) exten
 }
 
 private class StreamObjectOutput(os: DataOutputStream, output: StreamOutput) extends ObjectOutput {
-  override def sizePolicy: SizePolicy = SizePolicy.Never
+  override def sizePolicy: SizePolicy = SizePolicy.Ignored
 
   def writeField(key: String): Output = {
     output.writeString(key)

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
@@ -376,6 +376,8 @@ abstract class CborSequentialInput(reader: CborReader, private[this] var size: I
 
   private val indefDepth = reader.openIndefinites
 
+  override def knownSize: Int = size
+
   def hasNext: Boolean = {
     reader.closeIndefinites(indefDepth)
     size match {

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
@@ -7,8 +7,6 @@ import java.nio.charset.StandardCharsets
 import com.avsystem.commons.serialization.GenCodec.WriteFailure
 import com.avsystem.commons.serialization._
 
-object ListOrObjectSizeMarker extends TypeMarker[Int]
-
 /**
   * Defines translation between textual object field names and corresponding numeric labels. May be used to reduce
   * size of CBOR representation of objects.
@@ -63,9 +61,13 @@ abstract class BaseCborOutput(out: DataOutput) {
 }
 
 object CborOutput {
-  def write[T: GenCodec](value: T, fieldLabels: FieldLabels = FieldLabels.NoLabels): Array[Byte] = {
+  def write[T: GenCodec](
+    value: T,
+    fieldLabels: FieldLabels = FieldLabels.NoLabels,
+    sizePolicy: SizePolicy = SizePolicy.WhenCheap
+  ): Array[Byte] = {
     val baos = new ByteArrayOutputStream
-    GenCodec.write[T](new CborOutput(new DataOutputStream(baos), fieldLabels), value)
+    GenCodec.write[T](new CborOutput(new DataOutputStream(baos), fieldLabels, sizePolicy), value)
     baos.toByteArray
   }
 }
@@ -74,12 +76,8 @@ object CborOutput {
   * An [[com.avsystem.commons.serialization.Output Output]] implementation that serializes into
   * [[https://tools.ietf.org/html/rfc7049 CBOR]].
   */
-class CborOutput(out: DataOutput, fieldLabels: FieldLabels)
+class CborOutput(out: DataOutput, fieldLabels: FieldLabels, sizePolicy: SizePolicy)
   extends BaseCborOutput(out) with OutputAndSimpleOutput {
-
-  // Output currently does not support writing lists or objects with size known upfront
-  // so we have to handle this less nicely because SenML requires it
-  private[this] var listOrObjectSize: Int = -1
 
   def writeNull(): Unit =
     write(InitialByte.Null)
@@ -151,26 +149,17 @@ class CborOutput(out: DataOutput, fieldLabels: FieldLabels)
       writeDouble(millis.toDouble / 1000)
   }
 
-  def writeList(): ListOutput = {
-    if (listOrObjectSize >= 0) writeValue(MajorType.Array, listOrObjectSize)
-    else write(InitialByte(MajorType.Array, InitialByte.IndefiniteLengthInfo))
-    new CborListOutput(out, fieldLabels, listOrObjectSize)
-  }
+  def writeList(): ListOutput =
+    new CborListOutput(out, fieldLabels, sizePolicy)
 
-  def writeObject(): ObjectOutput = {
-    if (listOrObjectSize >= 0) writeValue(MajorType.Map, listOrObjectSize)
-    else write(InitialByte(MajorType.Map, InitialByte.IndefiniteLengthInfo))
-    new CborObjectOutput(out, fieldLabels, listOrObjectSize)
-  }
+  def writeObject(): ObjectOutput =
+    new CborObjectOutput(out, fieldLabels, sizePolicy)
 
   def writeRawCbor(raw: RawCbor): Unit =
     out.write(raw.bytes, raw.offset, raw.length)
 
   override def writeCustom[T](typeMarker: TypeMarker[T], value: T): Boolean =
     typeMarker match {
-      case ListOrObjectSizeMarker =>
-        listOrObjectSize = value
-        true
       case RawCbor =>
         writeRawCbor(value)
         true
@@ -184,30 +173,68 @@ class CborOutput(out: DataOutput, fieldLabels: FieldLabels)
   }
 }
 
-class CborListOutput(out: DataOutput, fieldLabels: FieldLabels, private[this] var size: Int)
-  extends BaseCborOutput(out) with ListOutput {
+abstract class CborSequentialOutput(
+  out: DataOutput,
+  override val sizePolicy: SizePolicy
+) extends BaseCborOutput(out) with SequentialOutput {
+
+  protected[this] var size: Int = -1
+  protected[this] var fresh: Boolean = true
+
+  protected def writeInitial(major: MajorType): Unit =
+    if (fresh) {
+      fresh = false
+      if (size >= 0) {
+        writeValue(major, size)
+      } else if (sizePolicy != SizePolicy.Always) {
+        write(InitialByte(major, InitialByte.IndefiniteLengthInfo))
+      } else {
+        throw new WriteFailure("explicit size for an array or object was required but it was not declared")
+      }
+    }
+
+  override def declareSize(size: Int): Unit =
+    if (fresh) {
+      this.size = size
+    } else {
+      throw new IllegalStateException("Cannot declare size after elements or fields have already been written")
+    }
+}
+
+class CborListOutput(
+  out: DataOutput,
+  fieldLabels: FieldLabels,
+  sizePolicy: SizePolicy
+) extends CborSequentialOutput(out, sizePolicy) with ListOutput {
 
   def writeElement(): Output = {
+    writeInitial(MajorType.Array)
     if (size > 0) {
       size -= 1
     } else if (size == 0) {
       throw new WriteFailure("explicit size was given and all the elements have already been written")
     }
-    new CborOutput(out, fieldLabels)
+    new CborOutput(out, fieldLabels, sizePolicy)
   }
 
-  def finish(): Unit =
+  def finish(): Unit = {
+    writeInitial(MajorType.Array)
     if (size < 0) {
       write(InitialByte.Break)
     } else if (size > 0) {
       throw new WriteFailure("explicit size was given but not enough elements were written")
     }
+  }
 }
 
-class CborObjectOutput(out: DataOutput, fieldLabels: FieldLabels, private[this] var size: Int)
-  extends BaseCborOutput(out) with ObjectOutput {
+class CborObjectOutput(
+  out: DataOutput,
+  fieldLabels: FieldLabels,
+  sizePolicy: SizePolicy
+) extends CborSequentialOutput(out, sizePolicy) with ObjectOutput {
 
   def writeField(key: String): Output = {
+    writeInitial(MajorType.Map)
     if (size > 0) {
       size -= 1
     } else if (size == 0) {
@@ -217,13 +244,15 @@ class CborObjectOutput(out: DataOutput, fieldLabels: FieldLabels, private[this] 
       case Opt(label) => writeSigned(label)
       case Opt.Empty => writeText(key)
     }
-    new CborOutput(out, fieldLabels)
+    new CborOutput(out, fieldLabels, sizePolicy)
   }
 
-  def finish(): Unit =
+  def finish(): Unit = {
+    writeInitial(MajorType.Map)
     if (size < 0) {
       write(InitialByte.Break)
     } else if (size > 0) {
       throw new WriteFailure("explicit size was given but not enough fields were written")
     }
+  }
 }

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
@@ -53,7 +53,7 @@ abstract class BaseCborOutput(out: DataOutput) {
   protected final def writeTag(tag: Tag): Unit =
     writeValue(MajorType.Tag, tag.value)
 
-  protected def writeText(str: String): Unit = {
+  protected final def writeText(str: String): Unit = {
     val bytes = str.getBytes(StandardCharsets.UTF_8)
     writeValue(MajorType.TextString, bytes.length)
     out.write(bytes)
@@ -181,7 +181,7 @@ abstract class CborSequentialOutput(
   protected[this] var size: Int = -1
   protected[this] var fresh: Boolean = true
 
-  protected def writeInitial(major: MajorType): Unit =
+  protected final def writeInitial(major: MajorType): Unit =
     if (fresh) {
       fresh = false
       if (size >= 0) {
@@ -193,7 +193,7 @@ abstract class CborSequentialOutput(
       }
     }
 
-  override def declareSize(size: Int): Unit =
+  override final def declareSize(size: Int): Unit =
     if (fresh) {
       this.size = size
     } else {

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
@@ -64,7 +64,7 @@ object CborOutput {
   def write[T: GenCodec](
     value: T,
     fieldLabels: FieldLabels = FieldLabels.NoLabels,
-    sizePolicy: SizePolicy = SizePolicy.WhenCheap
+    sizePolicy: SizePolicy = SizePolicy.Optional
   ): Array[Byte] = {
     val baos = new ByteArrayOutputStream
     GenCodec.write[T](new CborOutput(new DataOutputStream(baos), fieldLabels, sizePolicy), value)
@@ -186,7 +186,7 @@ abstract class CborSequentialOutput(
       fresh = false
       if (size >= 0) {
         writeValue(major, size)
-      } else if (sizePolicy != SizePolicy.Always) {
+      } else if (sizePolicy != SizePolicy.Required) {
         write(InitialByte(major, InitialByte.IndefiniteLengthInfo))
       } else {
         throw new WriteFailure("explicit size for an array or object was required but it was not declared")

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
@@ -136,7 +136,7 @@ final class JsonStringOutput(builder: JStringBuilder, options: JsonOptions = Jso
 final class JsonListOutput(builder: JStringBuilder, options: JsonOptions, depth: Int)
   extends BaseJsonOutput with ListOutput {
 
-  override def sizePolicy: SizePolicy = SizePolicy.Never
+  override def sizePolicy: SizePolicy = SizePolicy.Ignored
 
   private[this] var first = true
 
@@ -160,7 +160,7 @@ final class JsonListOutput(builder: JStringBuilder, options: JsonOptions, depth:
 final class JsonObjectOutput(builder: JStringBuilder, options: JsonOptions, depth: Int)
   extends BaseJsonOutput with ObjectOutput {
 
-  override def sizePolicy: SizePolicy = SizePolicy.Never
+  override def sizePolicy: SizePolicy = SizePolicy.Ignored
 
   private[this] var first = true
 

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
@@ -136,6 +136,8 @@ final class JsonStringOutput(builder: JStringBuilder, options: JsonOptions = Jso
 final class JsonListOutput(builder: JStringBuilder, options: JsonOptions, depth: Int)
   extends BaseJsonOutput with ListOutput {
 
+  override def sizePolicy: SizePolicy = SizePolicy.Never
+
   private[this] var first = true
 
   def writeElement(): JsonStringOutput = {
@@ -157,6 +159,8 @@ final class JsonListOutput(builder: JStringBuilder, options: JsonOptions, depth:
 
 final class JsonObjectOutput(builder: JStringBuilder, options: JsonOptions, depth: Int)
   extends BaseJsonOutput with ObjectOutput {
+
+  override def sizePolicy: SizePolicy = SizePolicy.Never
 
   private[this] var first = true
 

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -11,7 +11,8 @@ class SingletonCodec[T <: Singleton](
 ) extends ErrorReportingCodec[T] with OOOFieldsObjectCodec[T] {
   final def nullable = true
   final def readObject(input: ObjectInput, outOfOrderFields: FieldValues): T = singletonValue
-  def writeObject(output: ObjectOutput, value: T): Unit = ()
+  def size(value: T): Int = 0
+  def writeFields(output: ObjectOutput, value: T): Unit = ()
 }
 
 abstract class ApplyUnapplyCodec[T](
@@ -101,12 +102,16 @@ abstract class ProductCodec[T <: Product](
   nullable: Boolean,
   fieldNames: Array[String]
 ) extends ApplyUnapplyCodec[T](typeRepr, nullable, fieldNames) {
-  final def writeObject(output: ObjectOutput, value: T): Unit = {
-    var i = 0
-    while (i < value.productArity) {
-      writeField(output, i, value.productElement(i))
-      i += 1
-    }
+  def size(value: T): Int = value.productArity
+
+  final def writeFields(output: ObjectOutput, value: T): Unit = {
+    val size = value.productArity
+    @tailrec def loop(idx: Int): Unit =
+      if (idx < size) {
+        writeField(output, idx, value.productElement(idx))
+        loop(idx + 1)
+      }
+    loop(0)
   }
 }
 
@@ -141,6 +146,7 @@ abstract class NestedSealedHierarchyCodec[T](
 
   final def writeObject(output: ObjectOutput, value: T): Unit = {
     val caseIdx = caseIndexByValue(value)
+    output.declareSize(1)
     writeCase(caseNames(caseIdx), output, value, caseDeps(caseIdx).asInstanceOf[GenCodec[T]])
   }
 
@@ -177,8 +183,11 @@ abstract class FlatSealedHierarchyCodec[T](
   final def writeObject(output: ObjectOutput, value: T): Unit = {
     val caseIdx = caseIndexByValue(value)
     val transient = defaultCaseTransient && defaultCaseIdx == caseIdx
-    writeFlatCase(caseNames(caseIdx), transient, output, value,
-      caseDeps(caseIdx).asInstanceOf[OOOFieldsObjectCodec[T]])
+    val caseCodec = caseDeps(caseIdx).asInstanceOf[OOOFieldsObjectCodec[T]]
+    if (output.sizePolicy != SizePolicy.Never) {
+      output.declareSize((if (transient) 0 else 1) + caseCodec.size(value))
+    }
+    writeFlatCase(caseNames(caseIdx), transient, output, value, caseCodec)
   }
 
   final def readObject(input: ObjectInput): T = {
@@ -193,7 +202,7 @@ abstract class FlatSealedHierarchyCodec[T](
       }
     }
 
-    def read(): T =
+    @tailrec def read(): T =
       if (input.hasNext) {
         val fi = input.nextField()
         if (fi.fieldName == caseFieldName) readCase(fi)
@@ -289,12 +298,12 @@ abstract class ErrorReportingCodec[T] extends GenCodec[T] {
     decoratedWrite(fieldName, output, value, codec, "case")
 
   protected final def writeFlatCase[A](
-    caseName: String, transient: Boolean, output: ObjectOutput, value: A, codec: ObjectCodec[A]
+    caseName: String, transient: Boolean, output: ObjectOutput, value: A, codec: OOOFieldsObjectCodec[A]
   ): Unit = try {
     if (!transient) {
       output.writeField(caseFieldName).writeSimple().writeString(caseName)
     }
-    codec.writeObject(output, value)
+    codec.writeFields(output, value)
   } catch {
     case NonFatal(e) => throw new WriteFailure(s"Failed to write case $caseName of $typeRepr", e)
   }

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -184,7 +184,7 @@ abstract class FlatSealedHierarchyCodec[T](
     val caseIdx = caseIndexByValue(value)
     val transient = defaultCaseTransient && defaultCaseIdx == caseIdx
     val caseCodec = caseDeps(caseIdx).asInstanceOf[OOOFieldsObjectCodec[T]]
-    if (output.sizePolicy != SizePolicy.Never) {
+    if (output.sizePolicy != SizePolicy.Ignored) {
       output.declareSize((if (transient) 0 else 1) + caseCodec.size(value))
     }
     writeFlatCase(caseNames(caseIdx), transient, output, value, caseCodec)

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
@@ -1,0 +1,37 @@
+package com.avsystem.commons
+package serialization
+
+import org.scalatest.FunSuite
+
+case class RecordWithDefaults(
+  @transientDefault a: String = "",
+  b: Int = 42
+) {
+  @generated def c: String = s"$a-$b"
+}
+object RecordWithDefaults extends HasApplyUnapplyCodec[RecordWithDefaults]
+
+class CustomRecordWithDefaults(val a: String, val b: Int)
+object CustomRecordWithDefaults extends HasApplyUnapplyCodec[CustomRecordWithDefaults] {
+  def apply(@transientDefault a: String = "", b: Int = 42): CustomRecordWithDefaults =
+    new CustomRecordWithDefaults(a, b)
+  def unapply(crwd: CustomRecordWithDefaults): Opt[(String, Int)] =
+    Opt((crwd.a, crwd.b))
+}
+
+class CustomWrapper(val a: String)
+object CustomWrapper extends HasApplyUnapplyCodec[CustomWrapper] {
+  def apply(@transientDefault a: String = ""): CustomWrapper = new CustomWrapper(a)
+  def unapply(cw: CustomWrapper): Opt[String] = Opt(cw.a)
+}
+
+class ObjectSizeTest extends FunSuite {
+  test("computing object size") {
+    assert(RecordWithDefaults.codec.size(RecordWithDefaults()) == 2)
+    assert(RecordWithDefaults.codec.size(RecordWithDefaults("fuu")) == 3)
+    assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults()) == 1)
+    assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults("fuu")) == 2)
+    assert(CustomWrapper.codec.size(CustomWrapper()) == 0)
+    assert(CustomWrapper.codec.size(CustomWrapper("fuu")) == 1)
+  }
+}

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
@@ -110,6 +110,8 @@ class CborInputOutputTest extends FunSuite {
   roundtrip(Bytes("ąć"), "44C485C487")
   roundtrip(Bytes("a" * 30), "581E616161616161616161616161616161616161616161616161616161616161")
 
+  roundtrip(("foo", 42, 3.14), "8363666F6F182AFB40091EB851EB851F")
+
   roundtrip(List(1, 2, 3), "9F010203FF")
   roundtrip(Vector(1, 2, 3), "83010203")
 

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
@@ -25,7 +25,7 @@ class CborInputOutputTest extends FunSuite {
   )(implicit pos: Position): Unit =
     test(s"${pos.lineNumber}: $value") {
       val baos = new ByteArrayOutputStream
-      val output = new CborOutput(new DataOutputStream(baos), labels, SizePolicy.WhenCheap)
+      val output = new CborOutput(new DataOutputStream(baos), labels, SizePolicy.Optional)
       GenCodec.write[T](output, value)
       val bytes = baos.toByteArray
       assert(Bytes(bytes).toString == binary)
@@ -155,7 +155,7 @@ class CborGenCodecRoundtripTest extends GenCodecRoundtripTest {
 
   def writeToOutput(write: Output => Unit): RawCbor = {
     val baos = new ByteArrayOutputStream
-    write(new CborOutput(new DataOutputStream(baos), FieldLabels.NoLabels, SizePolicy.WhenCheap))
+    write(new CborOutput(new DataOutputStream(baos), FieldLabels.NoLabels, SizePolicy.Optional))
     RawCbor(baos.toByteArray)
   }
 

--- a/commons-hocon/src/main/scala/com/avsystem/commons/hocon/HoconInput.scala
+++ b/commons-hocon/src/main/scala/com/avsystem/commons/hocon/HoconInput.scala
@@ -80,6 +80,8 @@ class HoconInput(value: ConfigValue) extends InputAndSimpleInput with BaseHoconI
 class HoconListInput(configList: ConfigList) extends ListInput with BaseHoconInput {
   private val elements = configList.iterator.asScala
 
+  override def knownSize: Int = configList.size
+
   def hasNext: Boolean = elements.hasNext
 
   def nextElement(): Input =
@@ -88,6 +90,8 @@ class HoconListInput(configList: ConfigList) extends ListInput with BaseHoconInp
 
 class HoconObjectInput(configObject: ConfigObject) extends ObjectInput with BaseHoconInput {
   private val keys = configObject.keySet.iterator.asScala
+
+  override def knownSize: Int = configObject.size
 
   def hasNext: Boolean = keys.hasNext
 

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
@@ -18,6 +18,7 @@ class GenCodecMacros(ctx: blackbox.Context) extends CodecMacroCommons(ctx) with 
         def readList(input: $SerializationPkg.ListInput) =
           (..${indices.map(i => q"${elementCodecs(i)}.read(input.nextElement())")})
         def writeList(output: $SerializationPkg.ListOutput, value: $tupleTpe) = {
+          output.declareSize(${elementCodecs.size})
           ..${indices.map(i => q"${elementCodecs(i)}.write(output.writeElement(), value.${tupleGet(i)})")}
         }
       }

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
@@ -66,7 +66,7 @@ final class RedisDataOutput(consumer: ByteString => Unit) extends OutputAndSimpl
     private val sb = new JStringBuilder
     private val jlo = new JsonStringOutput(sb).writeList()
 
-    override def sizePolicy: SizePolicy = SizePolicy.Never
+    override def sizePolicy: SizePolicy = SizePolicy.Ignored
     def writeElement(): Output = jlo.writeElement()
     def finish(): Unit = {
       jlo.finish()
@@ -78,7 +78,7 @@ final class RedisDataOutput(consumer: ByteString => Unit) extends OutputAndSimpl
     private val sb = new JStringBuilder
     private val joo = new JsonStringOutput(sb).writeObject()
 
-    override def sizePolicy: SizePolicy = SizePolicy.Never
+    override def sizePolicy: SizePolicy = SizePolicy.Ignored
     def writeField(key: String): Output = joo.writeField(key)
     def finish(): Unit = {
       joo.finish()

--- a/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
+++ b/commons-redis/src/main/scala/com/avsystem/commons/redis/RedisDataCodec.scala
@@ -66,6 +66,7 @@ final class RedisDataOutput(consumer: ByteString => Unit) extends OutputAndSimpl
     private val sb = new JStringBuilder
     private val jlo = new JsonStringOutput(sb).writeList()
 
+    override def sizePolicy: SizePolicy = SizePolicy.Never
     def writeElement(): Output = jlo.writeElement()
     def finish(): Unit = {
       jlo.finish()
@@ -77,6 +78,7 @@ final class RedisDataOutput(consumer: ByteString => Unit) extends OutputAndSimpl
     private val sb = new JStringBuilder
     private val joo = new JsonStringOutput(sb).writeObject()
 
+    override def sizePolicy: SizePolicy = SizePolicy.Never
     def writeField(key: String): Output = joo.writeField(key)
     def finish(): Unit = {
       joo.finish()
@@ -86,6 +88,9 @@ final class RedisDataOutput(consumer: ByteString => Unit) extends OutputAndSimpl
 }
 
 class RedisRecordOutput(builder: MBuilder[BulkStringMsg, _]) extends ObjectOutput {
+  override def declareSize(size: Int): Unit =
+    builder.sizeHint(size)
+
   def writeField(key: String): Output = {
     builder += BulkStringMsg(ByteString(key))
     new RedisDataOutput(bs => builder += BulkStringMsg(bs))
@@ -130,6 +135,8 @@ class RedisFieldDataInput(val fieldName: String, bytes: ByteString)
 
 class RedisRecordInput(bulks: IndexedSeq[BulkStringMsg]) extends ObjectInput {
   private val it = bulks.iterator.map(_.string)
+
+  override def knownSize: Int = bulks.size
 
   def nextField(): FieldInput = {
     val fieldName = it.next.utf8String


### PR DESCRIPTION
This is especially useful for CBOR which has two representations for lists and objects (definite and indefinite length). Previously, it was impossible to use definite-length representation with standard `Output` API.

Also, `ListInput` and `ObjectInput` may now hint the codec about their size which may be used to optimize `GenCodec` implementation.