### PR TITLE
Conditional beans include support in commons-spring

### DIFF
--- a/commons-spring/src/main/scala/com/avsystem/commons/spring/HoconBeanDefinitionReader.scala
+++ b/commons-spring/src/main/scala/com/avsystem/commons/spring/HoconBeanDefinitionReader.scala
@@ -16,8 +16,8 @@ import scala.annotation.nowarn
 class HoconBeanDefinitionReader(registry: BeanDefinitionRegistry)
   extends AbstractBeanDefinitionReader(registry) {
 
+  import com.avsystem.commons.spring.HoconBeanDefinitionReader.Keys._
   import com.typesafe.config.ConfigValueType._
-  import com.avsystem.commons.spring.HoconBeanDefinitionReader._
 
   private implicit class ConfigValueExtensions(value: ConfigValue) {
     def as[T: HoconType] =
@@ -347,15 +347,14 @@ class HoconBeanDefinitionReader(registry: BeanDefinitionRegistry)
 
   private def readConditionals(config: Config): Config = {
     if (!config.hasPath(Conditionals)) config
-    else config.getList(Conditionals).asScala.foldLeft(config.withoutPath(Conditionals))((currentConfig, conditionalObject) => {
+    else config.getList(Conditionals).asScala.foldLeft(config.withoutPath(Conditionals)) { (currentConfig, conditionalObject) =>
       val props = getProps(conditionalObject.as[ConfigObject])
 
-      if (props.get(Condition).exists(_.as[Boolean])) {
+      if (props(Condition).as[Boolean])
         readConditionals(props(Config).as[Config]).withFallback(currentConfig)
-      } else {
+      else
         currentConfig
-      }
-    })
+    }
   }
 
   def loadBeanDefinitions(resourceConfig: Config): Int = {
@@ -371,9 +370,11 @@ class HoconBeanDefinitionReader(registry: BeanDefinitionRegistry)
     loadBeanDefinitions(ConfigFactory.parseURL(resource.getURL).resolve)
 }
 object HoconBeanDefinitionReader {
-  val Conditionals = "conditionals"
-  val Condition = "condition"
-  val Config = "config"
-  val Beans = "beans"
-  val Aliases = "aliases"
+  object Keys {
+    final val Conditionals = "conditionals"
+    final val Condition = "condition"
+    final val Config = "config"
+    final val Beans = "beans"
+    final val Aliases = "aliases"
+  }
 }

--- a/commons-spring/src/test/resources/conditionalInclude.conf
+++ b/commons-spring/src/test/resources/conditionalInclude.conf
@@ -1,0 +1,6 @@
+beans {
+  beanFromConditional = {
+    %class = com.avsystem.commons.spring.ConditionalTestBean, %construct = true
+    int = 100
+  }
+}

--- a/commons-spring/src/test/resources/conditionalsDisabled.conf
+++ b/commons-spring/src/test/resources/conditionalsDisabled.conf
@@ -3,5 +3,5 @@ featureFlag.enabled = false
 beans.beanFromConditional = null
 
 conditionals = [
-  {condition: ${featureFlag.enabled}, beans: {include "conditionalInclude.conf"}},
+  {condition: ${featureFlag.enabled}, config: {include "conditionalInclude.conf"}},
 ]

--- a/commons-spring/src/test/resources/conditionalsDisabled.conf
+++ b/commons-spring/src/test/resources/conditionalsDisabled.conf
@@ -1,0 +1,7 @@
+featureFlag.enabled = false
+
+beans.beanFromConditional = null
+
+conditionals = [
+  {condition: ${featureFlag.enabled}, beans: {include "conditionalInclude.conf"}},
+]

--- a/commons-spring/src/test/resources/conditionalsEnabled.conf
+++ b/commons-spring/src/test/resources/conditionalsEnabled.conf
@@ -3,5 +3,5 @@ featureFlag.enabled = true
 beans.beanFromConditional = null
 
 conditionals = [
-  {condition: ${featureFlag.enabled}, beans: {include "conditionalInclude.conf"}},
+  {condition: ${featureFlag.enabled}, config: {include "conditionalInclude.conf"}},
 ]

--- a/commons-spring/src/test/resources/conditionalsEnabled.conf
+++ b/commons-spring/src/test/resources/conditionalsEnabled.conf
@@ -1,0 +1,7 @@
+featureFlag.enabled = true
+
+beans.beanFromConditional = null
+
+conditionals = [
+  {condition: ${featureFlag.enabled}, beans: {include "conditionalInclude.conf"}},
+]

--- a/commons-spring/src/test/resources/conditionalsNested.conf
+++ b/commons-spring/src/test/resources/conditionalsNested.conf
@@ -7,14 +7,14 @@ beans {
 }
 
 conditionals = [
-  {condition: ${featureFlag.enabled}, beans: {beans.testBean.int = 0}},
-  {condition: ${featureFlag.enabled}, beans: {beans.testBean.int = 1}},
+  {condition: ${featureFlag.enabled}, config: {beans.testBean.int = 0}},
+  {condition: ${featureFlag.enabled}, config: {beans.testBean.int = 1}},
   {
-    condition: ${featureFlag.enabled}, beans: {
+    condition: ${featureFlag.enabled}, config: {
     conditionals = [
-      {condition: true, beans: {beans.testBean.int = 2}}
+      {condition: true, config: {beans.testBean.int = 2}}
     ]
   }
   },
-  {condition: false, beans: {beans.testBean.int = 3}},
+  {condition: false, config: {beans.testBean.int = 3}},
 ]

--- a/commons-spring/src/test/resources/conditionalsNested.conf
+++ b/commons-spring/src/test/resources/conditionalsNested.conf
@@ -1,0 +1,20 @@
+featureFlag.enabled = true
+
+beans {
+  testBean {
+    %class = com.avsystem.commons.spring.TestBean
+  }
+}
+
+conditionals = [
+  {condition: ${featureFlag.enabled}, beans: {beans.testBean.int = 0}},
+  {condition: ${featureFlag.enabled}, beans: {beans.testBean.int = 1}},
+  {
+    condition: ${featureFlag.enabled}, beans: {
+    conditionals = [
+      {condition: true, beans: {beans.testBean.int = 2}}
+    ]
+  }
+  },
+  {condition: false, beans: {beans.testBean.int = 3}},
+]

--- a/commons-spring/src/test/scala/com/avsystem/commons/spring/HoconBeanDefinitionReaderTest.scala
+++ b/commons-spring/src/test/scala/com/avsystem/commons/spring/HoconBeanDefinitionReaderTest.scala
@@ -49,21 +49,6 @@ class HoconBeanDefinitionReaderTest extends AnyFunSuite {
     ctx
   }
 
-  test("file should be included with true condition") {
-    ConditionalTestBean.initializedCount = 0
-    val ctx = createContext("conditionalsEnabled.conf")
-    val testBean = ctx.getBean("beanFromConditional", classOf[ConditionalTestBean])
-    assert(testBean != null)
-    assertResult(1)(ConditionalTestBean.initializedCount)
-  }
-
-  test("file should not be included with false condition") {
-    ConditionalTestBean.initializedCount = 0
-    val ctx = createContext("conditionalsDisabled.conf")
-    assert(!ctx.containsBean("beanFromConditional"))
-    assertResult(0)(ConditionalTestBean.initializedCount)
-  }
-
   test("hocon bean definition reader should work") {
     val ctx = createContext("testBean.conf")
 
@@ -105,5 +90,26 @@ class HoconBeanDefinitionReaderTest extends AnyFunSuite {
     val testBeanFMDefAll = ctx.getBean("testBeanFMDefAll", classOf[TestBean])
     assert(testBeanFMDefAll.constrInt == -1)
     assert(testBeanFMDefAll.constrString == "factoryDefault")
+  }
+
+  test("file should be included with true condition") {
+    ConditionalTestBean.initializedCount = 0
+    val ctx = createContext("conditionalsEnabled.conf")
+    val testBean = ctx.getBean("beanFromConditional", classOf[ConditionalTestBean])
+    assert(testBean != null)
+    assertResult(1)(ConditionalTestBean.initializedCount)
+  }
+
+  test("file should not be included with false condition") {
+    ConditionalTestBean.initializedCount = 0
+    val ctx = createContext("conditionalsDisabled.conf")
+    assert(!ctx.containsBean("beanFromConditional"))
+    assertResult(0)(ConditionalTestBean.initializedCount)
+  }
+
+  test("hocon bean definition with nested conditionals should work") {
+    val ctx = createContext("conditionalsNested.conf")
+    val testBean = ctx.getBean("testBean", classOf[TestBean])
+    assert(testBean.int == 2)
   }
 }

--- a/commons-spring/src/test/scala/com/avsystem/commons/spring/HoconBeanDefinitionReaderTest.scala
+++ b/commons-spring/src/test/scala/com/avsystem/commons/spring/HoconBeanDefinitionReaderTest.scala
@@ -1,14 +1,13 @@
 package com.avsystem.commons
 package spring
 
-import java.{util => ju}
-
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.funsuite.AnyFunSuite
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.context.support.GenericApplicationContext
 import org.springframework.core.StandardReflectionParameterNameDiscoverer
 
+import java.{util => ju}
 import scala.beans.BeanProperty
 
 class TestBean(val constrInt: Int = 1, val constrString: String = "constrDefault") {
@@ -25,6 +24,16 @@ object TestBean {
     new TestBean(theInt, theString)
 }
 
+class ConditionalTestBean(int: Int) {
+
+  import ConditionalTestBean.initializedCount
+
+  initializedCount += 1
+}
+object ConditionalTestBean {
+  var initializedCount = 0
+}
+
 class HoconBeanDefinitionReaderTest extends AnyFunSuite {
   def createContext(resource: String): GenericApplicationContext = {
     val beanFactory = new DefaultListableBeanFactory
@@ -38,6 +47,21 @@ class HoconBeanDefinitionReaderTest extends AnyFunSuite {
     ctx.refresh()
 
     ctx
+  }
+
+  test("file should be included with true condition") {
+    ConditionalTestBean.initializedCount = 0
+    val ctx = createContext("conditionalsEnabled.conf")
+    val testBean = ctx.getBean("beanFromConditional", classOf[ConditionalTestBean])
+    assert(testBean != null)
+    assertResult(1)(ConditionalTestBean.initializedCount)
+  }
+
+  test("file should not be included with false condition") {
+    ConditionalTestBean.initializedCount = 0
+    val ctx = createContext("conditionalsDisabled.conf")
+    assert(!ctx.containsBean("beanFromConditional"))
+    assertResult(0)(ConditionalTestBean.initializedCount)
   }
 
   test("hocon bean definition reader should work") {

--- a/commons-spring/src/test/scala/com/avsystem/commons/spring/HoconBeanDefinitionReaderTest.scala
+++ b/commons-spring/src/test/scala/com/avsystem/commons/spring/HoconBeanDefinitionReaderTest.scala
@@ -2,6 +2,7 @@ package com.avsystem.commons
 package spring
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.funsuite.AnyFunSuite
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.context.support.GenericApplicationContext
@@ -34,7 +35,7 @@ object ConditionalTestBean {
   var initializedCount = 0
 }
 
-class HoconBeanDefinitionReaderTest extends AnyFunSuite {
+class HoconBeanDefinitionReaderTest extends AnyFunSuite with BeforeAndAfterEach {
   def createContext(resource: String): GenericApplicationContext = {
     val beanFactory = new DefaultListableBeanFactory
     beanFactory.setParameterNameDiscoverer(new StandardReflectionParameterNameDiscoverer)
@@ -47,6 +48,10 @@ class HoconBeanDefinitionReaderTest extends AnyFunSuite {
     ctx.refresh()
 
     ctx
+  }
+
+  override def beforeEach(): Unit = {
+    ConditionalTestBean.initializedCount = 0
   }
 
   test("hocon bean definition reader should work") {
@@ -93,7 +98,6 @@ class HoconBeanDefinitionReaderTest extends AnyFunSuite {
   }
 
   test("file should be included with true condition") {
-    ConditionalTestBean.initializedCount = 0
     val ctx = createContext("conditionalsEnabled.conf")
     val testBean = ctx.getBean("beanFromConditional", classOf[ConditionalTestBean])
     assert(testBean != null)
@@ -101,7 +105,6 @@ class HoconBeanDefinitionReaderTest extends AnyFunSuite {
   }
 
   test("file should not be included with false condition") {
-    ConditionalTestBean.initializedCount = 0
     val ctx = createContext("conditionalsDisabled.conf")
     assert(!ctx.containsBean("beanFromConditional"))
     assertResult(0)(ConditionalTestBean.initializedCount)


### PR DESCRIPTION
Issue #431 

Makes it possible to include some config only if specified feature flag is enabled. The position of the `conditionals` list in the file doesn't matter, it will always overwrite other definitions in the file if condition is true. The order of conditional objects in the `conditionals` list does matter, the latter will possibly overwrite the former.

```hocon
beans {
  ...
}

conditionals = [
  {condition: ${ump.feature.enabled}, config: {include "feature.conf"}},
  {condition: ${ump.coolStuff.enabled}, config: {x = 2}}
] 
```