### PR TITLE
Fix implicit resolution conflict when MongoPolyDataCompanion is used with custom implicits

### DIFF
--- a/commons-mongo/jvm/src/main/scala-2.13/com/avsystem/commons/mongo/typed/MongoPolyDataCompanion.scala
+++ b/commons-mongo/jvm/src/main/scala-2.13/com/avsystem/commons/mongo/typed/MongoPolyDataCompanion.scala
@@ -12,13 +12,12 @@ trait MongoPolyAdtInstances[D[_]] {
   def codec[T: GenCodec]: GenObjectCodec[D[T]]
 
   /**
-    * We need to accept an implicit `GenObjectCodec[D[T]]` because materialization of
-    * [[MongoAdtFormat]] requires it ([[MongoAdtFormat.codec]]). In practice, it can be derived
-    * from the `MongoFormat[T]` that is already accepted by this method but we don't want to do this in this
-    * trait to avoid problems with priorities of implicits. Because of that, this implicit is actually constructed
-    * by [[AbstractMongoPolyDataCompanion.format]].
+    * We need to accept an implicit `GenCodec[T]` because materialization of
+    * [[MongoAdtFormat]] requires a [[GenObjectCodec]] ([[MongoAdtFormat.codec]]). In practice, it can be derived
+    * from the `MongoFormat[T]` that is already accepted by this method but we have to be careful about priority of
+    * implicits. Because of that, this implicit is actually provided by [[AbstractMongoPolyDataCompanion.format]].
     */
-  def format[T: MongoFormat](implicit codec: GenObjectCodec[D[T]]): MongoAdtFormat[D[T]]
+  def format[T: MongoFormat : GenCodec]: MongoAdtFormat[D[T]]
 }
 
 abstract class AbstractMongoPolyDataCompanion[Implicits, D[_]](implicits: Implicits)(

--- a/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
+++ b/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
@@ -1,0 +1,23 @@
+package com.avsystem.commons
+package mongo.typed
+
+import com.avsystem.commons.meta.MacroInstances
+import com.avsystem.commons.serialization.GenCodec
+
+case class CustomWrappy(value: String)
+
+object CustomImplicits {
+  implicit val customWrappyCodec: GenCodec[CustomWrappy] =
+    GenCodec.transformed[CustomWrappy, String](_.value, CustomWrappy)
+}
+
+abstract class CustomPolyDataCompanion[D[_]](
+  implicit instances: MacroInstances[CustomImplicits.type, MongoPolyAdtInstances[D]],
+) extends AbstractMongoPolyDataCompanion[CustomImplicits.type, D](CustomImplicits)
+
+/**
+  * This class tests (through its compilation) if implicit resolution conflicts that were
+  * previously present in [[MongoPolyAdtInstances]] are fixed.
+  */
+case class PolyDataWithCustomImplicits[+T](wrappy: CustomWrappy)
+object PolyDataWithCustomImplicits extends CustomPolyDataCompanion[PolyDataWithCustomImplicits]

--- a/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
+++ b/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
@@ -19,5 +19,5 @@ abstract class CustomPolyDataCompanion[D[_]](
   * This class tests (through its compilation) if implicit resolution conflicts that were
   * previously present in [[MongoPolyAdtInstances]] are fixed.
   */
-case class PolyDataWithCustomImplicits[+T](wrappy: CustomWrappy)
+case class PolyDataWithCustomImplicits[+T](wrappy: CustomWrappy, value: T)
 object PolyDataWithCustomImplicits extends CustomPolyDataCompanion[PolyDataWithCustomImplicits]

--- a/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
+++ b/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
@@ -17,7 +17,8 @@ abstract class CustomPolyDataCompanion[D[_]](
 
 /**
   * This class tests (through its compilation) if implicit resolution conflicts that were
-  * previously present in [[MongoPolyAdtInstances]] are fixed.
+  * previously present in [[MongoPolyAdtInstances]] are fixed
+  * ([[https://github.com/AVSystem/scala-commons/pull/429 #429]]).
   */
 case class PolyDataWithCustomImplicits[+T](wrappy: CustomWrappy, value: List[T])
 object PolyDataWithCustomImplicits extends CustomPolyDataCompanion[PolyDataWithCustomImplicits]

--- a/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
+++ b/commons-mongo/jvm/src/test/scala-2.13/com/avsystem/commons/mongo/typed/PolyDataWithCustomImplicits.scala
@@ -19,5 +19,5 @@ abstract class CustomPolyDataCompanion[D[_]](
   * This class tests (through its compilation) if implicit resolution conflicts that were
   * previously present in [[MongoPolyAdtInstances]] are fixed.
   */
-case class PolyDataWithCustomImplicits[+T](wrappy: CustomWrappy, value: T)
+case class PolyDataWithCustomImplicits[+T](wrappy: CustomWrappy, value: List[T])
 object PolyDataWithCustomImplicits extends CustomPolyDataCompanion[PolyDataWithCustomImplicits]


### PR DESCRIPTION
`MongoPolyAdtInstances.codecFromFormat` was a bit too broad and conflicted with implicits injected via `MacroInstances`.

This is a rather obscure scenario, please see the added test which shows the minimized problem.