### PR TITLE
Introduced `AutoOptionalParam` implicit as an alternative to `optionalParam` annotation

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/meta/OptionLike.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/meta/OptionLike.scala
@@ -52,3 +52,24 @@ object OptionLike {
   implicit def nOptOptionLike[A]: BaseOptionLike[NOpt[A], A] =
     new OptionLikeImpl(NOpt.Empty, NOpt.some, _.isDefined, _.get)
 }
+
+/**
+  * If there is an instance of [[AutoOptionalParam]] for some type `T` then all case class &
+  * RPC parameters of type `T` will be treated as if they were annotated with
+  * [[com.avsystem.commons.serialization.optionalParam @optionalParam]].
+  *
+  * As with `@optionalParam` annotation, independently there must be also
+  * an instance of [[OptionLike]] for `T` for the entire mechanism to work. See the scaladoc of
+  * [[com.avsystem.commons.serialization.optionalParam optionalParam]] for more information.
+  */
+sealed trait AutoOptionalParam[T]
+object AutoOptionalParam {
+  def apply[T]: AutoOptionalParam[T] = null
+}
+
+trait AutoOptionalParams {
+  implicit def allAutoOptionalParams[T](
+    implicit optionLike: OptionLike[T]
+  ): AutoOptionalParam[T] = AutoOptionalParam[T]
+}
+object AutoOptionalParams extends AutoOptionalParams

--- a/commons-core/src/main/scala/com/avsystem/commons/meta/OptionLike.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/meta/OptionLike.scala
@@ -10,12 +10,21 @@ sealed trait OptionLike[O] {
   def isDefined(opt: O): Boolean
   def get(opt: O): Value
 
+  /**
+    * Determines whether `null` values should be collapsed into empty values (i.e. [[none]]).
+    * Used primarily by `GenCodec` when deserializing and dealing with e.g. JSON nulls vs missing fields.
+    */
+  def ignoreNulls: Boolean
+
   def fold[B](opt: O, ifEmpty: => B)(f: Value => B): B = if (isDefined(opt)) f(get(opt)) else ifEmpty
   def getOrElse[B >: Value](opt: O, default: => B): B = if (isDefined(opt)) get(opt) else default
   def foreach(opt: O, f: Value => Unit): Unit = if (isDefined(opt)) f(get(opt))
 
   final def convert[OO, V](opt: O, into: OptionLike.Aux[OO, V])(fun: Value => V): OO =
     fold(opt, into.none)(v => into.some(fun(v)))
+
+  final def apply(value: Value): O =
+    if (ignoreNulls && (value.asInstanceOf[AnyRef] eq null)) none else some(value)
 }
 
 @bincompat
