### PR TITLE
indexOfOpt & indexWhereOpt

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -568,7 +568,7 @@ object SharedExtensions extends SharedExtensions {
 
     def indexOfOpt(elem: A, from: Int = 0): Opt[Int] = coll.toIterator.indexOf(elem, from).opt.filter(_ != -1)
 
-    def indexWhereOpt(p: A => Boolean, from: Int = 0): Opt[Int] = coll.toIterator.indexWhere(p, from).opt.filter(_ != -1)
+    def indexWhereOpt(p: A => Boolean): Opt[Int] = coll.toIterator.indexWhere(p).opt.filter(_ != -1)
 
     def mkStringOr(start: String, sep: String, end: String, default: String): String =
       if (coll.nonEmpty) coll.mkString(start, sep, end) else default

--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -566,6 +566,10 @@ object SharedExtensions extends SharedExtensions {
 
     def minOptBy[B: Ordering](f: A => B): Opt[A] = if (coll.isEmpty) Opt.Empty else coll.minBy(f).opt
 
+    def indexOfOpt(elem: A, from: Int = 0): Opt[Int] = coll.toIterator.indexOf(elem, from).opt.filter(_ != -1)
+
+    def indexWhereOpt(p: A => Boolean, from: Int = 0): Opt[Int] = coll.toIterator.indexWhere(p, from).opt.filter(_ != -1)
+
     def mkStringOr(start: String, sep: String, end: String, default: String): String =
       if (coll.nonEmpty) coll.mkString(start, sep, end) else default
 

--- a/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -566,7 +566,7 @@ object SharedExtensions extends SharedExtensions {
 
     def minOptBy[B: Ordering](f: A => B): Opt[A] = if (coll.isEmpty) Opt.Empty else coll.minBy(f).opt
 
-    def indexOfOpt(elem: A, from: Int = 0): Opt[Int] = coll.toIterator.indexOf(elem, from).opt.filter(_ != -1)
+    def indexOfOpt(elem: A): Opt[Int] = coll.toIterator.indexOf(elem).opt.filter(_ != -1)
 
     def indexWhereOpt(p: A => Boolean): Opt[Int] = coll.toIterator.indexWhere(p).opt.filter(_ != -1)
 

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
@@ -1,0 +1,56 @@
+package com.avsystem.commons
+package misc
+
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FunSuite, Matchers}
+
+class SharedExtensionsPropertyTest extends FunSuite with Matchers with GeneratorDrivenPropertyChecks {
+  private val elementGen = Gen.alphaChar
+  private val listGen = Gen.listOf(elementGen)
+  private val listWithIndexGen = for {
+    list <- Gen.nonEmptyListOf(elementGen)
+    index <- Gen.choose(0, list.length - 1)
+  } yield (list, index)
+  private val listWithElementGen = for {
+    list <- Gen.nonEmptyListOf(elementGen)
+    elem <- Gen.oneOf(list)
+  } yield (list, elem)
+
+  test("indexOfOpt(elem) should return Opt.Empty if the element does not exist in the list") {
+    forAll(listGen, elementGen) { (elemList, element) =>
+      elemList.filterNot(_ == element).indexOfOpt(element) shouldEqual Opt.Empty
+    }
+  }
+
+  test("indexOfOpt(elem) should not return Opt.Empty when the element exists in the list") {
+    forAll(listWithElementGen) { case (elemList, elem) =>
+      elemList.indexOfOpt(elem) should not equal Opt.Empty
+    }
+  }
+
+  test("indexOfOpt(elem).getOrElse(-1) should behave identically to indexOf(elem)") {
+    forAll(listGen, elementGen) { (elemList, element) =>
+      elemList.indexOf(element) shouldEqual elemList.indexOfOpt(element).getOrElse(-1)
+    }
+  }
+
+  test("indexOfOpt(elem, from).getOrElse(-1) should behave identically to indexOf(elem, from)") {
+    forAll(listWithIndexGen, elementGen) { case ((elemList, idx), element) =>
+      elemList.indexOf(element, idx) shouldEqual elemList.indexOfOpt(element, idx).getOrElse(-1)
+    }
+  }
+
+  test("indexWhereOpt(elem).getOrElse(-1) should behave identically to indexWhere(elem)") {
+    forAll(listGen, elementGen) { (elemList, element) =>
+      elemList.indexWhere(_ == element) shouldEqual elemList.indexWhereOpt(_ == element).getOrElse(-1)
+    }
+  }
+
+  test("indexWhereOpt(elem, from).getOrElse(-1) should behave identically to indexWhere(elem, from)") {
+    forAll(listWithIndexGen, elementGen) { case ((elemList, idx), element) =>
+      elemList.indexWhere(_ == element, idx) shouldEqual elemList.indexWhereOpt(_ == element, idx).getOrElse(-1)
+    }
+  }
+
+}

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
@@ -1,29 +1,28 @@
 package com.avsystem.commons
 package misc
 
-import org.scalacheck.Gen
+import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FunSuite, Matchers}
 
 class SharedExtensionsPropertyTest extends FunSuite with Matchers with GeneratorDrivenPropertyChecks {
+  implicit def shrinkNonEmpty[C[_] <: Iterable[_], T](implicit base: Shrink[C[T]]): Shrink[C[T]] =
+    Shrink(base.shrink(_).filter(_.nonEmpty))
+
   private val elementGen = Gen.alphaChar
   private val listGen = Gen.listOf(elementGen)
-  private val listWithIndexGen = for {
-    list <- Gen.nonEmptyListOf(elementGen)
-    index <- Gen.choose(0, list.length - 1)
-  } yield (list, index)
   private val listWithElementGen = for {
     list <- Gen.nonEmptyListOf(elementGen)
     elem <- Gen.oneOf(list)
   } yield (list, elem)
 
-  test("indexOfOpt(elem) should return Opt.Empty if the element does not exist in the list") {
+  test("indexOfOpt(elem) should return Opt.Empty if the element does not occur in the list") {
     forAll(listGen, elementGen) { (elemList, element) =>
       elemList.filterNot(_ == element).indexOfOpt(element) shouldEqual Opt.Empty
     }
   }
 
-  test("indexOfOpt(elem) should not return Opt.Empty when the element exists in the list") {
+  test("indexOfOpt(elem) should not return Opt.Empty when the element occurs in the list") {
     forAll(listWithElementGen) { case (elemList, elem) =>
       elemList.indexOfOpt(elem) should not equal Opt.Empty
     }
@@ -32,12 +31,6 @@ class SharedExtensionsPropertyTest extends FunSuite with Matchers with Generator
   test("indexOfOpt(elem).getOrElse(-1) should behave identically to indexOf(elem)") {
     forAll(listGen, elementGen) { (elemList, element) =>
       elemList.indexOf(element) shouldEqual elemList.indexOfOpt(element).getOrElse(-1)
-    }
-  }
-
-  test("indexOfOpt(elem, from).getOrElse(-1) should behave identically to indexOf(elem, from)") {
-    forAll(listWithIndexGen, elementGen) { case ((elemList, idx), element) =>
-      elemList.indexOf(element, idx) shouldEqual elemList.indexOfOpt(element, idx).getOrElse(-1)
     }
   }
 

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
@@ -46,11 +46,4 @@ class SharedExtensionsPropertyTest extends FunSuite with Matchers with Generator
       elemList.indexWhere(_ == element) shouldEqual elemList.indexWhereOpt(_ == element).getOrElse(-1)
     }
   }
-
-  test("indexWhereOpt(elem, from).getOrElse(-1) should behave identically to indexWhere(elem, from)") {
-    forAll(listWithIndexGen, elementGen) { case ((elemList, idx), element) =>
-      elemList.indexWhere(_ == element, idx) shouldEqual elemList.indexWhereOpt(_ == element, idx).getOrElse(-1)
-    }
-  }
-
 }


### PR DESCRIPTION
`indexOf` and `indexWhere` alternatives that return `Opt.Empty` instead of -1

Also added some Property tests, since that seemed like the most sensible way to test compatibility with the base method.

Unfortunately `indexOf(elem, from)` and `indexWhere(elem, from)`  doesn't yet exist in scala 2.11, they could probably be added once support for scala 2.11 is dropped.