### PR TITLE
Fix writing _id field in BsonOutput with 4.0 driver

### DIFF
--- a/commons-mongo/src/main/scala/com/avsystem/commons/mongo/BsonWriterOutput.scala
+++ b/commons-mongo/src/main/scala/com/avsystem/commons/mongo/BsonWriterOutput.scala
@@ -69,7 +69,8 @@ final class BsonWriterNamedOutput(escapedName: String, bw: BsonWriter, override 
     new BsonWriterListOutput(bw, legacyOptionEncoding)
   }
   override def writeObject(): BsonWriterObjectOutput = {
-    bw.writeStartDocument(escapedName)
+    bw.writeName(escapedName) // org.bson.BsonWriter.writeStartDocument(java.lang.String) fails when writing _id in 4.0 driver
+    bw.writeStartDocument()
     new BsonWriterObjectOutput(bw, legacyOptionEncoding)
   }
   override def writeObjectId(objectId: ObjectId): Unit =


### PR DESCRIPTION
In 4.0 driver there is new special implementation of the writer for _id field when doing inserts `com.mongodb.internal.connection.IdHoldingBsonWriter`. It creates internally completely new instance of the writer that ends up in the wrong state when calling `org.bson.BsonWriter.writeStartDocument(java.lang.String)` (and _id is an object!). Resulting exception:

`Caused by: sbt.ForkMain$ForkError: org.bson.BsonInvalidOperationException: A Name value cannot be written to the root level of a BSON document. at org.bson.AbstractBsonWriter.throwInvalidState(AbstractBsonWriter.java:740) at org.bson.AbstractBsonWriter.writeName(AbstractBsonWriter.java:531) at org.bson.AbstractBsonWriter.writeStartDocument(AbstractBsonWriter.java:271) at com.mongodb.internal.connection.BsonWriterDecorator.writeStartDocument(BsonWriterDecorator.java:43) at com.mongodb.internal.connection.LevelCountingBsonWriter.writeStartDocument(LevelCountingBsonWriter.java:36) at com.mongodb.internal.connection.IdHoldingBsonWriter.writeStartDocument(IdHoldingBsonWriter.java:68) at com.avsystem.commons.mongo.BsonWriterNamedOutput.writeObject(BsonWriterOutput.scala:72)`