### PR TITLE
Added partitionEither to TraversableOnceOps

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -584,14 +584,16 @@ object SharedExtensions extends SharedExtensions {
     def asyncForeach(fun: A => Future[Unit])(implicit ec: ExecutionContext): Future[Unit] =
       coll.foldLeft[Future[Unit]](Future.unit)((fu, a) => fu.flatMap(_ => fun(a)))
 
-    def partitionEither[L, R](fun: A => Either[L, R])(implicit cbfL: CanBuildFrom[Nothing, L, C[L]], cbfR: CanBuildFrom[Nothing, R, C[R]]): (C[L], C[R]) = {
-      val left = cbfL()
-      val right = cbfR()
+    def partitionEither[L, R](
+      fun: A => Either[L, R]
+    )(implicit cbfL: CanBuildFrom[Nothing, L, C[L]], cbfR: CanBuildFrom[Nothing, R, C[R]]): (C[L], C[R]) = {
+      val leftBuilder = cbfL()
+      val rightBuilder = cbfR()
       coll.foreach(fun(_) match {
-        case Left(l) => left += l
-        case Right(r) => right += r
+        case Left(l) => leftBuilder += l
+        case Right(r) => rightBuilder += r
       })
-      (left.result(), right.result())
+      (leftBuilder.result(), rightBuilder.result())
     }
   }
 

--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -583,6 +583,16 @@ object SharedExtensions extends SharedExtensions {
 
     def asyncForeach(fun: A => Future[Unit])(implicit ec: ExecutionContext): Future[Unit] =
       coll.foldLeft[Future[Unit]](Future.unit)((fu, a) => fu.flatMap(_ => fun(a)))
+
+    def partitionEither[L, R](fun: A => Either[L, R])(implicit cbfL: CanBuildFrom[Nothing, L, C[L]], cbfR: CanBuildFrom[Nothing, R, C[R]]): (C[L], C[R]) = {
+      val left = cbfL()
+      val right = cbfR()
+      coll.foreach(fun(_) match {
+        case Left(l) => left += l
+        case Right(r) => right += r
+      })
+      (left.result(), right.result())
+    }
   }
 
   class PairTraversableOnceOps[C[X] <: TraversableOnce[X], K, V](private val coll: C[(K, V)]) extends AnyVal {

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsTest.scala
@@ -177,4 +177,13 @@ class SharedExtensionsTest extends FunSuite with Matchers {
   test("withSourceCode") {
     assert(123.withSourceCode == (123, "123"))
   }
+
+  test("partitionEither") {
+    val list = List("1", "2", "3", "4", "5", "fds", "fasd", "d2s")
+    val (strings, numbers) = list.partitionEither { elem =>
+      Try(elem.toInt).toEither.swap.map(_ => elem).swap
+    }
+    assert(numbers == List(1, 2, 3, 4, 5))
+    assert(strings == List("fds", "fasd", "d2s"))
+  }
 }

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsTest.scala
@@ -179,11 +179,11 @@ class SharedExtensionsTest extends FunSuite with Matchers {
   }
 
   test("partitionEither") {
-    val list = List("1", "2", "3", "4", "5", "fds", "fasd", "d2s")
+    val list = List("1", "2", "3", "fds", "fasd", "4", "d2s", "5")
     val (strings, numbers) = list.partitionEither { elem =>
-      Try(elem.toInt).toEither.swap.map(_ => elem).swap
+      Try(elem.toInt).fold(_ => Left(elem), Right(_))
     }
-    assert(numbers == List(1, 2, 3, 4, 5))
     assert(strings == List("fds", "fasd", "d2s"))
+    assert(numbers == List(1, 2, 3, 4, 5))
   }
 }


### PR DESCRIPTION
Allows for a sort of typed (map + partition), done in one pass through a collection.

Inspired by cats' `Foldable.partitionEither`, but usable without depending on cats, or an `Alternative` instance for a collection.