### PR TITLE
Remove monix dependency from commons-mongo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val `commons-mongo` = project
     jvmCommonSettings,
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % guavaVersion,
-      "io.monix" %% "monix" % monixVersion,
+      "io.monix" %% "monix" % monixVersion % Test,
       "org.mongodb" % "mongodb-driver-core" % mongoVersion,
       "org.mongodb" % "mongodb-driver" % mongoVersion % Optional,
       "org.mongodb" % "mongodb-driver-async" % mongoVersion % Optional,

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/async/MongoObservableExtensions.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/async/MongoObservableExtensions.scala
@@ -15,6 +15,5 @@ object MongoObservableExtensions extends MongoObservableExtensions {
   @silent("deprecated")
   final class MongoObservableOps[T](private val obs: com.mongodb.async.client.Observable[T]) extends AnyVal {
     def asReactive: org.reactivestreams.Publisher[T] = new MongoObservableReactivePublisher[T](obs)
-    def asMonix: monix.reactive.Observable[T] = monix.reactive.Observable.fromReactivePublisher(asReactive)
   }
 }

--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/async/MongoObservableReactivePublisher.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/async/MongoObservableReactivePublisher.scala
@@ -1,9 +1,10 @@
 package com.avsystem.commons
 package mongo.async
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 import com.github.ghik.silencer.silent
 import com.mongodb.async.{client => mongo}
-import monix.execution.atomic.AtomicBoolean
 import org.{reactivestreams => reactive}
 
 @silent("deprecated")
@@ -13,7 +14,7 @@ final class MongoObservableReactivePublisher[T](observable: mongo.Observable[T])
       new mongo.Observer[T]() {
         override def onSubscribe(subscription: mongo.Subscription): Unit = {
           subscriber.onSubscribe(new reactive.Subscription() {
-            private final val cancelled: AtomicBoolean = AtomicBoolean(false)
+            private final val cancelled: AtomicBoolean = new AtomicBoolean(false)
 
             def request(n: Long): Unit = {
               if (!subscription.isUnsubscribed && n <= 0) {

--- a/commons-mongo/src/test/scala/com/avsystem/commons/mongo/async/MongoObservableReactivePublisherTest.scala
+++ b/commons-mongo/src/test/scala/com/avsystem/commons/mongo/async/MongoObservableReactivePublisherTest.scala
@@ -84,7 +84,7 @@ class MongoObservableReactivePublisherTest extends AnyFreeSpec {
   }
   "A Mongo-Monix observable" - new MockedObservableTests {
     override def subscribe[T](obs: mongo.Observable[T], testSubscriber: TestSubscriber[T]): Unit =
-      obs.asMonix.subscribe(
+      monix.reactive.Observable.fromReactivePublisher(obs.asReactive).subscribe(
         monix.reactive.observers.Subscriber.fromReactiveSubscriber(testSubscriber, Cancelable.empty)(Scheduler(RunNowEC))
       )
   }


### PR DESCRIPTION
Monix dependency was only used to add a single API conversion method to async driver publishers. With ongoing migrations to mongo-reactivestreams driver and monix 3.x this dependency path is a curse, not a blessing.