### PR TITLE
Allow Output to ignore @transientDefault

### DIFF
--- a/core/src/main/scala/com/avsystem/commons/serialization/GenCodec.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/GenCodec.scala
@@ -312,11 +312,13 @@ object GenCodec extends RecursiveAutoCodecs with TupleGenCodecs {
   }
 
   trait SizedCodec[T] extends GenCodec[T] {
-    def size(value: T): Int
+    def size(value: T): Int = size(value, Opt.Empty)
+
+    def size(value: T, output: Opt[SequentialOutput]): Int
 
     protected final def declareSizeFor(output: SequentialOutput, value: T): Unit =
       if (output.sizePolicy != SizePolicy.Ignored) {
-        output.declareSize(size(value))
+        output.declareSize(size(value, output.opt))
       }
   }
 
@@ -336,8 +338,8 @@ object GenCodec extends RecursiveAutoCodecs with TupleGenCodecs {
   object OOOFieldsObjectCodec {
     // this was introduced so that transparent wrapper cases are possible in flat sealed hierarchies
     final class Transformed[A, B](val wrapped: OOOFieldsObjectCodec[B], onWrite: A => B, onRead: B => A) extends OOOFieldsObjectCodec[A] {
-      def size(value: A): Int =
-        wrapped.size(onWrite(value))
+      def size(value: A, output: Opt[SequentialOutput]): Int =
+        wrapped.size(onWrite(value), output)
 
       def readObject(input: ObjectInput, outOfOrderFields: FieldValues): A =
         onRead(wrapped.readObject(input, outOfOrderFields))

--- a/core/src/main/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarker.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarker.scala
@@ -7,9 +7,9 @@ package serialization
   * representation. Deserialization behavior remains <b>unchanged</b>. If a field is missing from the input, the default
   * value will be used as usual.
   *
-  * This annotation can be helpful when using the same model class in multiple contexts with different serialization
+  * This marker can be helpful when using the same model class in multiple contexts with different serialization
   * formats that have conflicting requirements for handling default values.
   *
-  * @see [[CustomMarkersOutputWrapper]]
+  * @see [[CustomMarkersOutputWrapper]] for an easy way to add markers to existing [[Output]] implementations
   */
 object IgnoreTransientDefaultMarker extends CustomEventMarker[Unit]

--- a/core/src/main/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarker.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarker.scala
@@ -1,0 +1,15 @@
+package com.avsystem.commons
+package serialization
+
+/**
+  * Instructs [[GenCodec]] to <b>ignore</b> the [[transientDefault]] annotation when serializing a case class.
+  * This ensures that even if a field's value is the same as its default, it will be <b>included</b> in the serialized
+  * representation. Deserialization behavior remains <b>unchanged</b>. If a field is missing from the input, the default
+  * value will be used as usual.
+  *
+  * This annotation can be helpful when using the same model class in multiple contexts with different serialization
+  * formats that have conflicting requirements for handling default values.
+  *
+  * @see [[CustomMarkersOutputWrapper]]
+  */
+object IgnoreTransientDefaultMarker extends CustomEventMarker[Unit]

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOptimizedCodecs.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOptimizedCodecs.scala
@@ -87,7 +87,7 @@ class OOOFieldCborRawKeysCodec[T](stdObjectCodec: OOOFieldsObjectCodec[T], keyCo
     stdObjectCodec.writeFields(output, value)
   }
 
-  def size(value: T): Int = stdObjectCodec.size(value)
+  def size(value: T, output: Opt[SequentialOutput]): Int = stdObjectCodec.size(value, output)
   def nullable: Boolean = stdObjectCodec.nullable
 }
 

--- a/core/src/main/scala/com/avsystem/commons/serialization/customMarkerWrappers.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/customMarkerWrappers.scala
@@ -1,0 +1,139 @@
+package com.avsystem.commons
+package serialization
+
+/**
+  * [[Input]] implementation that adds additional markers [[CustomEventMarker]] to the provided [[Input]] instance
+  */
+final class CustomMarkersInputWrapper(
+  override protected val wrapped: Input,
+  markers: Set[CustomEventMarker[_]],
+) extends InputWrapper {
+
+  override def readList(): ListInput =
+    new CustomMarkersInputWrapper.AdjustedListInput(super.readList(), markers)
+
+  override def readObject(): ObjectInput =
+    new CustomMarkersInputWrapper.AdjustedObjectInput(super.readObject(), markers)
+
+  override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+    marker match {
+      case marker if markers(marker) => true
+      case _ => super.customEvent(marker, value)
+    }
+}
+object CustomMarkersInputWrapper {
+  def apply(input: Input, markers: CustomEventMarker[_]*): CustomMarkersInputWrapper =
+    new CustomMarkersInputWrapper(input, markers.toSet)
+
+  private final class AdjustedListInput(
+    override protected val wrapped: ListInput,
+    markers: Set[CustomEventMarker[_]],
+  ) extends ListInputWrapper {
+    override def nextElement(): Input = new CustomMarkersInputWrapper(super.nextElement(), markers)
+    override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+      marker match {
+        case marker if markers(marker) => true
+        case _ => super.customEvent(marker, value)
+      }
+  }
+
+  private final class AdjustedFieldInput(
+    override protected val wrapped: FieldInput,
+    markers: Set[CustomEventMarker[_]],
+  ) extends FieldInputWrapper {
+
+    override def readList(): ListInput = new AdjustedListInput(super.readList(), markers)
+    override def readObject(): ObjectInput = new AdjustedObjectInput(super.readObject(), markers)
+
+    override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+      marker match {
+        case marker if markers(marker) => true
+        case _ => super.customEvent(marker, value)
+      }
+  }
+
+  private final class AdjustedObjectInput(
+    override protected val wrapped: ObjectInput,
+    markers: Set[CustomEventMarker[_]],
+  ) extends ObjectInputWrapper {
+
+    override def nextField(): FieldInput = new AdjustedFieldInput(super.nextField(), markers)
+
+    override def peekField(name: String): Opt[FieldInput] =
+      super.peekField(name).map(new AdjustedFieldInput(_, markers))
+
+    override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+      marker match {
+        case marker if markers(marker) => true
+        case _ => super.customEvent(marker, value)
+      }
+  }
+}
+
+/**
+  * [[Output]] implementation that adds additional markers [[CustomEventMarker]] to the provided [[Output]] instance
+  */
+final class CustomMarkersOutputWrapper(
+  override protected val wrapped: Output,
+  markers: Set[CustomEventMarker[_]],
+) extends OutputWrapper {
+
+  override def writeSimple(): SimpleOutput =
+    new CustomMarkersOutputWrapper.AdjustedSimpleOutput(super.writeSimple(), markers)
+
+  override def writeList(): ListOutput =
+    new CustomMarkersOutputWrapper.AdjustedListOutput(super.writeList(), markers)
+
+  override def writeObject(): ObjectOutput =
+    new CustomMarkersOutputWrapper.AdjustedObjectOutput(super.writeObject(), markers)
+
+  override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+    marker match {
+      case marker if markers(marker) => true
+      case _ => super.customEvent(marker, value)
+    }
+}
+
+object CustomMarkersOutputWrapper {
+  def apply(output: Output, markers: CustomEventMarker[_]*): CustomMarkersOutputWrapper =
+    new CustomMarkersOutputWrapper(output, markers.toSet)
+
+  private final class AdjustedSimpleOutput(
+    override protected val wrapped: SimpleOutput,
+    markers: Set[CustomEventMarker[_]],
+  ) extends SimpleOutputWrapper {
+    override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+      marker match {
+        case marker if markers(marker) => true
+        case _ => super.customEvent(marker, value)
+      }
+  }
+
+  private final class AdjustedListOutput(
+    override protected val wrapped: ListOutput,
+    markers: Set[CustomEventMarker[_]],
+  ) extends ListOutputWrapper {
+    override def writeElement(): Output =
+      new CustomMarkersOutputWrapper(super.writeElement(), markers)
+
+    override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+      marker match {
+        case marker if markers(marker) => true
+        case _ => super.customEvent(marker, value)
+      }
+  }
+
+  private final class AdjustedObjectOutput(
+    override protected val wrapped: ObjectOutput,
+    markers: Set[CustomEventMarker[_]],
+  ) extends ObjectOutputWrapper {
+    override def writeField(key: String): Output =
+      new CustomMarkersOutputWrapper(super.writeField(key), markers)
+
+    override def customEvent[T](marker: CustomEventMarker[T], value: T): Boolean =
+      marker match {
+        case marker if markers(marker) => true
+        case _ => super.customEvent(marker, value)
+      }
+  }
+}

--- a/core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -12,7 +12,7 @@ class SingletonCodec[T <: Singleton](
 ) extends ErrorReportingCodec[T] with OOOFieldsObjectCodec[T] {
   final def nullable = true
   final def readObject(input: ObjectInput, outOfOrderFields: FieldValues): T = singletonValue
-  def size(value: T): Int = 0
+  def size(value: T, output: Opt[SequentialOutput]): Int = 0
   def writeFields(output: ObjectOutput, value: T): Unit = ()
 }
 
@@ -109,7 +109,7 @@ abstract class ProductCodec[T <: Product](
   nullable: Boolean,
   fieldNames: Array[String]
 ) extends ApplyUnapplyCodec[T](typeRepr, nullable, fieldNames) {
-  def size(value: T): Int = value.productArity
+  def size(value: T, output: Opt[SequentialOutput]): Int = value.productArity
 
   final def writeFields(output: ObjectOutput, value: T): Unit = {
     val size = value.productArity

--- a/core/src/test/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarkerTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarkerTest.scala
@@ -1,0 +1,52 @@
+package com.avsystem.commons
+package serialization
+
+import com.avsystem.commons.serialization.CodecTestData.HasDefaults
+
+object IgnoreTransientDefaultMarkerTest {
+  final case class NestedHasDefaults(
+    @transientDefault flag: Boolean = false,
+    obj: HasDefaults,
+    list: Seq[HasDefaults],
+    @transientDefault defaultObj: HasDefaults = HasDefaults(),
+  )
+  object NestedHasDefaults extends HasGenCodec[NestedHasDefaults]
+}
+
+class IgnoreTransientDefaultMarkerTest extends AbstractCodecTest {
+  import IgnoreTransientDefaultMarkerTest._
+
+  override type Raw = Any
+
+  def writeToOutput(write: Output => Unit): Any = {
+    var result: Any = null
+    write(CustomMarkersOutputWrapper(new SimpleValueOutput(result = _), IgnoreTransientDefaultMarker))
+    result
+  }
+
+  def createInput(raw: Any): Input = new SimpleValueInput(raw)
+
+  test("case class with default values") {
+    testWrite(HasDefaults(str = "lol"), Map("str" -> "lol", "int" -> 42))
+    testWrite(HasDefaults(43, "lol"), Map("int" -> 43, "str" -> "lol"))
+    testWrite(HasDefaults(str = null), Map("str" -> null, "int" -> 42))
+    testWrite(HasDefaults(str = "dafuq"), Map("str" -> "dafuq", "int" -> 42))
+  }
+
+  test("nested case class with default values") {
+    testWrite(
+      value = NestedHasDefaults(
+        flag = false,
+        obj = HasDefaults(str = "lol"),
+        list = Seq(HasDefaults(int = 43)),
+        defaultObj = HasDefaults(),
+      ),
+      expectedRepr = Map(
+        "flag" -> false,
+        "defaultObj" -> Map[String, Any]("str" -> "kek", "int" -> 42),
+        "obj" -> Map[String, Any]("str" -> "lol", "int" -> 42),
+        "list" -> List(Map[String, Any]("str" -> "kek", "int" -> 43)),
+      ),
+    )
+  }
+}

--- a/core/src/test/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarkerTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarkerTest.scala
@@ -20,13 +20,13 @@ object IgnoreTransientDefaultMarkerTest {
 }
 
 class IgnoreTransientDefaultMarkerTest extends AbstractCodecTest {
-  import IgnoreTransientDefaultMarkerTest._
+  import IgnoreTransientDefaultMarkerTest.*
 
   override type Raw = Any
 
   def writeToOutput(write: Output => Unit): Any = {
     var result: Any = null
-    write(CustomMarkersOutputWrapper(new SimpleValueOutput(result = _), IgnoreTransientDefaultMarker))
+    write(CustomMarkersOutputWrapper(new SimpleValueOutput(v => result = v), IgnoreTransientDefaultMarker))
     result
   }
 
@@ -40,6 +40,7 @@ class IgnoreTransientDefaultMarkerTest extends AbstractCodecTest {
     testWrite(HasDefaults(str = "dafuq"), Map("str" -> "dafuq", "int" -> 42))
   }
 
+  //noinspection RedundantDefaultArgument
   test("read case class with default values") {
     testRead(Map("str" -> "lol", "int" -> 42), HasDefaults(str = "lol", int = 42))
     testRead(Map("str" -> "lol"), HasDefaults(str = "lol", int = 42))
@@ -54,6 +55,7 @@ class IgnoreTransientDefaultMarkerTest extends AbstractCodecTest {
     testWrite(HasOptParam(), Map("flag" -> false))
   }
 
+  //noinspection RedundantDefaultArgument
   test("write nested case class with default values") {
     testWrite(
       value = NestedHasDefaults(

--- a/core/src/test/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarkerTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/IgnoreTransientDefaultMarkerTest.scala
@@ -11,6 +11,12 @@ object IgnoreTransientDefaultMarkerTest {
     @transientDefault defaultObj: HasDefaults = HasDefaults(),
   )
   object NestedHasDefaults extends HasGenCodec[NestedHasDefaults]
+
+  final case class HasOptParam(
+    @transientDefault flag: Boolean = false,
+    @optionalParam str: Opt[String] = Opt.Empty,
+  )
+  object HasOptParam extends HasGenCodec[HasOptParam]
 }
 
 class IgnoreTransientDefaultMarkerTest extends AbstractCodecTest {
@@ -24,16 +30,31 @@ class IgnoreTransientDefaultMarkerTest extends AbstractCodecTest {
     result
   }
 
-  def createInput(raw: Any): Input = new SimpleValueInput(raw)
+  def createInput(raw: Any): Input =
+    CustomMarkersInputWrapper(new SimpleValueInput(raw), IgnoreTransientDefaultMarker)
 
-  test("case class with default values") {
+  test("write case class with default values") {
     testWrite(HasDefaults(str = "lol"), Map("str" -> "lol", "int" -> 42))
     testWrite(HasDefaults(43, "lol"), Map("int" -> 43, "str" -> "lol"))
     testWrite(HasDefaults(str = null), Map("str" -> null, "int" -> 42))
     testWrite(HasDefaults(str = "dafuq"), Map("str" -> "dafuq", "int" -> 42))
   }
 
-  test("nested case class with default values") {
+  test("read case class with default values") {
+    testRead(Map("str" -> "lol", "int" -> 42), HasDefaults(str = "lol", int = 42))
+    testRead(Map("str" -> "lol"), HasDefaults(str = "lol", int = 42))
+    testRead(Map("int" -> 43, "str" -> "lol"), HasDefaults(int = 43, str = "lol"))
+    testRead(Map("str" -> null, "int" -> 42), HasDefaults(str = null, int = 42))
+    testRead(Map("str" -> null), HasDefaults(str = null, int = 42))
+    testRead(Map(), HasDefaults(str = "dafuq", int = 42))
+  }
+
+  test("write case class with opt values") {
+    testWrite(HasOptParam(str = "lol".opt), Map("flag" -> false, "str" -> "lol"))
+    testWrite(HasOptParam(), Map("flag" -> false))
+  }
+
+  test("write nested case class with default values") {
     testWrite(
       value = NestedHasDefaults(
         flag = false,

--- a/core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
@@ -3,7 +3,7 @@ package serialization
 
 import org.scalatest.funsuite.AnyFunSuite
 
-case class RecordWithDefaults(
+final case class RecordWithDefaults(
   @transientDefault a: String = "",
   b: Int = 42
 ) {
@@ -11,7 +11,7 @@ case class RecordWithDefaults(
 }
 object RecordWithDefaults extends HasApplyUnapplyCodec[RecordWithDefaults]
 
-class CustomRecordWithDefaults(val a: String, val b: Int)
+final class CustomRecordWithDefaults(val a: String, val b: Int)
 object CustomRecordWithDefaults extends HasApplyUnapplyCodec[CustomRecordWithDefaults] {
   def apply(@transientDefault a: String = "", b: Int = 42): CustomRecordWithDefaults =
     new CustomRecordWithDefaults(a, b)
@@ -19,23 +19,23 @@ object CustomRecordWithDefaults extends HasApplyUnapplyCodec[CustomRecordWithDef
     Opt((crwd.a, crwd.b))
 }
 
-class CustomWrapper(val a: String)
+final class CustomWrapper(val a: String)
 object CustomWrapper extends HasApplyUnapplyCodec[CustomWrapper] {
   def apply(@transientDefault a: String = ""): CustomWrapper = new CustomWrapper(a)
   def unapply(cw: CustomWrapper): Opt[String] = Opt(cw.a)
 }
 
-case class RecordWithOpts(
+final case class RecordWithOpts(
   @optionalParam abc: Opt[String] = Opt.Empty,
   @transientDefault flag: Opt[Boolean] = Opt.Empty,
   b: Int = 42,
 )
 object RecordWithOpts extends HasApplyUnapplyCodec[RecordWithOpts]
 
-case class SingleFieldRecordWithOpts(@optionalParam abc: Opt[String] = Opt.Empty)
+final case class SingleFieldRecordWithOpts(@optionalParam abc: Opt[String] = Opt.Empty)
 object SingleFieldRecordWithOpts extends HasApplyUnapplyCodec[SingleFieldRecordWithOpts]
 
-case class SingleFieldRecordWithTD(@transientDefault abc: String = "abc")
+final case class SingleFieldRecordWithTD(@transientDefault abc: String = "abc")
 object SingleFieldRecordWithTD extends HasApplyUnapplyCodec[SingleFieldRecordWithTD]
 
 class ObjectSizeTest extends AnyFunSuite {

--- a/core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
@@ -34,4 +34,19 @@ class ObjectSizeTest extends AnyFunSuite {
     assert(CustomWrapper.codec.size(CustomWrapper()) == 0)
     assert(CustomWrapper.codec.size(CustomWrapper("fuu")) == 1)
   }
+
+  test("computing object size with custom output") {
+    val defaultIgnoringOutput = new SequentialOutput {
+      override def customEvent[T](marker: CustomEventMarker[T], event: T): Boolean =
+        marker match {
+          case IgnoreTransientDefaultMarker => true
+          case _ =>  super.customEvent(marker, event)
+        }
+      override def finish(): Unit = ()
+    }
+    assert(RecordWithDefaults.codec.size(RecordWithDefaults(), defaultIgnoringOutput.opt) == 3)
+    assert(RecordWithDefaults.codec.size(RecordWithDefaults("fuu"), defaultIgnoringOutput.opt) == 3)
+    assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults(), defaultIgnoringOutput.opt) == 2)
+    assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults("fuu"), defaultIgnoringOutput.opt) == 2)
+  }
 }

--- a/core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/ObjectSizeTest.scala
@@ -25,10 +25,30 @@ object CustomWrapper extends HasApplyUnapplyCodec[CustomWrapper] {
   def unapply(cw: CustomWrapper): Opt[String] = Opt(cw.a)
 }
 
+case class RecordWithOpts(
+  @optionalParam abc: Opt[String] = Opt.Empty,
+  @transientDefault flag: Opt[Boolean] = Opt.Empty,
+  b: Int = 42,
+)
+object RecordWithOpts extends HasApplyUnapplyCodec[RecordWithOpts]
+
+case class SingleFieldRecordWithOpts(@optionalParam abc: Opt[String] = Opt.Empty)
+object SingleFieldRecordWithOpts extends HasApplyUnapplyCodec[SingleFieldRecordWithOpts]
+
+case class SingleFieldRecordWithTD(@transientDefault abc: String = "abc")
+object SingleFieldRecordWithTD extends HasApplyUnapplyCodec[SingleFieldRecordWithTD]
+
 class ObjectSizeTest extends AnyFunSuite {
   test("computing object size") {
     assert(RecordWithDefaults.codec.size(RecordWithDefaults()) == 2)
     assert(RecordWithDefaults.codec.size(RecordWithDefaults("fuu")) == 3)
+    assert(RecordWithOpts.codec.size(RecordWithOpts("abc".opt)) == 2)
+    assert(RecordWithOpts.codec.size(RecordWithOpts("abc".opt, true.opt)) == 3)
+    assert(RecordWithOpts.codec.size(RecordWithOpts()) == 1)
+    assert(SingleFieldRecordWithOpts.codec.size(SingleFieldRecordWithOpts()) == 0)
+    assert(SingleFieldRecordWithOpts.codec.size(SingleFieldRecordWithOpts("abc".opt)) == 1)
+    assert(SingleFieldRecordWithTD.codec.size(SingleFieldRecordWithTD()) == 0)
+    assert(SingleFieldRecordWithTD.codec.size(SingleFieldRecordWithTD("haha")) == 1)
     assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults()) == 1)
     assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults("fuu")) == 2)
     assert(CustomWrapper.codec.size(CustomWrapper()) == 0)
@@ -46,6 +66,13 @@ class ObjectSizeTest extends AnyFunSuite {
     }
     assert(RecordWithDefaults.codec.size(RecordWithDefaults(), defaultIgnoringOutput.opt) == 3)
     assert(RecordWithDefaults.codec.size(RecordWithDefaults("fuu"), defaultIgnoringOutput.opt) == 3)
+    assert(RecordWithOpts.codec.size(RecordWithOpts("abc".opt), defaultIgnoringOutput.opt) == 3)
+    assert(RecordWithOpts.codec.size(RecordWithOpts("abc".opt, true.opt), defaultIgnoringOutput.opt) == 3)
+    assert(RecordWithOpts.codec.size(RecordWithOpts(), defaultIgnoringOutput.opt) == 2)
+    assert(SingleFieldRecordWithOpts.codec.size(SingleFieldRecordWithOpts(), defaultIgnoringOutput.opt) == 0) // @optionalParam field should NOT be counted
+    assert(SingleFieldRecordWithOpts.codec.size(SingleFieldRecordWithOpts("abc".opt), defaultIgnoringOutput.opt) == 1)
+    assert(SingleFieldRecordWithTD.codec.size(SingleFieldRecordWithTD(), defaultIgnoringOutput.opt) == 1) // @transientDefault field should be counted
+    assert(SingleFieldRecordWithTD.codec.size(SingleFieldRecordWithTD("haha"), defaultIgnoringOutput.opt) == 1)
     assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults(), defaultIgnoringOutput.opt) == 2)
     assert(CustomRecordWithDefaults.codec.size(CustomRecordWithDefaults("fuu"), defaultIgnoringOutput.opt) == 2)
   }

--- a/core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import java.io.{ByteArrayOutputStream, DataOutputStream}
 
-case class Record(
+final case class Record(
   b: Boolean,
   i: Int,
   l: List[String],
@@ -19,7 +19,7 @@ case class Record(
 )
 object Record extends HasGenCodec[Record]
 
-case class CustomKeysRecord(
+final case class CustomKeysRecord(
   @cborKey(1) first: Int,
   @cborKey(true) second: Boolean,
   @cborKey(Vector(1, 2, 3)) third: String,
@@ -28,13 +28,13 @@ case class CustomKeysRecord(
 )
 object CustomKeysRecord extends HasCborCodec[CustomKeysRecord]
 
-case class CustomKeysRecordWithDefaults(
+final case class CustomKeysRecordWithDefaults(
   @transientDefault @cborKey(1) first: Int = 0,
   @cborKey(true) second: Boolean,
 )
 object CustomKeysRecordWithDefaults extends HasCborCodec[CustomKeysRecordWithDefaults]
 
-case class CustomKeysRecordWithNoDefaults(
+final case class CustomKeysRecordWithNoDefaults(
   @cborKey(1) first: Int = 0,
   @cborKey(true) second: Boolean,
 )
@@ -242,11 +242,13 @@ class CborInputOutputTest extends AnyFunSuite {
     val value = CustomKeysRecordWithDefaults(first = 0, second = true)
     GenCodec.write(output, value)
     val bytes = Bytes(baos.toByteArray)
-    assert(bytes.toString == "A20100F5F5")
+
+    val expectedRawValue = "A20100F5F5"
+    assert(bytes.toString == expectedRawValue)
     assert(RawCbor(bytes.bytes).readAs[CustomKeysRecordWithDefaults](keyCodec) == value)
 
     // should be the same as model with @transientDefault and serialization ignoring it
-    assertRoundtrip(CustomKeysRecordWithNoDefaults(first = 0, second = true), "A20100F5F5")
+    assertRoundtrip(CustomKeysRecordWithNoDefaults(first = 0, second = true), expectedRawValue)
   }
 
   test("chunked text string") {

--- a/core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
@@ -28,6 +28,18 @@ case class CustomKeysRecord(
 )
 object CustomKeysRecord extends HasCborCodec[CustomKeysRecord]
 
+case class CustomKeysRecordWithDefaults(
+  @transientDefault @cborKey(1) first: Int = 0,
+  @cborKey(true) second: Boolean,
+)
+object CustomKeysRecordWithDefaults extends HasCborCodec[CustomKeysRecordWithDefaults]
+
+case class CustomKeysRecordWithNoDefaults(
+  @cborKey(1) first: Int = 0,
+  @cborKey(true) second: Boolean,
+)
+object CustomKeysRecordWithNoDefaults extends HasCborCodec[CustomKeysRecordWithNoDefaults]
+
 @cborDiscriminator(0)
 sealed trait GenericSealedTrait[+T]
 object GenericSealedTrait extends HasPolyCborCodec[GenericSealedTrait] {
@@ -61,13 +73,21 @@ class CborInputOutputTest extends AnyFunSuite {
     keyCodec: CborKeyCodec = CborKeyCodec.Default
   )(implicit pos: Position): Unit =
     test(s"${pos.lineNumber}: $value") {
-      val baos = new ByteArrayOutputStream
-      val output = new CborOutput(new DataOutputStream(baos), keyCodec, SizePolicy.Optional)
-      GenCodec.write[T](output, value)
-      val bytes = baos.toByteArray
-      assert(Bytes(bytes).toString == binary)
-      assert(RawCbor(bytes).readAs[T](keyCodec) == value)
+      assertRoundtrip(value, binary, keyCodec)
     }
+
+  private def assertRoundtrip[T: GenCodec](
+    value: T,
+    binary: String,
+    keyCodec: CborKeyCodec = CborKeyCodec.Default
+  )(implicit pos: Position): Unit = {
+    val baos = new ByteArrayOutputStream
+    val output = new CborOutput(new DataOutputStream(baos), keyCodec, SizePolicy.Optional)
+    GenCodec.write[T](output, value)
+    val bytes = baos.toByteArray
+    assert(Bytes(bytes).toString == binary)
+    assert(RawCbor(bytes).readAs[T](keyCodec) == value)
+  }
 
   // binary representation from cbor.me
 
@@ -211,6 +231,22 @@ class CborInputOutputTest extends AnyFunSuite {
   test("writing with CBOR optimized codec to non-CBOR output") {
     assert(JsonStringOutput.write(CustomKeysRecord(42, second = true, "foo", Map("foo" -> 1), Map(1 -> "foo"))) ==
       """{"first":42,"second":true,"third":"foo","strMap":{"foo":1},"intMap":{"1":"foo"}}""")
+  }
+
+  test("writing with IgnoreTransientDefaultMarker to CBOR output") {
+    val baos = new ByteArrayOutputStream
+    val output = CustomMarkersOutputWrapper(
+      new CborOutput(new DataOutputStream(baos), keyCodec, SizePolicy.Optional),
+      IgnoreTransientDefaultMarker,
+    )
+    val value = CustomKeysRecordWithDefaults(first = 0, second = true)
+    GenCodec.write(output, value)
+    val bytes = Bytes(baos.toByteArray)
+    assert(bytes.toString == "A20100F5F5")
+    assert(RawCbor(bytes.bytes).readAs[CustomKeysRecordWithDefaults](keyCodec) == value)
+
+    // should be the same as model with @transientDefault and serialization ignoring it
+    assertRoundtrip(CustomKeysRecordWithNoDefaults(first = 0, second = true), "A20100F5F5")
   }
 
   test("chunked text string") {

--- a/macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
+++ b/macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
@@ -313,8 +313,8 @@ class GenCodecMacros(ctx: blackbox.Context) extends CodecMacroCommons(ctx) with 
       def sizeMethod: List[Tree] = if (useProductCodec) Nil else {
         val res =
           q"""
-            def size(value: $dtpe): $IntCls =
-              ${params.size} + ${generated.size} - $countTransientFields
+            def size(value: $dtpe, output: $OptCls[$SerializationPkg.SequentialOutput]): $IntCls =
+              ${params.size} + ${generated.size} - output.filter(_.customEvent($SerializationPkg.IgnoreTransientDefaultMarker, ())).mapOr($countTransientFields, _ => 0)
           """
         List(res)
       }

--- a/macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
+++ b/macros/src/main/scala/com/avsystem/commons/macros/serialization/GenCodecMacros.scala
@@ -120,7 +120,7 @@ class GenCodecMacros(ctx: blackbox.Context) extends CodecMacroCommons(ctx) with 
       q"""
         new $SerializationPkg.SingletonCodec[$tpe](${tpe.toString}, $safeSingleValue) {
           ..${generated.map({ case (sym, depTpe) => generatedDepDeclaration(sym, depTpe) })}
-          override def size(value: $tpe): $IntCls = ${generated.size}
+          override def size(value: $tpe, output: $OptCls[$SerializationPkg.SequentialOutput]): $IntCls = ${generated.size}
           override def writeFields(output: $SerializationPkg.ObjectOutput, value: $tpe): $UnitCls = {
             ..${generated.map({ case (sym, _) => generatedWrite(sym) })}
           }


### PR DESCRIPTION
 Implement `IgnoreTransientDefaultMarker` that allows `Output` implementation to instruct `GenCodec` instance to ignore
`@transientDefault` annotation on case class fields and serialize all fields even when field value is equal to it's default value.

 Allowing this behaviour can be helpful when using the same model class in multiple contexts with different serialization
 formats that have conflicting requirements for handling default values.