### PR TITLE
Add `Opt.when` method

### DIFF
--- a/core/src/test/scala/com/avsystem/commons/misc/OptTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/OptTest.scala
@@ -66,4 +66,16 @@ class OptTest extends AnyFunSuite {
     val seq: Seq[Int] = Opt(5).mapOr(Nil, i => 0 until i)
     assert(seq == (0 until 5))
   }
+
+  test("Opt.{when, unless}") {
+    val opt = Opt(42)
+
+    assert(opt.when(true) == opt)
+    assert(opt.when(false) == Opt.Empty)
+    assert(Opt(fail("Parameter should not be evaluated")).when(false) == Opt.Empty)
+
+    assert(opt.unless(false) == opt)
+    assert(opt.unless(true) == Opt.Empty)
+    assert(Opt(fail("Parameter should not be evaluated")).unless(true) == Opt.Empty)
+  }
 }


### PR DESCRIPTION
`Opt.when` is similar to `optIf`, but takes `Opt[?]` parameter. The inspiration came from `Task.when`.

It may simplify code like this:

`if (predicate(sth)) sthElse.orElse(sthMoreElse.map(_.sth)) else Opt.Empty`

to

`Opt.when(predicate(sth)){ sthElse.orElse(sthMoreElse.map(_.sth)) }`