@@ -27,30 +36,38 @@ final class OptionLikeImpl[O, A](
   empty: O,
   someFun: A => O,
   isDefinedFun: O => Boolean,
-  getFun: O => A
+  getFun: O => A,
+  val ignoreNulls: Boolean
 ) extends BaseOptionLike[O, A] {
   def none: O = empty
   def some(value: A): O = someFun(value)
   def isDefined(opt: O): Boolean = isDefinedFun(opt)
   def get(opt: O): A = getFun(opt)
+
+  @bincompat private[meta] def this(
+    empty: O,
+    someFun: A => O,
+    isDefinedFun: O => Boolean,
+    getFun: O => A,
+  ) = this(empty, someFun, isDefinedFun, getFun, ignoreNulls = true)
 }
 object OptionLike {
   type Aux[O, V] = OptionLike[O] {type Value = V}
 
   implicit def optionOptionLike[A]: BaseOptionLike[Option[A], A] =
-    new OptionLikeImpl(None, Some(_), _.isDefined, _.get)
+    new OptionLikeImpl(None, Some(_), _.isDefined, _.get, ignoreNulls = true)
 
   implicit def optOptionLike[A]: BaseOptionLike[Opt[A], A] =
-    new OptionLikeImpl(Opt.Empty, Opt.some, _.isDefined, _.get)
+    new OptionLikeImpl(Opt.Empty, Opt.some, _.isDefined, _.get, ignoreNulls = true)
 
   implicit def optRefOptionLike[A >: Null]: BaseOptionLike[OptRef[A], A] =
-    new OptionLikeImpl(OptRef.Empty, OptRef.some, _.isDefined, _.get)
+    new OptionLikeImpl(OptRef.Empty, OptRef.some, _.isDefined, _.get, ignoreNulls = true)
 
   implicit def optArgOptionLike[A]: BaseOptionLike[OptArg[A], A] =
-    new OptionLikeImpl(OptArg.Empty, OptArg.some, _.isDefined, _.get)
+    new OptionLikeImpl(OptArg.Empty, OptArg.some, _.isDefined, _.get, ignoreNulls = true)
 
   implicit def nOptOptionLike[A]: BaseOptionLike[NOpt[A], A] =
-    new OptionLikeImpl(NOpt.Empty, NOpt.some, _.isDefined, _.get)
+    new OptionLikeImpl(NOpt.Empty, NOpt.some, _.isDefined, _.get, ignoreNulls = false)
 }
 
 /**

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/OptionalFieldValueCodec.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/OptionalFieldValueCodec.scala
@@ -1,0 +1,13 @@
+package com.avsystem.commons
+package serialization
+
+import com.avsystem.commons.meta.OptionLike
+
+final class OptionalFieldValueCodec[O, V](optionLike: OptionLike.Aux[O, V], valueCodec: GenCodec[V]) extends GenCodec[O] {
+  def read(input: Input): O =
+    if (optionLike.ignoreNulls && input.readNull()) optionLike.none
+    else optionLike.some(valueCodec.read(input))
+
+  def write(output: Output, value: O): Unit =
+    optionLike.fold(value, output.writeNull())(valueCodec.write(output, _))
+}

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/optionalParam.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/optionalParam.scala
@@ -7,8 +7,13 @@ package serialization
   *
   * Makes the parameter optional, meaning that its type must be an `Option`, `Opt`, `OptArg` or any other type
   * that has an instance of [[com.avsystem.commons.meta.OptionLike OptionLike]].
-  * When the value is empty, the resulting JSON object or map of raw values simply lacks the entry
-  * corresponding to this parameter.
+  * When writing, the resulting object (e.g. JSON) or map of raw values simply lacks the entry corresponding
+  * to this parameter if its value is empty (as defined by `OptionLike` instance).
+  *
+  * When reading, a complete lack of a field in an object (e.g. JSON) is interpreted as an empty value.
+  * Depending on the exact param type (e.g. `Opt` vs `NOpt`), `null` value may also be interpreted as a complete
+  * lack of a value. This is controlled by `OptionLike.ignoreNulls` which is `true` for all option-like
+  * types except `NOpt`.
   *
   * [[optionalParam]] is an alternative, better way of expressing optional params as opposed to usage of
   * [[whenAbsent]] with [[transientDefault]], i.e.

--- a/commons-core/src/main/scala/com/avsystem/commons/serialization/optionalParam.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/serialization/optionalParam.scala
@@ -4,7 +4,29 @@ package serialization
 /**
   * Can be applied on case class fields (for `GenCodec` generation) and RPC parameters (for RPC interfaces)
   * collected into a map of raw values.
-  * Makes the parameter optional, meaning that its type must be an `Option`, `Opt`, `OptArg`, etc. When the value is
-  * empty, the resulting JSON object or map of raw values simply lacks the entry corresponding to this parameter.
+  *
+  * Makes the parameter optional, meaning that its type must be an `Option`, `Opt`, `OptArg` or any other type
+  * that has an instance of [[com.avsystem.commons.meta.OptionLike OptionLike]].
+  * When the value is empty, the resulting JSON object or map of raw values simply lacks the entry
+  * corresponding to this parameter.
+  *
+  * [[optionalParam]] is an alternative, better way of expressing optional params as opposed to usage of
+  * [[whenAbsent]] with [[transientDefault]], i.e.
+  *
+  * {{{
+  *   case class Stuff(@optionalParam optInt: Opt[Int])
+  *   object Stuff extends HasGenCodec[Stuff]
+  * }}}
+  *
+  * works effectively the same as
+  *
+  * {{{
+  *   case class Stuff(@transientDefault @whenAbsent(Opt.Empty) optInt: Opt[Int])
+  *   object Stuff extends HasGenCodec[Stuff]
+  * }}}
+  *
+  * The difference is that when using `@whenAbsent` + `@transientDefault`, an instance of `GenCodec[Opt[Int]]`
+  * is looked up by the macro engine. When using `@optionalParam`, an instance of `GenCodec[Int]` is looked up
+  * directly (`Opt` is automatically unwrapped from implicit search).
   */
 class optionalParam extends StaticAnnotation

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/CodecTestData.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/CodecTestData.scala
@@ -3,6 +3,7 @@ package serialization
 
 import com.avsystem.commons.annotation.AnnotationAggregate
 import com.avsystem.commons.meta.MacroInstances
