### PR TITLE
Reactive Publisher to Monix extensions for typed Mongo

### DIFF
--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/reactive/ReactiveMongoExtensions.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/reactive/ReactiveMongoExtensions.scala
@@ -1,0 +1,29 @@
+package com.avsystem.commons
+package mongo.reactive
+
+import monix.eval.Task
+import monix.reactive.Observable
+import org.reactivestreams.Publisher
+
+trait ReactiveMongoExtensions {
+  import ReactiveMongoExtensions._
+
+  implicit final def publisherOps[T](publisher: Publisher[T]): PublisherOps[T] = new PublisherOps(publisher)
+}
+object ReactiveMongoExtensions extends ReactiveMongoExtensions {
+  /**
+    * Extensions for converting [[Publisher]] to [[Task]]/[[Observable]] Monix types
+    */
+  final class PublisherOps[T](private val publisher: Publisher[T]) extends AnyVal {
+    def asMonix: Observable[T] = Observable.fromReactivePublisher(publisher)
+
+    // prefer using the family of methods below for observables which are intended to only return a single document,
+    // mongo observable implementation sometimes logs an error on server-closed cursors
+    private def singleObservable: Task[Option[T]] = Task.fromReactivePublisher(publisher)
+
+    def headOptL: Task[Opt[T]] = singleObservable.map(_.toOpt)
+    def headOptionL: Task[Option[T]] = singleObservable.map(_.filterNot(_ == null))
+    def headL: Task[T] = singleObservable.map(_.get)
+    def completedL: Task[Unit] = singleObservable.void
+  }
+}

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/reactive/ReactiveMongoExtensions.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/reactive/ReactiveMongoExtensions.scala
@@ -21,9 +21,11 @@ object ReactiveMongoExtensions extends ReactiveMongoExtensions {
     // mongo observable implementation sometimes logs an error on server-closed cursors
     private def singleObservable: Task[Option[T]] = Task.fromReactivePublisher(publisher)
 
-    def headOptL: Task[Opt[T]] = singleObservable.map(_.toOpt)
+    // handles both an empty Publisher and and a single null item
     def headOptionL: Task[Option[T]] = singleObservable.map(_.filterNot(_ == null))
+    def headOptL: Task[Opt[T]] = headOptionL.map(_.toOpt)
+    // can return null if Mongo driver for some reason returns null, intentionally don't want to report failure
     def headL: Task[T] = singleObservable.map(_.get)
-    def completedL: Task[Unit] = singleObservable.void
+    def completedL: Task[Unit] = headOptionL.void
   }
 }

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoUtils.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoUtils.scala
@@ -7,18 +7,13 @@ import monix.reactive.Observable
 import org.reactivestreams.Publisher
 
 trait TypedMongoUtils {
-  protected final def empty(publisher: Publisher[Void]): Task[Unit] =
-    Observable.fromReactivePublisher(publisher, 1).completedL
+  import com.avsystem.commons.mongo.reactive.ReactiveMongoExtensions._
 
-  protected final def single[T](publisher: Publisher[T]): Task[T] =
-    Observable.fromReactivePublisher(publisher, 1).firstL
-
+  protected final def empty(publisher: Publisher[Void]): Task[Unit] = publisher.completedL
+  protected final def single[T](publisher: Publisher[T]): Task[T] = publisher.headL
   // handles both an empty Publisher and and a single null item
-  protected final def singleOpt[T](publisher: Publisher[T]): Task[Option[T]] =
-    Observable.fromReactivePublisher(publisher, 1).filter(_ != null).firstOptionL
-
-  protected final def multi[T](publisher: Publisher[T]): Observable[T] =
-    Observable.fromReactivePublisher(publisher)
+  protected final def singleOpt[T](publisher: Publisher[T]): Task[Option[T]] = publisher.headOptionL
+  protected final def multi[T](publisher: Publisher[T]): Observable[T] = publisher.asMonix
 
   /**
     * Transforms an expression `method(nullableArg, moreArgs)` into


### PR DESCRIPTION
Extract conversions from `TypedMongoUtils` as proper extension methods, so they can be reused in other places