### PR TITLE
Convert optional value wrappers to immutable Iterable

### DIFF
--- a/commons-core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
@@ -1,5 +1,7 @@
 package com.avsystem.commons.misc
 
+import com.avsystem.commons.IIterable
+
 object NOpt {
   // These two are used as NOpt's raw value to represent empty NOpt and NOpt(null).
   // Unfortunately, null itself can't be used for that purpose because https://github.com/scala/bug/issues/7396
@@ -20,7 +22,7 @@ object NOpt {
   def some[A](value: A): NOpt[A] =
     new NOpt(if (value == null) NullMarker else value)
 
-  implicit def opt2Iterable[A](xo: NOpt[A]): Iterable[A] = xo.toList
+  implicit def opt2Iterable[A](xo: NOpt[A]): IIterable[A] = xo.toList
 
   final val Empty: NOpt[Nothing] = new NOpt(EmptyMarker)
 

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/Opt.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/Opt.scala
@@ -1,5 +1,7 @@
 package com.avsystem.commons.misc
 
+import com.avsystem.commons.IIterable
+
 object Opt {
   // Used as Opt's raw value to represent empty Opt. Unfortunately, null can't be used for that purpose
   // because https://github.com/scala/bug/issues/7396
@@ -12,7 +14,7 @@ object Opt {
     if (value != null) new Opt[A](value)
     else throw new NullPointerException
 
-  implicit def opt2Iterable[A](xo: Opt[A]): Iterable[A] = xo.toList
+  implicit def opt2Iterable[A](xo: Opt[A]): IIterable[A] = xo.toList
 
   final val Empty: Opt[Nothing] = new Opt(EmptyMarker)
 

--- a/commons-core/src/main/scala/com/avsystem/commons/misc/OptRef.scala
+++ b/commons-core/src/main/scala/com/avsystem/commons/misc/OptRef.scala
@@ -1,5 +1,7 @@
 package com.avsystem.commons.misc
 
+import com.avsystem.commons.IIterable
+
 object OptRef {
   def apply[A >: Null](value: A): OptRef[A] = new OptRef[A](value)
   def unapply[A >: Null](opt: OptRef[A]): OptRef[A] = opt //name-based extractor
@@ -13,7 +15,7 @@ object OptRef {
       if (optRef.isEmpty) Opt.Empty else Opt(unboxing.fun(optRef.get))
   }
 
-  implicit def opt2Iterable[A >: Null](xo: OptRef[A]): Iterable[A] = xo.toList
+  implicit def opt2Iterable[A >: Null](xo: OptRef[A]): IIterable[A] = xo.toList
 
   final val Empty: OptRef[Null] = new OptRef[Null](null)
 

--- a/commons-core/src/test/scala/com/avsystem/commons/misc/OptTest.scala
+++ b/commons-core/src/test/scala/com/avsystem/commons/misc/OptTest.scala
@@ -1,8 +1,7 @@
 package com.avsystem.commons.misc
 
-import com.avsystem.commons
-import org.scalatest.funsuite.AnyFunSuite
 import com.avsystem.commons.JInteger
+import org.scalatest.funsuite.AnyFunSuite
 
 class OptTest extends AnyFunSuite {
   test("nonempty test") {


### PR DESCRIPTION
Requested change: `opt2iterable` implicit conversion returns `scala.collection.immutable.Iterable` instead of base `scala.collection.Iterable`.

Reason to change: implicit conversion is not applied when working with immutable APIs like `monix.reactive.Observable#flatMapIterable`. This change should not break backwards compatibility since `sci.Iterable` extends `sc.Iterable`. Also implementation is not affected since wrappers are converted to `List` underneath.