### PR TITLE
Set content type and character encoding in JettyRPCFramework response

### DIFF
--- a/commons-jetty/src/main/scala/com/avsystem/commons/jetty/rpc/JettyRPCFramework.scala
+++ b/commons-jetty/src/main/scala/com/avsystem/commons/jetty/rpc/JettyRPCFramework.scala
@@ -104,6 +104,8 @@ object JettyRPCFramework extends StandardRPCFramework with LazyLogging {
           val async = request.startAsync().setup(_.setTimeout(contextTimeout.toMillis))
           handlePost(call).andThenNow {
             case Success(responseContent) =>
+              response.setContentType(MimeTypes.Type.APPLICATION_JSON.asString())
+              response.setCharacterEncoding(StandardCharsets.UTF_8.name())
               response.getWriter.write(responseContent.s)
             case Failure(t) =>
               response.sendError(HttpStatus.INTERNAL_SERVER_ERROR_500, t.getMessage)

--- a/commons-jetty/src/test/scala/com/avsystem/commons/jetty/rpc/JettyRPCFrameworkTest.scala
+++ b/commons-jetty/src/test/scala/com/avsystem/commons/jetty/rpc/JettyRPCFrameworkTest.scala
@@ -93,7 +93,7 @@ class JettyRPCFrameworkTest extends AnyFunSuite with ScalaFutures with Matchers 
   }
 
   test("inner rpc + string arg -> string") {
-    val world = "world"
+    val world = "gżegżółka"
     rpc.topper.hello(world).futureValue shouldBe world
     val anonymous = ""
     rpc.topper.hello(anonymous).futureValue shouldBe anonymous


### PR DESCRIPTION
Technically any of these suffices, but I guess it doesn't hurt to be strict.