+import com.avsystem.commons.meta.AutoOptionalParams
 import com.avsystem.commons.misc.{TypedKey, TypedKeyCompanion}
 
 object CodecTestData {
@@ -169,6 +170,13 @@ object CodecTestData {
     @optionalParam bul: Option[Boolean]
   )
   object CaseClassWithOptionalFields extends HasGenCodec[CaseClassWithOptionalFields]
+
+  case class CaseClassWithAutoOptionalFields(
+    str: String,
+    int: Opt[Int],
+    bul: Option[Boolean]
+  )
+  object CaseClassWithAutoOptionalFields extends HasGenCodecWithDeps[AutoOptionalParams.type, CaseClassWithAutoOptionalFields]
 
   class CaseClassLike(val str: String, val intList: List[Int])
     extends Wrapper[CaseClassLike](str, intList)

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/CodecTestData.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/CodecTestData.scala
@@ -174,7 +174,8 @@ object CodecTestData {
   case class CaseClassWithAutoOptionalFields(
     str: String,
     int: Opt[Int],
-    bul: Option[Boolean]
+    bul: Option[Boolean],
+    nint: NOpt[Opt[Int]],
   )
   object CaseClassWithAutoOptionalFields extends HasGenCodecWithDeps[AutoOptionalParams.type, CaseClassWithAutoOptionalFields]
 

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
@@ -87,9 +87,9 @@ abstract class GenCodecRoundtripTest extends AbstractCodecTest {
   }
 
   test("case class with auto optional fields") {
-    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt(42), Some(true)))
-    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true)))
-    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt.Empty, None))
+    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt(42), Some(true), NOpt(Opt(123))))
+    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true), NOpt(Opt.Empty)))
+    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt.Empty, None, NOpt.empty))
   }
 
   test("case class like") {

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
@@ -86,6 +86,12 @@ abstract class GenCodecRoundtripTest extends AbstractCodecTest {
     testRoundtrip(CaseClassWithOptionalFields("foo", Opt.Empty, None))
   }
 
+  test("case class with auto optional fields") {
+    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt(42), Some(true)))
+    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true)))
+    testRoundtrip(CaseClassWithAutoOptionalFields("foo", Opt.Empty, None))
+  }
+
   test("case class like") {
     testRoundtrip(CaseClassLike("dafuq", List(1, 2, 3)))
   }

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
@@ -113,9 +113,14 @@ class SimpleGenCodecTest extends SimpleIOCodecTest {
   }
 
   test("case class with auto optional fields") {
-    testWrite(CaseClassWithAutoOptionalFields("foo", Opt(42), Some(true)), Map("str" -> "foo", "int" -> 42, "bul" -> true))
-    testWrite(CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true)), Map("str" -> "foo", "bul" -> true))
-    testWrite(CaseClassWithAutoOptionalFields("foo", Opt.Empty, None), Map("str" -> "foo"))
+    testWrite(CaseClassWithAutoOptionalFields("foo", Opt(42), Some(true), NOpt(Opt(123))), Map("str" -> "foo", "int" -> 42, "bul" -> true, "nint" -> 123))
+    testWrite(CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true), NOpt(Opt.Empty)), Map("str" -> "foo", "bul" -> true, "nint" -> null))
+    testWrite(CaseClassWithAutoOptionalFields("foo", Opt.Empty, None, NOpt.empty), Map("str" -> "foo"))
+  }
+
+  test("reading nulls in case class with auto optional fields") {
+    testRead(Map("str" -> "foo", "int" -> null, "bul" -> true, "nint" -> null), CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true), NOpt(Opt.Empty)))
+    testRead(Map("str" -> "foo", "int" -> null, "bul" -> null), CaseClassWithAutoOptionalFields("foo", Opt.Empty, None, NOpt.Empty))
   }
 
   test("case class like") {

--- a/commons-core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
@@ -112,6 +112,12 @@ class SimpleGenCodecTest extends SimpleIOCodecTest {
     testWrite(CaseClassWithOptionalFields("foo", Opt.Empty, None), Map("str" -> "foo"))
   }
 
+  test("case class with auto optional fields") {
+    testWrite(CaseClassWithAutoOptionalFields("foo", Opt(42), Some(true)), Map("str" -> "foo", "int" -> 42, "bul" -> true))
+    testWrite(CaseClassWithAutoOptionalFields("foo", Opt.Empty, Some(true)), Map("str" -> "foo", "bul" -> true))
+    testWrite(CaseClassWithAutoOptionalFields("foo", Opt.Empty, None), Map("str" -> "foo"))
+  }
+
   test("case class like") {
     testWrite(CaseClassLike("dafuq", List(1, 2, 3)),
       Map("some.str" -> "dafuq", "intList" -> List(1, 2, 3))

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/TypeClassDerivation.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/TypeClassDerivation.scala
@@ -1,9 +1,11 @@
 package com.avsystem.commons
 package macros
 
+import com.avsystem.commons.macros.meta.MacroSymbols
+
 import scala.reflect.macros.blackbox
 
-trait TypeClassDerivation extends MacroCommons {
+trait TypeClassDerivation extends MacroSymbols {
 
   import c.universe._
 
@@ -122,7 +124,7 @@ trait TypeClassDerivation extends MacroCommons {
   def dependencyType(tpe: Type): Type = typeClassInstance(tpe)
 
   def getOptionLike(sym: Symbol, tpe: Type): Option[CachedImplicit] =
-    if (allowOptionalParams && findAnnotation(sym, OptionalParamAT).isDefined)
+    if (allowOptionalParams && isOptionalParam(sym, tpe))
       Some(inferCachedImplicit(getType(tq"$CommonsPkg.meta.OptionLike[$tpe]"), ErrorCtx("not an option-like type", sym.pos)))
     else
       None

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/meta/AdtMetadataMacros.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/meta/AdtMetadataMacros.scala
@@ -89,7 +89,7 @@ private[commons] class AdtMetadataMacros(ctx: blackbox.Context) extends Abstract
     def description: String = s"$shortDescription $nameStr of ${owner.description}"
 
     lazy val optionLike: Option[CachedImplicit] =
-      annot(OptionalParamAT).map(_ => infer(tq"$OptionLikeCls[$actualType]"))
+      if (isOptionalParam(symbol, actualType)) Some(infer(tq"$OptionLikeCls[$actualType]")) else None
 
     lazy val nonOptionalType: Type =
       optionLike.fold(actualType)(optionLikeValueType(_, this))

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/meta/MacroSymbols.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/meta/MacroSymbols.scala
@@ -16,6 +16,7 @@ private[commons] trait MacroSymbols extends MacroCommons {
   final def MetaPackage = q"$CommonsPkg.meta"
   final def RpcUtils = q"$RpcPackage.RpcUtils"
   final def OptionLikeCls = tq"$MetaPackage.OptionLike"
+  final def AutoOptionalParamCls = tq"$MetaPackage.AutoOptionalParam"
   final def FactoryCls = tq"$CollectionPkg.compat.Factory"
   final lazy val RpcArityAT: Type = staticType(tq"$MetaPackage.SymbolArity")
   final lazy val SingleArityAT: Type = staticType(tq"$MetaPackage.single")
@@ -36,6 +37,9 @@ private[commons] trait MacroSymbols extends MacroCommons {
   final lazy val WhenUntaggedArg: Symbol = TaggedAT.member(TermName("whenUntagged"))
   final lazy val UnmatchedErrorArg: Symbol = UnmatchedAT.member(TermName("error"))
   final lazy val UnmatchedParamErrorArg: Symbol = UnmatchedParamAT.member(TermName("error"))
+
+  def isOptionalParam(param: Symbol, tpe: Type): Boolean =
+    findAnnotation(param, OptionalParamAT).isDefined || inferImplicitValue(getType(tq"$AutoOptionalParamCls[$tpe]")) != EmptyTree
 
   def primaryConstructor(ownerType: Type, ownerParam: Option[MacroSymbol]): Symbol =
     primaryConstructorOf(ownerType, ownerParam.fold("")(p => s"${p.problemStr}:\n"))

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/rpc/RpcMappings.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/rpc/RpcMappings.scala
@@ -278,7 +278,7 @@ private[commons] trait RpcMappings { this: RpcMacroCommons with RpcSymbols =>
         val realValueTree = erp.realParam.optionLike match {
           case Some(realOptionLike) =>
             def optionLike = realOptionLike.reference(Nil)
-            q"$mappedPf.andThen($optionLike.some(_)).applyOrElse(${erp.rpcName}, (_: $StringCls) => $optionLike.none)"
+            q"$mappedPf.andThen($optionLike.apply(_)).applyOrElse(${erp.rpcName}, (_: $StringCls) => $optionLike.none)"
           case None =>
             q"$mappedPf.applyOrElse(${erp.rpcName}, (_: $StringCls) => ${erp.fallbackValueTree})"
         }

--- a/commons-macros/src/main/scala/com/avsystem/commons/macros/rpc/RpcSymbols.scala
+++ b/commons-macros/src/main/scala/com/avsystem/commons/macros/rpc/RpcSymbols.scala
@@ -245,7 +245,7 @@ private[commons] trait RpcSymbols extends MacroSymbols { this: RpcMacroCommons =
       owner.typeParams.filter(tp => actualType.contains(tp.symbol))
 
     lazy val optionLike: Option[CachedImplicit] =
-      annot(OptionalParamAT).map(_ => infer(tq"$OptionLikeCls[$actualType]"))
+      if (isOptionalParam(symbol, actualType)) Some(infer(tq"$OptionLikeCls[$actualType]")) else None
 
     lazy val nonOptionalType: Type =
       optionLike.fold(actualType)(optionLikeValueType(_, this))


### PR DESCRIPTION
Using implicit instances of `AutoOptionalParam` it is now possible to make some types behave as if there were always annotated with `@optionalParam` annotation. This is an opt-in mechanism, you have to bring implicit `AutoOptionalParam` instances explicitly into your scope, e.g. with `HasGenCodecWithDeps[AutoOptionalParams.type, ...]`