### PR TITLE
Use fallback value when executing Redis commands using Monix API

### DIFF
--- a/redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/ApiSubset.scala
@@ -160,7 +160,7 @@ trait RedisMonixApi extends RedisExecutedApi {
   type Result[A] = Task[A]
 
   def execute[A](command: RedisCommand[A]): Task[A] = Task.deferFutureAction { scheduler =>
-    executor.executeBatch(command, execConfig.copy(decodeOn = scheduler))
+    executor.executeBatch(command.batchOrFallback, execConfig.copy(decodeOn = scheduler))
   }
 
   def recoverWith[A](executed: => Task[A])(fun: PartialFunction[Throwable, Task[A]]): Task[A] =


### PR DESCRIPTION
Calling DEL Redis command with empty keys list using monix API
```
monixApi.del(Seq()).value
```
results in:
```
The future returned an exception of type: com.avsystem.commons.redis.exception.ErrorReplyException, with message: Redis replied with error: ERR wrong number of arguments for 'del' command, command: "DEL".
```

When using blockingApi everything is fine

