### PR TITLE
Remove BlockingUtils#asIO & monix-bio optional dependency

### DIFF
--- a/core/jvm/src/main/scala/com/avsystem/commons/concurrent/BlockingUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/concurrent/BlockingUtils.scala
@@ -5,7 +5,6 @@ import com.avsystem.commons.collection.CloseableIterator
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
-import monix.bio.IO
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -38,9 +37,6 @@ abstract class BlockingUtils {
     */
   def asTask[T](blockingCode: => T): Task[T] =
     Task.eval(blockingCode).executeOn(ioScheduler, forceAsync = true)
-
-  def asIO[A, B](blockingCode: => Either[A, B]): IO[A, B] =
-    IO.deferTotal(IO.fromEither(blockingCode)).executeOn(ioScheduler, forceAsync = true)
 
   def await[T](future: Future[T]): T =
     await(future, defaultTimeout)

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -37,7 +37,6 @@ object Commons extends ProjectGroup("commons") {
   val scalaLoggingVersion = "3.9.5"
   val akkaVersion = "2.6.19"
   val monixVersion = "3.4.1"
-  val monixBioVersion = "1.2.0"
   val circeVersion = "0.14.5" // benchmark only
   val upickleVersion = "3.1.2" // benchmark only
   val scalajsBenchmarkVersion = "0.10.0"
@@ -287,7 +286,6 @@ object Commons extends ProjectGroup("commons") {
         "com.google.code.findbugs" % "jsr305" % jsr305Version % Optional,
         "com.google.guava" % "guava" % guavaVersion % Optional,
         "io.monix" %% "monix" % monixVersion % Optional,
-        "io.monix" %% "monix-bio" % monixBioVersion % Optional,
       ),
     )
 


### PR DESCRIPTION
Recently, we've ran into a problem, where some usages of `BlockingUtils` which involved Java code would not respect the optionality of monix-bio on the classpath. Since there's only a single usage for monix-bio in the commons library and the maintenance status of the library is questionable, I'd like to propose removing the optional dependency. Removed method can be easily restored in the projects if at all needed.