### PR TITLE
Redis client connection/reconnection fix

### DIFF
--- a/redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
@@ -227,7 +227,7 @@ final class RedisConnectionActor(address: NodeAddress, config: ConnectionConfig)
       val initBatch = config.initCommands *> RedisApi.Batches.StringTyped.ping
       val initBuffer = ByteBuffer.allocate(initBatch.rawCommandPacks.encodedSize)
       // schedule a Cancellable RetryInit in case we do not receive a response for our request
-      val scheduledRetry = system.scheduler.scheduleOnce(config.initTimeout, self, RetryInit(retryStrategy.next))
+      val scheduledRetry = system.scheduler.scheduleOnce(config.initResponseTimeout, self, RetryInit(retryStrategy.next))
       new ReplyCollector(initBatch.rawCommandPacks, initBuffer, onInitResult(_, retryStrategy))
         .sendEmptyReplyOr { collector =>
           flip(initBuffer)

--- a/redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/actor/RedisConnectionActor.scala
@@ -110,6 +110,7 @@ final class RedisConnectionActor(address: NodeAddress, config: ConnectionConfig)
         log.error(s"Received Connected for connection different than currently trying to establish")
         connection ! CloseConnection(immediate = true)
       } else {
+        log.debug(s"Connected to Redis at $address")
         //TODO: use dedicated retry strategy for initialization instead of reconnection strategy
         new ConnectedTo(connection, localAddress, remoteAddress).initialize(retryStrategy)
         readInitSender.foreach(_ ! ReadAck)

--- a/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -155,7 +155,7 @@ case class NodeConfig(
   * @param idleTimeout          maximum idle time for the connection
   * @param maxWriteSizeHint     hint for maximum number of bytes sent in a single network write message (the actual number
   *                             of bytes sent may be slightly larger)
-  * @param initTimeout          maximum time to wait for Redis response while initializing the client
+  * @param initResponseTimeout  maximum time to wait for Redis response while initializing the client
   * @param reconnectionStrategy a [[RetryStrategy]] used to determine what delay should be used when reconnecting
   *                             a failed connection. NOTE: `reconnectionStrategy` is ignored by `RedisConnectionClient`
   * @param debugListener        listener for traffic going through this connection. Only for debugging and testing
@@ -170,7 +170,7 @@ case class ConnectionConfig(
   connectTimeout: OptArg[FiniteDuration] = OptArg.Empty,
   idleTimeout: OptArg[FiniteDuration] = OptArg.Empty,
   maxWriteSizeHint: OptArg[Int] = 50000,
-  initTimeout: FiniteDuration = 5.seconds,
+  initResponseTimeout: FiniteDuration = 15.seconds,
   reconnectionStrategy: RetryStrategy = immediately.andThen(exponentially(1.seconds)).maxDelay(8.seconds),
   debugListener: DebugListener = DevNullListener
 )

--- a/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -155,6 +155,7 @@ case class NodeConfig(
   * @param idleTimeout          maximum idle time for the connection
   * @param maxWriteSizeHint     hint for maximum number of bytes sent in a single network write message (the actual number
   *                             of bytes sent may be slightly larger)
+  * @param initTimeout          maximum time to wait for Redis response while initializing the client
   * @param reconnectionStrategy a [[RetryStrategy]] used to determine what delay should be used when reconnecting
   *                             a failed connection. NOTE: `reconnectionStrategy` is ignored by `RedisConnectionClient`
   * @param debugListener        listener for traffic going through this connection. Only for debugging and testing
@@ -169,6 +170,7 @@ case class ConnectionConfig(
   connectTimeout: OptArg[FiniteDuration] = OptArg.Empty,
   idleTimeout: OptArg[FiniteDuration] = OptArg.Empty,
   maxWriteSizeHint: OptArg[Int] = 50000,
+  initTimeout: FiniteDuration = 5.seconds,
   reconnectionStrategy: RetryStrategy = immediately.andThen(exponentially(1.seconds)).maxDelay(8.seconds),
   debugListener: DebugListener = DevNullListener
 )


### PR DESCRIPTION
If PR fixes few issues:
- When client is reconnecting multiple times in a very short period of time it is possible that _Connected_ message from previous connection attempt will be handled after receiving _ConnectionClosed_. This was w race condition that causes client to think that it is connected
- _ConnectionClosed_ was ignored in _connecting_ state
- When Redis Server did not respond to our initial request, client was hung, waiting for the response without any timeout
- Retry strategy wasn't passed correctly in few places and there were some cases when client was trying to reconnect without any back-off
- Fix cluster initialisation procedure for tests
