### PR TITLE
Changed `BsonInput`/`BsonOutput` implementations to use optimized value representations

### DIFF
--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonGenCodecs.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonGenCodecs.scala
@@ -1,18 +1,17 @@
 package com.avsystem.commons
 package mongo
 
-import java.nio.ByteBuffer
-import com.avsystem.commons.serialization.GenCodec.{ReadFailure, WriteFailure}
-import com.avsystem.commons.serialization.{GenCodec, GenKeyCodec, TransparentWrapping}
-import org.bson.codecs.{BsonValueCodec, DecoderContext, EncoderContext}
+import com.avsystem.commons.serialization.GenCodec.ReadFailure
+import com.avsystem.commons.serialization._
+import org.bson._
 import org.bson.io.BasicOutputBuffer
 import org.bson.types.{Decimal128, ObjectId}
-import org.bson.{BsonArray, BsonBinary, BsonBinaryReader, BsonBinaryWriter, BsonBoolean, BsonDateTime, BsonDecimal128, BsonDocument, BsonDouble, BsonElement, BsonInt32, BsonInt64, BsonNull, BsonObjectId, BsonString, BsonType, BsonValue}
+
+import java.nio.ByteBuffer
 
 trait BsonGenCodecs {
   implicit def objectIdCodec: GenCodec[ObjectId] = BsonGenCodecs.objectIdCodec
   implicit def objectIdKeyCodec: GenKeyCodec[ObjectId] = BsonGenCodecs.objectIdKeyCodec
-
   implicit def decimal128Codec: GenCodec[Decimal128] = BsonGenCodecs.decimal128Codec
 
   implicit def bsonArrayCodec: GenCodec[BsonArray] = BsonGenCodecs.bsonArrayCodec
@@ -33,13 +32,13 @@ trait BsonGenCodecs {
 object BsonGenCodecs {
   // needed so that ObjectId can be used as ID type in AutoIdMongoEntity
   // (TransparentWrapping is used in EntityIdMode)
-  implicit val objectIdIdentityWrapping: TransparentWrapping[ObjectId, ObjectId] =
-    TransparentWrapping.identity
+  implicit val objectIdIdentityWrapping: TransparentWrapping[ObjectId, ObjectId] = TransparentWrapping.identity
 
   implicit val objectIdCodec: GenCodec[ObjectId] = GenCodec.nullable(
     i => i.readCustom(ObjectIdMarker).getOrElse(new ObjectId(i.readSimple().readString())),
     (o, v) => if (!o.writeCustom(ObjectIdMarker, v)) o.writeSimple().writeString(v.toHexString)
   )
+
   implicit val objectIdKeyCodec: GenKeyCodec[ObjectId] =
     GenKeyCodec.create(new ObjectId(_), _.toHexString)
 
@@ -48,104 +47,43 @@ object BsonGenCodecs {
     (o, v) => if (!o.writeCustom(Decimal128Marker, v)) o.writeSimple().writeBigDecimal(v.bigDecimalValue())
   )
 
-  implicit val bsonArrayCodec: GenCodec[BsonArray] = GenCodec.nullableList(
-    li => new BsonArray(li.iterator(bsonValueCodec.read).to(JList)),
-    (lo, ba) => ba.asScala.foreach(bsonValueCodec.write(lo.writeElement(), _))
-  )
-
-  implicit val bsonBinaryCodec: GenCodec[BsonBinary] =
-    GenCodec.ByteArrayCodec.transform[BsonBinary](_.getData, new BsonBinary(_))
-
-  implicit val bsonBooleanCodec: GenCodec[BsonBoolean] =
-    GenCodec.BooleanCodec.transform[BsonBoolean](_.getValue, new BsonBoolean(_))
-
-  implicit val bsonDateTimeCodec: GenCodec[BsonDateTime] = GenCodec.nullableSimple(
-    i => new BsonDateTime(i.readTimestamp()),
-    (o, v) => o.writeTimestamp(v.getValue)
-  )
-
-  implicit val bsonDocumentCodec: GenCodec[BsonDocument] = GenCodec.nullableObject(
-    oi => new BsonDocument(oi.iterator(bsonValueCodec.read).map {
-      case (k, v) => new BsonElement(k, v)
-    }.to(JList)),
-    (oo, bd) => bd.asScala.foreach { case (key, value) =>
-      bsonValueCodec.write(oo.writeField(key), value)
+  implicit val bsonValueCodec: GenCodec[BsonValue] = GenCodec.create(
+    i => i.readCustom(BsonValueMarker).getOrElse {
+      val reader = new BsonBinaryReader(ByteBuffer.wrap(i.readSimple().readBinary()))
+      BsonValueUtils.decode(reader)
+    },
+    (o, bv) => if (!o.writeCustom(BsonValueMarker, bv)) {
+      val buffer = new BasicOutputBuffer()
+      val writer = new BsonBinaryWriter(buffer)
+      BsonValueUtils.encode(writer, bv)
+      writer.flush()
+      writer.close()
+      o.writeSimple().writeBinary(buffer.toByteArray)
     }
   )
 
-  implicit val bsonDecimal128Codec: GenCodec[BsonDecimal128] =
-    decimal128Codec.transform[BsonDecimal128](_.getValue, new BsonDecimal128(_))
+  private def bsonValueSubCodec[T <: BsonValue](fromBsonValue: BsonValue => T): GenCodec[T] =
+    bsonValueCodec.transform(identity, fromBsonValue)
 
-  implicit val bsonDoubleCodec: GenCodec[BsonDouble] =
-    GenCodec.DoubleCodec.transform(_.getValue, new BsonDouble(_))
-
-  implicit val bsonInt32Codec: GenCodec[BsonInt32] =
-    GenCodec.IntCodec.transform(_.getValue, new BsonInt32(_))
-
-  implicit val bsonInt64Codec: GenCodec[BsonInt64] =
-    GenCodec.LongCodec.transform(_.getValue, new BsonInt64(_))
+  implicit val bsonArrayCodec: GenCodec[BsonArray] = bsonValueSubCodec(_.asArray())
+  implicit val bsonBinaryCodec: GenCodec[BsonBinary] = bsonValueSubCodec(_.asBinary())
+  implicit val bsonBooleanCodec: GenCodec[BsonBoolean] = bsonValueSubCodec(_.asBoolean())
+  implicit val bsonDateTimeCodec: GenCodec[BsonDateTime] = bsonValueSubCodec(_.asDateTime())
+  implicit val bsonDocumentCodec: GenCodec[BsonDocument] = bsonValueSubCodec(_.asDocument())
+  implicit val bsonDecimal128Codec: GenCodec[BsonDecimal128] = bsonValueSubCodec(_.asDecimal128())
+  implicit val bsonDoubleCodec: GenCodec[BsonDouble] = bsonValueSubCodec(_.asDouble())
+  implicit val bsonInt32Codec: GenCodec[BsonInt32] = bsonValueSubCodec(_.asInt32())
+  implicit val bsonInt64Codec: GenCodec[BsonInt64] = bsonValueSubCodec(_.asInt64())
 
   implicit val bsonNullCodec: GenCodec[BsonNull] =
-    GenCodec.create(i => {
-      if (!i.readNull()) throw new ReadFailure("Input did not contain expected null value")
-      BsonNull.VALUE
-    }, (o, _) => o.writeNull())
+    bsonValueSubCodec { bv =>
+      if (bv.isNull) BsonNull.VALUE
+      else throw new ReadFailure("Input did not contain expected null value")
+    }
 
   implicit val bsonObjectIdCodec: GenCodec[BsonObjectId] =
     objectIdCodec.transform(_.getValue, new BsonObjectId(_))
 
   implicit val bsonStringCodec: GenCodec[BsonString] =
     GenCodec.StringCodec.transform(_.getValue, new BsonString(_))
-
-  private val mongoBsonValueCodec: BsonValueCodec = new BsonValueCodec()
-  private val mongoDecoderContext: DecoderContext = DecoderContext.builder().build()
-  private val mongoEncoderContext: EncoderContext = EncoderContext.builder().build()
-
-  implicit val bsonValueCodec: GenCodec[BsonValue] = GenCodec.create(
-    i => {
-      val bvOpt = i.readMetadata(BsonTypeMetadata) map {
-        case BsonType.ARRAY => bsonArrayCodec.read(i)
-        case BsonType.BINARY => bsonBinaryCodec.read(i)
-        case BsonType.BOOLEAN => bsonBooleanCodec.read(i)
-        case BsonType.DATE_TIME => bsonDateTimeCodec.read(i)
-        case BsonType.DECIMAL128 => bsonDecimal128Codec.read(i)
-        case BsonType.DOCUMENT => bsonDocumentCodec.read(i)
-        case BsonType.DOUBLE => bsonDoubleCodec.read(i)
-        case BsonType.INT32 => bsonInt32Codec.read(i)
-        case BsonType.INT64 => bsonInt64Codec.read(i)
-        case BsonType.NULL => bsonNullCodec.read(i)
-        case BsonType.OBJECT_ID => bsonObjectIdCodec.read(i)
-        case BsonType.STRING => bsonStringCodec.read(i)
-        case other => throw new ReadFailure(s"Unsupported Bson type: $other")
-      }
-      bvOpt.getOrElse {
-        val reader = new BsonBinaryReader(ByteBuffer.wrap(i.readSimple().readBinary()))
-        mongoBsonValueCodec.decode(reader, mongoDecoderContext)
-      }
-    },
-    (o, bv) => if (o.keepsMetadata(BsonTypeMetadata)) {
-      bv match {
-        case array: BsonArray => bsonArrayCodec.write(o, array)
-        case binary: BsonBinary => bsonBinaryCodec.write(o, binary)
-        case boolean: BsonBoolean => bsonBooleanCodec.write(o, boolean)
-        case dateTime: BsonDateTime => bsonDateTimeCodec.write(o, dateTime)
-        case decimal128: BsonDecimal128 => bsonDecimal128Codec.write(o, decimal128)
-        case document: BsonDocument => bsonDocumentCodec.write(o, document)
-        case double: BsonDouble => bsonDoubleCodec.write(o, double)
-        case int32: BsonInt32 => bsonInt32Codec.write(o, int32)
-        case int64: BsonInt64 => bsonInt64Codec.write(o, int64)
-        case bNull: BsonNull => bsonNullCodec.write(o, bNull)
-        case objectId: BsonObjectId => bsonObjectIdCodec.write(o, objectId)
-        case string: BsonString => bsonStringCodec.write(o, string)
-        case other => throw new WriteFailure(s"Unsupported value: $other")
-      }
-    } else {
-      val buffer = new BasicOutputBuffer()
-      val writer = new BsonBinaryWriter(buffer)
-      mongoBsonValueCodec.encode(writer, bv, mongoEncoderContext)
-      writer.flush()
-      writer.close()
-      o.writeSimple().writeBinary(buffer.toByteArray)
-    }
-  )
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
@@ -1,11 +1,12 @@
 package com.avsystem.commons
 package mongo
 
-import java.nio.ByteBuffer
-
+import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization.{InputAndSimpleInput, InputMetadata, OutputAndSimpleOutput, TypeMarker}
-import org.bson.BsonType
+import org.bson.{BsonInvalidOperationException, BsonType}
 import org.bson.types.{Decimal128, ObjectId}
+
+import java.nio.ByteBuffer
 
 object ObjectIdMarker extends TypeMarker[ObjectId]
 object Decimal128Marker extends TypeMarker[Decimal128]
@@ -17,6 +18,48 @@ trait BsonInput extends Any with InputAndSimpleInput {
   def readDecimal128(): Decimal128
 
   protected def bsonType: BsonType
+
+  protected def handleFailures[T](expr: => T): T =
+    try expr catch {
+      case e: BsonInvalidOperationException => throw new ReadFailure(e.getMessage, e)
+    }
+
+  protected def wrongType(expected: BsonType*): Nothing =
+    throw new ReadFailure(s"Encountered BsonValue of type $bsonType, expected ${expected.mkString(" or ")}")
+
+  protected def expect[T](tpe: BsonType, value: => T): T =
+    if (bsonType == tpe) handleFailures(value)
+    else wrongType(tpe)
+
+  override def readBigInt(): BigInt = handleFailures {
+    bsonType match {
+      case BsonType.INT32 | BsonType.INT64 =>
+        BigInt(readLong())
+      case BsonType.DECIMAL128 =>
+        val bigDec = BigDecimal(readDecimal128().bigDecimalValue())
+        bigDec.toBigIntExact.getOrElse(throw new ReadFailure(s"whole number expected but got $bigDec"))
+      case BsonType.BINARY =>
+        BigInt(readBinary())
+      case _ =>
+        wrongType(BsonType.INT32, BsonType.INT64, BsonType.DECIMAL128, BsonType.BINARY)
+    }
+  }
+
+  override def readBigDecimal(): BigDecimal =
+    handleFailures {
+      bsonType match {
+        case BsonType.INT32 | BsonType.INT64 =>
+          BigDecimal(readLong())
+        case BsonType.DOUBLE =>
+          BigDecimal(readDouble())
+        case BsonType.DECIMAL128 =>
+          BigDecimal(readDecimal128().bigDecimalValue)
+        case BsonType.BINARY =>
+          BsonInput.bigDecimalFromBytes(readBinary())
+        case _ =>
+          wrongType(BsonType.INT32, BsonType.INT64, BsonType.DOUBLE, BsonType.DECIMAL128, BsonType.BINARY)
+      }
+    }
 
   override def readMetadata[T](metadata: InputMetadata[T]): Opt[T] =
     metadata match {
@@ -47,6 +90,19 @@ trait BsonOutput extends Any with OutputAndSimpleOutput {
   def writeObjectId(objectId: ObjectId): Unit
   def writeDecimal128(decimal128: Decimal128): Unit
 
+  override def writeBigInt(bigInt: BigInt): Unit =
+    if (bigInt.isValidLong) writeLong(bigInt.longValue)
+    else Decimal128Utils.fromBigDecimal(BigDecimal(bigInt)) match {
+      case Opt(dec128) => writeDecimal128(dec128)
+      case Opt.Empty => writeBinary(bigInt.toByteArray)
+    }
+
+  override def writeBigDecimal(bigDecimal: BigDecimal): Unit =
+    Decimal128Utils.fromBigDecimal(bigDecimal) match {
+      case Opt(dec128) => writeDecimal128(dec128)
+      case Opt.Empty => writeBinary(BsonOutput.bigDecimalBytes(bigDecimal))
+    }
+
   override def keepsMetadata(metadata: InputMetadata[_]): Boolean =
     BsonTypeMetadata == metadata
 
@@ -61,6 +117,7 @@ trait BsonOutput extends Any with OutputAndSimpleOutput {
 object BsonOutput {
   def bigDecimalBytes(bigDecimal: BigDecimal): Array[Byte] = {
     val unscaledBytes = bigDecimal.bigDecimal.unscaledValue.toByteArray
-    ByteBuffer.allocate(unscaledBytes.length + Integer.BYTES).put(unscaledBytes).putInt(bigDecimal.scale).array
+    ByteBuffer.allocate(unscaledBytes.length + Integer.BYTES)
+      .put(unscaledBytes).putInt(bigDecimal.scale).array
   }
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package mongo
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization.{InputAndSimpleInput, InputMetadata, OutputAndSimpleOutput, TypeMarker}
+import com.avsystem.commons.serialization.{FieldInput, InputAndSimpleInput, InputMetadata, OutputAndSimpleOutput, TypeMarker}
 import org.bson.types.{Decimal128, ObjectId}
 import org.bson.{BsonInvalidOperationException, BsonType, BsonValue}
 
@@ -88,6 +88,8 @@ object BsonInput {
     BigDecimal(unscaled, scale)
   }
 }
+
+trait BsonFieldInput extends BsonInput with FieldInput
 
 trait BsonOutput extends Any with OutputAndSimpleOutput {
   def writeObjectId(objectId: ObjectId): Unit

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
@@ -3,19 +3,21 @@ package mongo
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization.{InputAndSimpleInput, InputMetadata, OutputAndSimpleOutput, TypeMarker}
-import org.bson.{BsonInvalidOperationException, BsonType}
+import org.bson.{BsonInvalidOperationException, BsonType, BsonValue}
 import org.bson.types.{Decimal128, ObjectId}
 
 import java.nio.ByteBuffer
 
 object ObjectIdMarker extends TypeMarker[ObjectId]
 object Decimal128Marker extends TypeMarker[Decimal128]
+object BsonValueMarker extends TypeMarker[BsonValue]
 
 object BsonTypeMetadata extends InputMetadata[BsonType]
 
 trait BsonInput extends Any with InputAndSimpleInput {
   def readObjectId(): ObjectId
   def readDecimal128(): Decimal128
+  def readBsonValue(): BsonValue
 
   protected def bsonType: BsonType
 
@@ -71,6 +73,7 @@ trait BsonInput extends Any with InputAndSimpleInput {
     typeMarker match {
       case ObjectIdMarker => readObjectId().opt
       case Decimal128Marker => readDecimal128().opt
+      case BsonValueMarker => readBsonValue().opt
       case _ => Opt.Empty
     }
 }
@@ -89,6 +92,7 @@ object BsonInput {
 trait BsonOutput extends Any with OutputAndSimpleOutput {
   def writeObjectId(objectId: ObjectId): Unit
   def writeDecimal128(decimal128: Decimal128): Unit
+  def writeBsonValue(bsonValue: BsonValue): Unit
 
   override def writeBigInt(bigInt: BigInt): Unit =
     if (bigInt.isValidLong) writeLong(bigInt.longValue)
@@ -110,6 +114,7 @@ trait BsonOutput extends Any with OutputAndSimpleOutput {
     typeMarker match {
       case ObjectIdMarker => writeObjectId(value); true
       case Decimal128Marker => writeDecimal128(value); true
+      case BsonValueMarker => writeBsonValue(value); true
       case _ => false
     }
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonInputOutput.scala
@@ -3,8 +3,8 @@ package mongo
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization.{InputAndSimpleInput, InputMetadata, OutputAndSimpleOutput, TypeMarker}
-import org.bson.{BsonInvalidOperationException, BsonType, BsonValue}
 import org.bson.types.{Decimal128, ObjectId}
+import org.bson.{BsonInvalidOperationException, BsonType, BsonValue}
 
 import java.nio.ByteBuffer
 

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
@@ -26,10 +26,12 @@ class BsonReaderInput(br: BsonReader, override val legacyOptionEncoding: Boolean
   override def readInt(): Int =
     expect(BsonType.INT32, br.readInt32())
 
-  override def readLong(): Long = bsonType match {
-    case BsonType.INT32 => br.readInt32().toLong
-    case BsonType.INT64 => br.readInt64()
-    case _ => wrongType(BsonType.INT32, BsonType.INT64)
+  override def readLong(): Long = handleFailures {
+    bsonType match {
+      case BsonType.INT32 => br.readInt32().toLong
+      case BsonType.INT64 => br.readInt64()
+      case _ => wrongType(BsonType.INT32, BsonType.INT64)
+    }
   }
 
   override def readTimestamp(): Long =
@@ -41,12 +43,12 @@ class BsonReaderInput(br: BsonReader, override val legacyOptionEncoding: Boolean
   override def readBinary(): Array[Byte] =
     expect(BsonType.BINARY, br.readBinaryData().getData)
 
-  override def readList(): BsonReaderListInput = {
+  override def readList(): BsonReaderListInput = handleFailures {
     br.readStartArray()
     new BsonReaderListInput(new BsonReaderIterator(br, _.readEndArray(), new BsonReaderInput(_, legacyOptionEncoding)))
   }
 
-  override def readObject(): BsonReaderObjectInput = {
+  override def readObject(): BsonReaderObjectInput = handleFailures {
     br.readStartDocument()
     new BsonReaderObjectInput(br, legacyOptionEncoding)
   }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
@@ -1,10 +1,12 @@
 package com.avsystem.commons
 package mongo
 
-import com.avsystem.commons.serialization.{FieldInput, ListInput, ObjectInput}
+import com.avsystem.commons.serialization.{ListInput, ObjectInput}
 import com.google.common.collect.AbstractIterator
+import org.bson._
 import org.bson.types.{Decimal128, ObjectId}
-import org.bson.{BsonReader, BsonType, BsonValue}
+
+import _root_.scala.annotation.tailrec
 
 class BsonReaderInput(br: BsonReader, override val legacyOptionEncoding: Boolean = false)
   extends BsonInput {
@@ -46,9 +48,7 @@ class BsonReaderInput(br: BsonReader, override val legacyOptionEncoding: Boolean
 
   override def readObject(): BsonReaderObjectInput = {
     br.readStartDocument()
-    new BsonReaderObjectInput(new BsonReaderIterator(br, _.readEndDocument(),
-      br => new BsonReaderFieldInput(KeyEscaper.unescape(br.readName()), br, legacyOptionEncoding)
-    ))
+    new BsonReaderObjectInput(br, legacyOptionEncoding)
   }
 
   override def readObjectId(): ObjectId =
@@ -70,7 +70,7 @@ class BsonReaderInput(br: BsonReader, override val legacyOptionEncoding: Boolean
 }
 
 final class BsonReaderFieldInput(name: String, br: BsonReader, legacyOptionEncoding: Boolean)
-  extends BsonReaderInput(br, legacyOptionEncoding) with FieldInput {
+  extends BsonReaderInput(br, legacyOptionEncoding) with BsonFieldInput {
   override def fieldName: String = name
 }
 
@@ -91,7 +91,48 @@ final class BsonReaderListInput(it: BsonReaderIterator[BsonReaderInput]) extends
   override def nextElement(): BsonReaderInput = it.next()
 }
 
-final class BsonReaderObjectInput(it: BsonReaderIterator[BsonReaderFieldInput]) extends ObjectInput {
+final class BsonReaderObjectInput(br: BsonReader, legacyOptionEncoding: Boolean) extends ObjectInput {
+  private[this] val it = new BsonReaderIterator(br, _.readEndDocument(),
+    br => new BsonReaderFieldInput(
+      KeyEscaper.unescape(br.readName()),
+      br,
+      legacyOptionEncoding
+    )
+  )
+
+  private[this] var peekMark: BsonReaderMark = br.getMark
+  private[this] var peekedFields: MHashMap[String, BsonValue] = _
+
+  override def peekField(name: String): Opt[BsonFieldInput] =
+    br match {
+      case _: BsonDocumentReader =>
+        // Looks like there's a bug in BsonDocumentReader.Mark implementation, tests don't pass
+        // TODO: find and report/fix this bug
+        Opt.Empty
+      case _ =>
+        val peekedValue = peekedFields.opt.flatMap(_.getOpt(name)).orElse {
+          val savedMark = br.getMark
+          peekMark.reset()
+
+          @tailrec def loop(): Opt[BsonValue] =
+            if (br.readBsonType() == BsonType.END_OF_DOCUMENT) Opt.Empty
+            else KeyEscaper.unescape(br.readName()) match {
+              case `name` => BsonValueUtils.decode(br).opt
+              case otherName =>
+                if (peekedFields eq null) {
+                  peekedFields = new MHashMap
+                }
+                peekedFields(otherName) = BsonValueUtils.decode(br)
+                peekMark = br.getMark
+                loop()
+            }
+
+          try loop() finally savedMark.reset()
+        }
+
+        peekedValue.map(new BsonValueFieldInput(name, _, legacyOptionEncoding))
+    }
+
   override def hasNext: Boolean = it.hasNext
   override def nextField(): BsonReaderFieldInput = it.next()
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package mongo
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization.{FieldInput, GenCodec, Input, ListInput, ObjectInput}
+import com.avsystem.commons.serialization._
 import org.bson._
 import org.bson.types.{Decimal128, ObjectId}
 
@@ -14,31 +14,47 @@ object BsonValueInput {
 class BsonValueInput(bsonValue: BsonValue, override val legacyOptionEncoding: Boolean = false) extends BsonInput {
   protected def bsonType: BsonType = bsonValue.getBsonType
 
-  private def handleFailures[T](expr: => T): T =
-    try expr catch {
-      case e: BsonInvalidOperationException => throw new ReadFailure(e.getMessage, e)
-    }
+  def readString(): String =
+    expect(BsonType.STRING, bsonValue.asString().getValue)
 
-  def readString(): String = handleFailures(bsonValue.asString().getValue)
-  def readBoolean(): Boolean = handleFailures(bsonValue.asBoolean().getValue)
-  def readInt(): Int = handleFailures(bsonValue.asInt32().getValue)
+  def readBoolean(): Boolean =
+    expect(BsonType.BOOLEAN, bsonValue.asBoolean().getValue)
+
+  def readInt(): Int =
+    expect(BsonType.INT32, bsonValue.asInt32().getValue)
+
   def readLong(): Long = handleFailures {
     bsonType match {
-      case BsonType.INT32 => bsonValue.asInt32().getValue.toLong // allow converting INT32 to Long
-      case _ => bsonValue.asInt64().getValue
+      case BsonType.INT32 => readInt().toLong
+      case BsonType.INT64 => bsonValue.asInt64().getValue
+      case _ => wrongType(BsonType.INT32, BsonType.INT64)
     }
   }
-  override def readTimestamp(): Long = handleFailures(bsonValue.asDateTime().getValue)
-  def readDouble(): Double = handleFailures(bsonValue.asDouble().getValue)
-  def readBigInt(): BigInt = handleFailures(BigInt(bsonValue.asBinary().getData))
-  def readBigDecimal(): BigDecimal = handleFailures(BsonInput.bigDecimalFromBytes(bsonValue.asBinary().getData))
-  def readBinary(): Array[Byte] = handleFailures(bsonValue.asBinary().getData)
-  def readObjectId(): ObjectId = handleFailures(bsonValue.asObjectId().getValue)
-  def readDecimal128(): Decimal128 = handleFailures(bsonValue.asDecimal128().getValue)
 
-  def readNull(): Boolean = bsonValue == BsonNull.VALUE
-  def readList(): ListInput = new BsonValueListInput(handleFailures(bsonValue.asArray()), legacyOptionEncoding)
-  def readObject(): ObjectInput = new BsonValueObjectInput(handleFailures(bsonValue.asDocument()), legacyOptionEncoding)
+  override def readTimestamp(): Long =
+    expect(BsonType.DATE_TIME, bsonValue.asDateTime().getValue)
+
+  def readDouble(): Double =
+    expect(BsonType.DOUBLE, bsonValue.asDouble().getValue)
+
+  def readBinary(): Array[Byte] =
+    expect(BsonType.BINARY, bsonValue.asBinary().getData)
+
+  def readObjectId(): ObjectId =
+    expect(BsonType.OBJECT_ID, bsonValue.asObjectId().getValue)
+
+  def readDecimal128(): Decimal128 =
+    expect(BsonType.DECIMAL128, bsonValue.asDecimal128().getValue)
+
+  def readNull(): Boolean =
+    bsonValue == BsonNull.VALUE
+
+  def readList(): ListInput =
+    new BsonValueListInput(expect(BsonType.ARRAY, bsonValue.asArray()), legacyOptionEncoding)
+
+  def readObject(): ObjectInput =
+    new BsonValueObjectInput(expect(BsonType.DOCUMENT, bsonValue.asDocument()), legacyOptionEncoding)
+
   def skip(): Unit = ()
 }
 

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
@@ -1,7 +1,6 @@
 package com.avsystem.commons
 package mongo
 
-import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization._
 import org.bson._
 import org.bson.types.{Decimal128, ObjectId}
@@ -45,6 +44,9 @@ class BsonValueInput(bsonValue: BsonValue, override val legacyOptionEncoding: Bo
 
   def readDecimal128(): Decimal128 =
     expect(BsonType.DECIMAL128, bsonValue.asDecimal128().getValue)
+
+  def readBsonValue(): BsonValue =
+    bsonValue
 
   def readNull(): Boolean =
     bsonValue == BsonNull.VALUE

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
@@ -61,7 +61,7 @@ class BsonValueInput(bsonValue: BsonValue, override val legacyOptionEncoding: Bo
 }
 
 class BsonValueFieldInput(val fieldName: String, bsonValue: BsonValue, legacyOptionEncoding: Boolean)
-  extends BsonValueInput(bsonValue, legacyOptionEncoding) with FieldInput
+  extends BsonValueInput(bsonValue, legacyOptionEncoding) with BsonFieldInput
 
 class BsonValueListInput(bsonArray: BsonArray, legacyOptionEncoding: Boolean) extends ListInput {
   private val it = bsonArray.iterator

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueOutput.scala
@@ -13,8 +13,10 @@ object BsonValueOutput {
   }
 }
 
-final class BsonValueOutput(receiver: BsonValue => Unit = _ => (), override val legacyOptionEncoding: Boolean = false)
-  extends BsonOutput {
+final class BsonValueOutput(
+  receiver: BsonValue => Unit = _ => (),
+  override val legacyOptionEncoding: Boolean = false
+) extends BsonOutput {
 
   private var _value: Opt[BsonValue] = Opt.empty
 
@@ -28,20 +30,42 @@ final class BsonValueOutput(receiver: BsonValue => Unit = _ => (), override val 
     }
   }
 
-  override def writeNull(): Unit = setValue(BsonNull.VALUE)
-  override def writeString(str: String): Unit = setValue(new BsonString(str))
-  override def writeBoolean(boolean: Boolean): Unit = setValue(BsonBoolean.valueOf(boolean))
-  override def writeInt(int: Int): Unit = setValue(new BsonInt32(int))
-  override def writeLong(long: Long): Unit = setValue(new BsonInt64(long))
-  override def writeTimestamp(millis: Long): Unit = setValue(new BsonDateTime(millis))
-  override def writeDouble(double: Double): Unit = setValue(new BsonDouble(double))
-  override def writeBigInt(bigInt: BigInt): Unit = setValue(new BsonBinary(bigInt.toByteArray))
-  override def writeBigDecimal(bigDecimal: BigDecimal): Unit = setValue(new BsonBinary(BsonOutput.bigDecimalBytes(bigDecimal)))
-  override def writeBinary(binary: Array[Byte]): Unit = setValue(new BsonBinary(binary))
-  override def writeList(): ListOutput = new BsonValueListOutput(setValue, legacyOptionEncoding)
-  override def writeObject(): ObjectOutput = new BsonValueObjectOutput(setValue, legacyOptionEncoding)
-  override def writeObjectId(objectId: ObjectId): Unit = setValue(new BsonObjectId(objectId))
-  override def writeDecimal128(decimal128: Decimal128): Unit = setValue(new BsonDecimal128(decimal128))
+  override def writeNull(): Unit =
+    setValue(BsonNull.VALUE)
+
+  override def writeString(str: String): Unit =
+    setValue(new BsonString(str))
+
+  override def writeBoolean(boolean: Boolean): Unit =
+    setValue(BsonBoolean.valueOf(boolean))
+
+  override def writeInt(int: Int): Unit =
+    setValue(new BsonInt32(int))
+
+  override def writeLong(long: Long): Unit =
+    if (long.isValidInt) writeInt(long.toInt)
+    else setValue(new BsonInt64(long))
+
+  override def writeTimestamp(millis: Long): Unit =
+    setValue(new BsonDateTime(millis))
+
+  override def writeDouble(double: Double): Unit =
+    setValue(new BsonDouble(double))
+
+  override def writeBinary(binary: Array[Byte]): Unit =
+    setValue(new BsonBinary(binary))
+
+  override def writeList(): ListOutput =
+    new BsonValueListOutput(setValue, legacyOptionEncoding)
+
+  override def writeObject(): ObjectOutput =
+    new BsonValueObjectOutput(setValue, legacyOptionEncoding)
+
+  override def writeObjectId(objectId: ObjectId): Unit =
+    setValue(new BsonObjectId(objectId))
+
+  override def writeDecimal128(decimal128: Decimal128): Unit =
+    setValue(new BsonDecimal128(decimal128))
 }
 
 final class BsonValueListOutput(receiver: BsonArray => Unit, legacyOptionEncoding: Boolean)

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueOutput.scala
@@ -66,6 +66,9 @@ final class BsonValueOutput(
 
   override def writeDecimal128(decimal128: Decimal128): Unit =
     setValue(new BsonDecimal128(decimal128))
+
+  override def writeBsonValue(bsonValue: BsonValue): Unit =
+    setValue(bsonValue)
 }
 
 final class BsonValueListOutput(receiver: BsonArray => Unit, legacyOptionEncoding: Boolean)

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueUtils.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueUtils.scala
@@ -1,0 +1,19 @@
+package com.avsystem.commons
+package mongo
+
+import org.bson.codecs.{BsonValueCodec, DecoderContext, EncoderContext}
+import org.bson.{BsonReader, BsonValue, BsonWriter}
+
+object BsonValueUtils {
+  private val bsonValueCodec = new BsonValueCodec
+  private val encoderContext = EncoderContext.builder.build
+  private val decoderContext = DecoderContext.builder.build
+
+  def encode(bw: BsonWriter, bv: BsonValue): Unit =
+    bsonValueCodec.encode(bw, bv, encoderContext)
+
+  def decode(br: BsonReader): BsonValue = {
+    br.readBsonType() // without this, `br.getCurrentBsonType` may return null (why?)
+    bsonValueCodec.decode(br, decoderContext)
+  }
+}

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueUtils.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueUtils.scala
@@ -13,7 +13,9 @@ object BsonValueUtils {
     bsonValueCodec.encode(bw, bv, encoderContext)
 
   def decode(br: BsonReader): BsonValue = {
-    br.readBsonType() // without this, `br.getCurrentBsonType` may return null (why?)
+    if (br.getCurrentBsonType eq null) {
+      br.readBsonType()
+    }
     bsonValueCodec.decode(br, decoderContext)
   }
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonWriterOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonWriterOutput.scala
@@ -3,7 +3,7 @@ package mongo
 
 import com.avsystem.commons.serialization.{ListOutput, ObjectOutput}
 import org.bson.types.{Decimal128, ObjectId}
-import org.bson.{BsonBinary, BsonWriter}
+import org.bson.{BsonBinary, BsonValue, BsonWriter}
 
 final class BsonWriterOutput(bw: BsonWriter, override val legacyOptionEncoding: Boolean = false)
   extends BsonOutput {
@@ -48,56 +48,13 @@ final class BsonWriterOutput(bw: BsonWriter, override val legacyOptionEncoding: 
 
   override def writeDecimal128(decimal128: Decimal128): Unit =
     bw.writeDecimal128(decimal128)
-}
 
-final class BsonWriterNamedOutput(escapedName: String, bw: BsonWriter, override val legacyOptionEncoding: Boolean)
-  extends BsonOutput {
-
-  override def writeNull(): Unit =
-    bw.writeNull(escapedName)
-
-  override def writeString(str: String): Unit =
-    bw.writeString(escapedName, str)
-
-  override def writeBoolean(boolean: Boolean): Unit =
-    bw.writeBoolean(escapedName, boolean)
-
-  override def writeInt(int: Int): Unit =
-    bw.writeInt32(escapedName, int)
-
-  override def writeLong(long: Long): Unit =
-    if (long.isValidInt) writeInt(long.toInt)
-    else bw.writeInt64(escapedName, long)
-
-  override def writeTimestamp(millis: Long): Unit =
-    bw.writeDateTime(escapedName, millis)
-
-  override def writeDouble(double: Double): Unit =
-    bw.writeDouble(escapedName, double)
-
-  override def writeBinary(binary: Array[Byte]): Unit =
-    bw.writeBinaryData(escapedName, new BsonBinary(binary))
-
-  override def writeList(): BsonWriterListOutput = {
-    bw.writeStartArray(escapedName)
-    new BsonWriterListOutput(bw, legacyOptionEncoding)
-  }
-
-  override def writeObject(): BsonWriterObjectOutput = {
-    bw.writeName(escapedName) // org.bson.BsonWriter.writeStartDocument(java.lang.String) fails when writing _id in 4.0 driver
-    bw.writeStartDocument()
-    new BsonWriterObjectOutput(bw, legacyOptionEncoding)
-  }
-
-  override def writeObjectId(objectId: ObjectId): Unit =
-    bw.writeObjectId(escapedName, objectId)
-
-  override def writeDecimal128(decimal128: Decimal128): Unit =
-    bw.writeDecimal128(escapedName, decimal128)
+  override def writeBsonValue(bsonValue: BsonValue): Unit =
+    BsonValueUtils.encode(bw, bsonValue)
 }
 
 final class BsonWriterListOutput(bw: BsonWriter, legacyOptionEncoding: Boolean) extends ListOutput {
-  override def writeElement() =
+  override def writeElement(): BsonWriterOutput =
     new BsonWriterOutput(bw, legacyOptionEncoding)
 
   override def finish(): Unit =
@@ -105,8 +62,10 @@ final class BsonWriterListOutput(bw: BsonWriter, legacyOptionEncoding: Boolean) 
 }
 
 final class BsonWriterObjectOutput(bw: BsonWriter, legacyOptionEncoding: Boolean) extends ObjectOutput {
-  override def writeField(key: String) =
-    new BsonWriterNamedOutput(KeyEscaper.escape(key), bw, legacyOptionEncoding)
+  override def writeField(key: String): BsonWriterOutput = {
+    bw.writeName(KeyEscaper.escape(key))
+    new BsonWriterOutput(bw, legacyOptionEncoding)
+  }
 
   override def finish(): Unit =
     bw.writeEndDocument()

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonWriterOutput.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonWriterOutput.scala
@@ -5,38 +5,47 @@ import com.avsystem.commons.serialization.{ListOutput, ObjectOutput}
 import org.bson.types.{Decimal128, ObjectId}
 import org.bson.{BsonBinary, BsonWriter}
 
-final class BsonWriterOutput(bw: BsonWriter, override val legacyOptionEncoding: Boolean = false) extends BsonOutput {
+final class BsonWriterOutput(bw: BsonWriter, override val legacyOptionEncoding: Boolean = false)
+  extends BsonOutput {
 
   override def writeNull(): Unit =
     bw.writeNull()
+
   override def writeString(str: String): Unit =
     bw.writeString(str)
+
   override def writeBoolean(boolean: Boolean): Unit =
     bw.writeBoolean(boolean)
+
   override def writeInt(int: Int): Unit =
     bw.writeInt32(int)
+
   override def writeLong(long: Long): Unit =
-    bw.writeInt64(long)
+    if (long.isValidInt) writeInt(long.toInt)
+    else bw.writeInt64(long)
+
   override def writeTimestamp(millis: Long): Unit =
     bw.writeDateTime(millis)
+
   override def writeDouble(double: Double): Unit =
     bw.writeDouble(double)
-  override def writeBigInt(bigInt: BigInt): Unit =
-    bw.writeBinaryData(new BsonBinary(bigInt.toByteArray))
-  override def writeBigDecimal(bigDecimal: BigDecimal): Unit =
-    bw.writeBinaryData(new BsonBinary(BsonOutput.bigDecimalBytes(bigDecimal)))
+
   override def writeBinary(binary: Array[Byte]): Unit =
     bw.writeBinaryData(new BsonBinary(binary))
+
   override def writeList(): BsonWriterListOutput = {
     bw.writeStartArray()
     new BsonWriterListOutput(bw, legacyOptionEncoding)
   }
+
   override def writeObject(): BsonWriterObjectOutput = {
     bw.writeStartDocument()
     new BsonWriterObjectOutput(bw, legacyOptionEncoding)
   }
+
   override def writeObjectId(objectId: ObjectId): Unit =
     bw.writeObjectId(objectId)
+
   override def writeDecimal128(decimal128: Decimal128): Unit =
     bw.writeDecimal128(decimal128)
 }
@@ -46,35 +55,43 @@ final class BsonWriterNamedOutput(escapedName: String, bw: BsonWriter, override 
 
   override def writeNull(): Unit =
     bw.writeNull(escapedName)
+
   override def writeString(str: String): Unit =
     bw.writeString(escapedName, str)
+
   override def writeBoolean(boolean: Boolean): Unit =
     bw.writeBoolean(escapedName, boolean)
+
   override def writeInt(int: Int): Unit =
     bw.writeInt32(escapedName, int)
+
   override def writeLong(long: Long): Unit =
-    bw.writeInt64(escapedName, long)
+    if (long.isValidInt) writeInt(long.toInt)
+    else bw.writeInt64(escapedName, long)
+
   override def writeTimestamp(millis: Long): Unit =
     bw.writeDateTime(escapedName, millis)
+
   override def writeDouble(double: Double): Unit =
     bw.writeDouble(escapedName, double)
-  override def writeBigInt(bigInt: BigInt): Unit =
-    bw.writeBinaryData(escapedName, new BsonBinary(bigInt.toByteArray))
-  override def writeBigDecimal(bigDecimal: BigDecimal): Unit =
-    bw.writeBinaryData(escapedName, new BsonBinary(BsonOutput.bigDecimalBytes(bigDecimal)))
+
   override def writeBinary(binary: Array[Byte]): Unit =
     bw.writeBinaryData(escapedName, new BsonBinary(binary))
+
   override def writeList(): BsonWriterListOutput = {
     bw.writeStartArray(escapedName)
     new BsonWriterListOutput(bw, legacyOptionEncoding)
   }
+
   override def writeObject(): BsonWriterObjectOutput = {
     bw.writeName(escapedName) // org.bson.BsonWriter.writeStartDocument(java.lang.String) fails when writing _id in 4.0 driver
     bw.writeStartDocument()
     new BsonWriterObjectOutput(bw, legacyOptionEncoding)
   }
+
   override def writeObjectId(objectId: ObjectId): Unit =
     bw.writeObjectId(escapedName, objectId)
+
   override def writeDecimal128(decimal128: Decimal128): Unit =
     bw.writeDecimal128(escapedName, decimal128)
 }
@@ -82,6 +99,7 @@ final class BsonWriterNamedOutput(escapedName: String, bw: BsonWriter, override 
 final class BsonWriterListOutput(bw: BsonWriter, legacyOptionEncoding: Boolean) extends ListOutput {
   override def writeElement() =
     new BsonWriterOutput(bw, legacyOptionEncoding)
+
   override def finish(): Unit =
     bw.writeEndArray()
 }
@@ -89,6 +107,7 @@ final class BsonWriterListOutput(bw: BsonWriter, legacyOptionEncoding: Boolean) 
 final class BsonWriterObjectOutput(bw: BsonWriter, legacyOptionEncoding: Boolean) extends ObjectOutput {
   override def writeField(key: String) =
     new BsonWriterNamedOutput(KeyEscaper.escape(key), bw, legacyOptionEncoding)
+
   override def finish(): Unit =
     bw.writeEndDocument()
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Decimal128Utils.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Decimal128Utils.scala
@@ -1,0 +1,118 @@
+package com.avsystem.commons
+package mongo
+
+import org.bson.types.Decimal128
+
+import java.math.MathContext
+import _root_.scala.util.control.NoStackTrace
+
+object Decimal128Utils {
+  final val MaxExponent = 6111
+  final val MinExponent = -6176
+  final val ExponentOffset = 6176
+  final val MaxBitLength = 113
+  final val SignBitMask = 1L << 63
+  final val BigIntZero = new JBigInteger("0")
+  final val BigIntOne = new JBigInteger("1")
+  final val BigIntTen = new JBigInteger("10")
+
+  def fromBigDecimal(value: BigDecimal): Opt[Decimal128] =
+    try fromBigDecimal(value.bigDecimal, value.signum == -1).opt catch {
+      case Decimal128FormatException => Opt.Empty
+    }
+
+  private final val Decimal128FormatException = new RuntimeException with NoStackTrace
+
+  /*
+   * All of the code below is copied from `org.bson.types.Decimal128` and modified to use exceptions without
+   * stack traces. This is necessary for performant checking of whether a `BigDecimal` can be represented
+   * as `Decimal128`.
+   */
+
+  // isNegative is necessary to detect -0, which can't be represented with a BigDecimal
+  private def fromBigDecimal(initialValue: JBigDecimal, isNegative: Boolean): Decimal128 = {
+    var localHigh: Long = 0
+    var localLow: Long = 0
+
+    val value = clampAndRound(initialValue)
+    val exponent = -value.scale
+
+    if (exponent < MinExponent || exponent > MaxExponent || value.unscaledValue.bitLength > MaxBitLength)
+      throw Decimal128FormatException
+
+    val significand = value.unscaledValue.abs
+    val bitLength = significand.bitLength
+
+    var i = 0
+    while (i < Math.min(64, bitLength)) {
+      if (significand.testBit(i)) {
+        localLow |= 1L << i
+      }
+      i += 1
+    }
+
+    i = 64
+    while (i < bitLength) {
+      if (significand.testBit(i)) {
+        localHigh |= 1L << (i - 64)
+      }
+      i += 1
+    }
+
+    val biasedExponent: Long = exponent + ExponentOffset
+    localHigh |= biasedExponent << 49
+
+    if (value.signum == -1 || isNegative) {
+      localHigh |= SignBitMask
+    }
+
+    Decimal128.fromIEEE754BIDEncoding(localHigh, localLow)
+  }
+
+  private def clampAndRound(initialValue: JBigDecimal): JBigDecimal = {
+    var value: JBigDecimal = null
+    if (-initialValue.scale > MaxExponent) {
+      val diff = -initialValue.scale - MaxExponent
+      if (initialValue.unscaledValue == BigIntZero) {
+        value = new JBigDecimal(initialValue.unscaledValue, -MaxExponent)
+      } else if (diff + initialValue.precision > 34) {
+        throw Decimal128FormatException
+      } else {
+        val multiplier = BigIntTen.pow(diff)
+        value = new JBigDecimal(initialValue.unscaledValue.multiply(multiplier), initialValue.scale + diff)
+      }
+    }
+    else if (-initialValue.scale < MinExponent) {
+      // Increasing a very negative exponent may require decreasing precision, which is rounding
+      // Only round exactly (by removing precision that is all zeroes).  An exception is thrown if the rounding would be inexact:
+      // Exact:     .000...0011000  => 11000E-6177  => 1100E-6176  => .000001100
+      // Inexact:   .000...0011001  => 11001E-6177  => 1100E-6176  => .000001100
+      val diff = initialValue.scale + MinExponent
+      val undiscardedPrecision = ensureExactRounding(initialValue, diff)
+      val divisor =
+        if (undiscardedPrecision == 0) BigIntOne else BigIntTen.pow(diff)
+      value = new JBigDecimal(initialValue.unscaledValue.divide(divisor), initialValue.scale - diff)
+    }
+    else {
+      value = initialValue.round(MathContext.DECIMAL128)
+      val extraPrecision = initialValue.precision - value.precision
+      if (extraPrecision > 0) { // Again, only round exactly
+        ensureExactRounding(initialValue, extraPrecision)
+      }
+    }
+    value
+  }
+
+  private def ensureExactRounding(initialValue: JBigDecimal, extraPrecision: Int): Int = {
+    val significand = initialValue.unscaledValue.abs.toString
+    val undiscardedPrecision = Math.max(0, significand.length - extraPrecision)
+    var i = undiscardedPrecision
+    while (i < significand.length) {
+      if (significand.charAt(i) != '0') {
+        throw Decimal128FormatException
+      }
+      i += 1
+    }
+    undiscardedPrecision
+  }
+}

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/GenCodecBasedBsonCodec.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/GenCodecBasedBsonCodec.scala
@@ -8,13 +8,11 @@ import org.bson.{BsonReader, BsonWriter}
 class GenCodecBasedBsonCodec[T](legacyOptionEncoding: Boolean)(
   implicit ct: ClassTag[T], genCodec: GenCodec[T]
 ) extends Codec[T] {
-  override def getEncoderClass = ct.runtimeClass.asInstanceOf[Class[T]]
+  override def getEncoderClass: Class[T] = ct.runtimeClass.asInstanceOf[Class[T]]
 
-  override def decode(reader: BsonReader, decoderContext: DecoderContext) = {
+  override def decode(reader: BsonReader, decoderContext: DecoderContext): T =
     genCodec.read(new BsonReaderInput(reader, legacyOptionEncoding))
-  }
 
-  override def encode(writer: BsonWriter, value: T, encoderContext: EncoderContext) = {
+  override def encode(writer: BsonWriter, value: T, encoderContext: EncoderContext): Unit =
     genCodec.write(new BsonWriterOutput(writer, legacyOptionEncoding), value)
-  }
 }

--- a/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/core/GenCodecRegistry.scala
+++ b/commons-mongo/jvm/src/main/scala/com/avsystem/commons/mongo/core/GenCodecRegistry.scala
@@ -8,9 +8,10 @@ object GenCodecRegistry {
   final val LegacyOptionEncoding: Boolean =
     System.getProperty("commons.mongo.legacyOptionEncoding").opt.fold(false)(_.toBoolean)
 
-  def create[T: ClassTag : GenCodec](baseRegistry: CodecRegistry,
-    legacyOptionEncoding: Boolean = LegacyOptionEncoding): CodecRegistry = {
-
+  def create[T: ClassTag : GenCodec](
+    baseRegistry: CodecRegistry,
+    legacyOptionEncoding: Boolean = LegacyOptionEncoding
+  ): CodecRegistry = {
     val genProvider = new GenCodecProvider[T](legacyOptionEncoding)
     val genRegistry = CodecRegistries.fromProviders(genProvider)
     CodecRegistries.fromRegistries(genRegistry, baseRegistry)

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
@@ -167,7 +167,7 @@ class BsonInputOutputTest extends AnyFunSuite with ScalaCheckPropertyChecks {
       fieldInput.skip()
     }
 
-    assert(input.readMetadata(BsonTypeMetadata).isEmpty)
+    assert(input.readMetadata(BsonTypeMetadata).contains(BsonType.DOCUMENT))
 
     val objectInput = input.readObject()
     assert(input.readMetadata(BsonTypeMetadata).contains(BsonType.DOCUMENT))

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
@@ -194,9 +194,9 @@ class BsonInputOutputTest extends AnyFunSuite with ScalaCheckPropertyChecks {
 
 
   def testMetadata(input: BsonInput)(implicit position: Position): Unit = {
-    def testFieldType(input: ObjectInput)(tpe: BsonType): Unit = {
+    def testFieldType(input: ObjectInput)(tpes: BsonType*): Unit = {
       val fieldInput = input.nextField()
-      assert(fieldInput.readMetadata(BsonTypeMetadata).contains(tpe))
+      assert(fieldInput.readMetadata(BsonTypeMetadata).exists(tpes.contains))
       fieldInput.skip()
     }
 
@@ -217,7 +217,7 @@ class BsonInputOutputTest extends AnyFunSuite with ScalaCheckPropertyChecks {
     testFieldType(objectInput)(BsonType.STRING)
     testFieldType(objectInput)(BsonType.BOOLEAN)
     testFieldType(objectInput)(BsonType.INT32)
-    testFieldType(objectInput)(BsonType.INT64)
+    testFieldType(objectInput)(BsonType.INT32, BsonType.INT64)
     testFieldType(objectInput)(BsonType.DATE_TIME)
     testFieldType(objectInput)(BsonType.DOUBLE)
     testFieldType(objectInput)(BsonType.BINARY)

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
@@ -302,12 +302,15 @@ class BsonInputOutputTest extends AnyFunSuite with ScalaCheckPropertyChecks {
     doc
   }
 
+  def longBson(l: Long): BsonValue =
+    if(l.isValidInt) new BsonInt32(l.toInt) else new BsonInt64(l)
+
   def somethingToBson(s: SomethingPlain): BsonDocument = {
     new BsonDocument()
       .append("string", new BsonString(s.string))
       .append("boolean", new BsonBoolean(s.boolean))
       .append("int", new BsonInt32(s.int))
-      .append("long", new BsonInt64(s.long))
+      .append("long", longBson(s.long))
       .append("timestamp", new BsonDateTime(s.timestamp.getTime))
       .append("double", new BsonDouble(s.double))
       .append("binary", new BsonBinary(s.binary.bytes))

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonValueCodecsTest.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonValueCodecsTest.scala
@@ -26,7 +26,7 @@ object AllTypesInABag extends HasGenCodecWithDeps[BsonGenCodecs.type, AllTypesIn
 class BsonValueCodecsTest extends AnyFunSuite {
   test("codec roundtrip") {
     val doc = new BsonDocument(JList(
-      new BsonElement("someInt64", new BsonInt64(Int.MaxValue + 1L)),
+      new BsonElement("someInt64", new BsonInt64(64)),
       new BsonElement("someString", new BsonString("some"))
     ))
 
@@ -39,7 +39,7 @@ class BsonValueCodecsTest extends AnyFunSuite {
       new BsonDecimal128(new Decimal128(1331)),
       new BsonDouble(1.31),
       new BsonInt32(132),
-      new BsonInt64(Int.MaxValue + 1L),
+      new BsonInt64(164),
       new BsonObjectId(new ObjectId("12345678901234567890ABCD")),
       new BsonString("sss"),
       doc

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonValueCodecsTest.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonValueCodecsTest.scala
@@ -4,7 +4,7 @@ package mongo
 import com.avsystem.commons.serialization.{GenCodec, HasGenCodecWithDeps}
 import org.bson.json.JsonReader
 import org.bson.types.{Decimal128, ObjectId}
-import org.bson.{BsonArray, BsonBinary, BsonBoolean, BsonDateTime, BsonDecimal128, BsonDocument, BsonDouble, BsonElement, BsonInt32, BsonInt64, BsonNull, BsonObjectId, BsonString, BsonValue}
+import org.bson._
 import org.scalatest.funsuite.AnyFunSuite
 
 case class AllTypesInABag(
@@ -26,7 +26,7 @@ object AllTypesInABag extends HasGenCodecWithDeps[BsonGenCodecs.type, AllTypesIn
 class BsonValueCodecsTest extends AnyFunSuite {
   test("codec roundtrip") {
     val doc = new BsonDocument(JList(
-      new BsonElement("someInt64", new BsonInt64(64)),
+      new BsonElement("someInt64", new BsonInt64(Int.MaxValue + 1L)),
       new BsonElement("someString", new BsonString("some"))
     ))
 
@@ -39,7 +39,7 @@ class BsonValueCodecsTest extends AnyFunSuite {
       new BsonDecimal128(new Decimal128(1331)),
       new BsonDouble(1.31),
       new BsonInt32(132),
-      new BsonInt64(164),
+      new BsonInt64(Int.MaxValue + 1L),
       new BsonObjectId(new ObjectId("12345678901234567890ABCD")),
       new BsonString("sss"),
       doc

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/Decimal128UtilsTest.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/Decimal128UtilsTest.scala
@@ -1,0 +1,19 @@
+package com.avsystem.commons
+package mongo
+
+import org.bson.types.Decimal128
+import org.scalacheck.Arbitrary
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class Decimal128UtilsTest extends AnyFunSuite with ScalaCheckPropertyChecks {
+  test("Decimal128Utils.fromBigDecimal is equivalent to new Decimal128") {
+    forAll(Arbitrary.arbitrary[BigDecimal]) { bd: BigDecimal =>
+      val usingUtils = Decimal128Utils.fromBigDecimal(bd)
+      val usingConstructor = try new Decimal128(bd.bigDecimal).opt catch {
+        case _: NumberFormatException => Opt.Empty
+      }
+      assert(usingUtils == usingConstructor)
+    }
+  }
+}

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/SomethingPlain.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/SomethingPlain.scala
@@ -33,10 +33,7 @@ object SomethingPlain extends HasGenCodec[SomethingPlain] {
     string <- arbitrary[String]
     boolean <- arbitrary[Boolean]
     int <- arbitrary[Int]
-    long <- Gen.oneOf(
-      Gen.choose(Long.MinValue, Int.MinValue - 1L),
-      Gen.choose(Int.MaxValue + 1L, Long.MaxValue),
-    )
+    long <- arbitrary[Long]
     timestamp <- arbitrary[JDate]
     double <- arbitrary[Double]
     binary <- Gen.buildableOf[Array[Byte], Byte](arbitrary[Byte]).map(new Bytes(_))

--- a/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/SomethingPlain.scala
+++ b/commons-mongo/jvm/src/test/scala/com/avsystem/commons/mongo/SomethingPlain.scala
@@ -33,7 +33,10 @@ object SomethingPlain extends HasGenCodec[SomethingPlain] {
     string <- arbitrary[String]
     boolean <- arbitrary[Boolean]
     int <- arbitrary[Int]
-    long <- arbitrary[Long]
+    long <- Gen.oneOf(
+      Gen.choose(Long.MinValue, Int.MinValue - 1L),
+      Gen.choose(Int.MaxValue + 1L, Long.MaxValue),
+    )
     timestamp <- arbitrary[JDate]
     double <- arbitrary[Double]
     binary <- Gen.buildableOf[Array[Byte], Byte](arbitrary[Byte]).map(new Bytes(_))


### PR DESCRIPTION
* When writing numbers, `BsonOutput` implementations try to use smallest possible type
  * e.g. when writing a `Long` that actually fits into an `Int`, value will be written as `BsonInt32`
* `Decimal128` is used for `BigInt` and `BigDecimal` where possible
* `BsonInput` representations are lenient when reading numbers and accept multiple `BsonType`s

This change should not break backwards compatibility because:
* `BsonInput` implementations have been updated to be lenient
* Having mixed types for the same field (e.g. `BsonInt32` and `BsonInt64`) is not a problem for MongoDB queries and indexes (value comparisons)

This also addresses #410 

Additional piggybacked changes: `peekField` implementation for `BsonReaderInput`, addressing #411 