### PR TITLE
Analyzer rule to check for a required base package

### DIFF
--- a/commons-analyzer/src/main/scala/com/avsystem/commons/analyzer/AnalyzerPlugin.scala
+++ b/commons-analyzer/src/main/scala/com/avsystem/commons/analyzer/AnalyzerPlugin.scala
@@ -58,6 +58,7 @@ final class AnalyzerPlugin(val global: Global) extends Plugin { plugin =>
     new DiscardedMonixTask(global),
     new BadSingletonComponent(global),
     new ConstantDeclarations(global),
+    new BasePackage(global),
   )
 
   private lazy val rulesByName = rules.map(r => (r.name, r)).toMap

--- a/commons-analyzer/src/main/scala/com/avsystem/commons/analyzer/BasePackage.scala
+++ b/commons-analyzer/src/main/scala/com/avsystem/commons/analyzer/BasePackage.scala
@@ -1,0 +1,22 @@
+package com.avsystem.commons
+package analyzer
+
+import scala.annotation.tailrec
+import scala.tools.nsc.Global
+
+class BasePackage(g: Global) extends AnalyzerRule(g, "basePackage") {
+
+  import global._
+
+  def analyze(unit: CompilationUnit): Unit = if (argument != null) {
+    val requiredBasePackage = argument
+
+    @tailrec def validate(tree: Tree): Unit = tree match {
+      case PackageDef(pid, _) if pid.symbol.hasPackageFlag && pid.symbol.fullName == requiredBasePackage =>
+      case PackageDef(_, List(stat)) => validate(stat)
+      case t => report(t.pos, s"`$requiredBasePackage` must be one of the base packages in this file")
+    }
+
+    validate(unit.body)
+  }
+}

--- a/commons-analyzer/src/test/scala/com/avsystem/commons/analyzer/BasePackageTest.scala
+++ b/commons-analyzer/src/test/scala/com/avsystem/commons/analyzer/BasePackageTest.scala
@@ -35,6 +35,15 @@ class BasePackageTest extends AnyFunSuite with AnalyzerTest {
         |""".stripMargin)
   }
 
+  test("base package object") {
+    assertNoErrors(
+      """
+        |package com.avsystem
+        |
+        |package object commons
+        |""".stripMargin)
+  }
+
   test("no base package") {
     assertErrors(1,
       """

--- a/commons-analyzer/src/test/scala/com/avsystem/commons/analyzer/BasePackageTest.scala
+++ b/commons-analyzer/src/test/scala/com/avsystem/commons/analyzer/BasePackageTest.scala
@@ -1,0 +1,62 @@
+package com.avsystem.commons
+package analyzer
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class BasePackageTest extends AnyFunSuite with AnalyzerTest {
+  settings.pluginOptions.value ++= List("AVSystemAnalyzer:+basePackage:com.avsystem.commons")
+
+  test("base package only") {
+    assertNoErrors(
+      """
+        |package com.avsystem.commons
+        |
+        |object bar
+        |""".stripMargin)
+  }
+
+  test("chained base package") {
+    assertNoErrors(
+      """
+        |package com.avsystem
+        |package commons
+        |
+        |object bar
+        |""".stripMargin)
+  }
+
+  test("base package with chained subpackage") {
+    assertNoErrors(
+      """
+        |package com.avsystem.commons
+        |package core
+        |
+        |object bar
+        |""".stripMargin)
+  }
+
+  test("no base package") {
+    assertErrors(1,
+      """
+        |object bar
+        |""".stripMargin)
+  }
+
+  test("wrong base package") {
+    assertErrors(1,
+      """
+        |package com.avsystem.kommons
+        |
+        |object bar
+        |""".stripMargin)
+  }
+
+  test("unchained subpackage") {
+    assertErrors(1,
+      """
+        |package com.avsystem.commons.core
+        |
+        |object bar
+        |""".stripMargin)
+  }
+}

--- a/docs/Analyzer.md
+++ b/docs/Analyzer.md
@@ -30,11 +30,12 @@ Here's a list of currently supported rules:
 | `discardedMonixTask`       | warning       | Makes sure that expressions evaluating to Monix `Task`s are not accidentally discarded by conversion to `Unit`                                                                                       |
 | `throwableObjects`         | warning       | Makes sure that objects are never used as `Throwable`s (unless they have stack traces disabled)                                                                                                      |
 | `constantDeclarations`     | off           | Checks if constants are always declared as `final val`s with `UpperCamelCase` and no explicit type annotation for literal values                                                                     |
+| `basePackage               | warning       | Checks if all sources are within the specified base package                                                                                                                                          |
 
 Rules may be enabled and disabled in `build.sbt` with Scala compiler options:
 
 ```scala
-scalacOptions += "-P:AVSystemAnalyzer:<level><ruleName>,<level><ruleName>,..."
+scalacOptions += "-P:AVSystemAnalyzer:<level><ruleName>(:<arg>)?,<level><ruleName>(:<arg>)?,..."
 ```
 
 `<name>` must be one of the rule names listed above or `_` to apply to all rules.
@@ -45,3 +46,13 @@ scalacOptions += "-P:AVSystemAnalyzer:<level><ruleName>,<level><ruleName>,..."
 * `*` for "info" level
 * _empty_ for "warning" level
 * `+` for "error" level
+
+`<arg>` is an argument specific for given rule
+
+For example, this options sets all rules on "error" level except for `constantDeclarations` which is disabled
+and `discardedMonixTask` which is lowered to "warning" level. The `basePackage` rule is also lowered to "warning" level
+and `com.avsystem.commons` is specified as the base package.
+
+```scala
+scalacOptions += "-P:AVSystemAnalyzer:+_,-constantDeclarations,discardedMonixTask,basePackage:com.avsystem.commons
+```

--- a/docs/Analyzer.md
+++ b/docs/Analyzer.md
@@ -35,7 +35,7 @@ Here's a list of currently supported rules:
 Rules may be enabled and disabled in `build.sbt` with Scala compiler options:
 
 ```scala
-scalacOptions += "-P:AVSystemAnalyzer:<level><ruleName>(:<arg>)?,<level><ruleName>(:<arg>)?,..."
+scalacOptions += "-P:AVSystemAnalyzer:<level><ruleName>[:<arg>],<level><ruleName>[:<arg>],..."
 ```
 
 `<name>` must be one of the rule names listed above or `_` to apply to all rules.

--- a/docs/Analyzer.md
+++ b/docs/Analyzer.md
@@ -38,7 +38,7 @@ Rules may be enabled and disabled in `build.sbt` with Scala compiler options:
 scalacOptions += "-P:AVSystemAnalyzer:<level><ruleName>[:<arg>],<level><ruleName>[:<arg>],..."
 ```
 
-`<name>` must be one of the rule names listed above or `_` to apply to all rules.
+`<ruleName>` must be one of the rule names listed above or `_` to apply to all rules.
 
 `<level>` may be one of:
 


### PR DESCRIPTION
Example compiler option to enable this rule:

```
-P:AVSystemAnalyzer:basePackage:com.avsystem.commons
```

The rule checks two things:
* whether everything is in the specified package
* whether the specified package is also a _base package_, i.e. any subpackages must be specified in a separate, chained package clause