### PR TITLE
JsonStringInput can peek fields by name

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -271,7 +271,7 @@ final class JsonObjectInput(reader: JsonReader, options: JsonOptions, callback: 
       }
     }
 
-    val alreadyPeeked = peekedFields.opt.flatMap(_.getOpt(name).map(idx => peekFieldInput(name, idx)))
+    val alreadyPeeked = peekedFields.opt.flatMap(_.get(name).toOpt.map(idx => peekFieldInput(name, idx)))
     alreadyPeeked orElse {
       val savedIdx = reader.index
       try {

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -2,6 +2,7 @@ package com.avsystem.commons
 package serialization.json
 
 import com.avsystem.commons.annotation.explicitGenerics
+import com.avsystem.commons.misc.CrossUtils
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization._
 import com.avsystem.commons.serialization.json.JsonStringInput._
@@ -225,7 +226,7 @@ final class JsonObjectInput(reader: JsonReader, options: JsonOptions, callback: 
   prepareForNext(first = true)
 
   private[this] var peekIdx = if (end) -1 else reader.index
-  private[this] var peekedFields: MMap[String, Int] = _
+  private[this] var peekedFields: CrossUtils.NativeDict[Int] = _
 
   private def prepareForNext(first: Boolean): Unit = {
     reader.skipWs()
@@ -286,7 +287,7 @@ final class JsonObjectInput(reader: JsonReader, options: JsonOptions, callback: 
               Opt(peekFieldInput(foundName, valueIndex))
             } else {
               if (peekedFields == null) {
-                peekedFields = new MHashMap
+                peekedFields = CrossUtils.newNativeDict[Int]
               }
               peekedFields(foundName) = valueIndex
               peekIdx = skipToNextFieldName()

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -281,6 +281,8 @@ final class JsonObjectInput(reader: JsonReader, options: JsonOptions, callback: 
             val foundName = nextFieldName()
             val valueIndex = reader.index
             if (foundName == name) {
+              // intentionally not saving this field into `peekedFields` as a performance optimization for the
+              // situation where peeked field is very likely to be the first field (flat sealed hierarchies)
               Opt(peekFieldInput(foundName, valueIndex))
             } else {
               if (peekedFields == null) {

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/CodecTestData.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/CodecTestData.scala
@@ -296,6 +296,7 @@ object CodecTestData {
 
   @flatten("kejs") sealed trait CustomizedSeal
   @defaultCase(transient = true) case class CustomizedCase(str: String) extends CustomizedSeal
+  case class OtherCustomCase(value: Int, flag: Boolean) extends CustomizedSeal
   case object CustomizedObjekt extends CustomizedSeal
   object CustomizedSeal extends HasGenCodec[CustomizedSeal]
 

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package serialization.json
 
-import com.avsystem.commons.serialization.CodecTestData.FlatSealedBase
+import com.avsystem.commons.serialization.CodecTestData.{CustomizedSeal, FlatSealedBase, OtherCustomCase}
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization._
 import org.scalacheck.Arbitrary.arbitrary
@@ -409,5 +409,10 @@ class JsonStringInputOutputTest extends AnyFunSuite with SerializationTestUtils 
   test("reading flat sealed hierarchy with changed field order") {
     val json = """{"_id": "foo", "int": 31, "_case": "FirstCase"}"""
     assert(JsonStringInput.read[FlatSealedBase](json) == FlatSealedBase.FirstCase("foo", 31))
+  }
+
+  test("reading flat sealed hierarchy with changed field order & custom case field name") {
+    val json = """{"flag": false, "kejs": "OtherCustomCase", "value": 41}"""
+    assert(JsonStringInput.read[CustomizedSeal](json) == OtherCustomCase(41, flag = false))
   }
 }

--- a/docs/GenCodec.md
+++ b/docs/GenCodec.md
@@ -166,12 +166,17 @@ For most serialization formats, it's completely natural to retain object field o
 were written to `JsonObjectOutput`. For these formats it is required that an `ObjectInput` returns object fields in exactly the same order as they were written to
 a corresponding `ObjectOutput`. This normally includes all serialization formats backed by strings, byte sequences, streams, etc.
 
+> :bulb: It is generally recommended reading data with particular `Input` only when it was written using its 
+> corresponding `Output`. > However, some intputs offer additional guarantees. For example `JsonStringInput` will accept 
+> fields in any order even though `JsonStringOutput` retains field order in the resulting JSON string. This way it's 
+> possible to use `JsonStringInput` to read JSON that was written by other tools or humans that may mix up field order.
+
 However, there are also serialization formats that use memory representation where an object is usually backed by a hashtable. Such representations cannot retain field order.
 `GenCodec` can still work with these but as an alternative to preserving field order, they must implement random field access (field-by-name access). This is done by
 overriding [`peekField`](avsystem.github.io/scala-commons/api/com/avsystem/commons/serialization/ObjectInput.html#peekField(name:String):com.avsystem.commons.misc.Opt[com.avsystem.commons.serialization.FieldInput]) on `ObjectInput`.
 
 To summarize, an `ObjectInput` is generally **not** guaranteed to retain order of fields as they were written to an `ObjectOutput` but if it doesn't then it must
-provide random field access by field name. Also, note that out of all the default and macro-generated codecs provided, only [flat sealed hierarchy codecs](#flat-format) actually depend
+provide random field access by field name. Also, note that out of all the default and macro-generated codecs provided, only [flat sealed hierarchy codecs](#flat-format) actually depends
 on this requirement. All the other (non-custom) codecs ignore field order during deserialization so you can e.g. freely
 reorder fields in your case classes if they use macro generated codecs.
 

--- a/docs/GenCodec.md
+++ b/docs/GenCodec.md
@@ -167,7 +167,7 @@ were written to `JsonObjectOutput`. For these formats it is required that an `Ob
 a corresponding `ObjectOutput`. This normally includes all serialization formats backed by strings, byte sequences, streams, etc.
 
 > :bulb: It is generally recommended reading data with particular `Input` only when it was written using its 
-> corresponding `Output`. > However, some intputs offer additional guarantees. For example `JsonStringInput` will accept 
+> corresponding `Output`. However, some intputs offer additional guarantees. For example `JsonStringInput` will accept 
 > fields in any order even though `JsonStringOutput` retains field order in the resulting JSON string. This way it's 
 > possible to use `JsonStringInput` to read JSON that was written by other tools or humans that may mix up field order.
 


### PR DESCRIPTION
This makes it possible to read [flat sealed hierarchies](https://github.com/AVSystem/scala-commons/blob/master/docs/GenCodec.md#flat-format) even if `_case` field is not the first one.