### PR TITLE
Deprecate commons-redis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  REDIS_VERSION: 6.2.12
 
 jobs:
   build:
@@ -52,12 +51,6 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Cache Redis
-        uses: actions/cache@v2
-        with:
-          path: ./redis-${{ env.REDIS_VERSION }}
-          key: ${{ runner.os }}-redis-cache-v2-${{ env.REDIS_VERSION }}
-
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
@@ -68,9 +61,6 @@ jobs:
         with:
           mongodb-version: 7.0
           mongodb-replica-set: test-rs
-
-      - name: Setup Redis
-        run: ./install-redis.sh
 
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
     [`OptRef`](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/misc/OptRef.html) (implemented as value
     classes)
   * [Components](docs/Components.md) and Dependency Injection library
-* `commons-redis` - [Scala driver for Redis](docs/RedisDriver.md)
 * `commons-macros` contains implementations of macros used in other modules and reusable macro utilities:
   * `MacroCommons` trait with several convenience functions for implementing macros
   * `TypeClassDerivation` - implements infrastructure for automatic type class derivation

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
     [`OptRef`](http://avsystem.github.io/scala-commons/api/com/avsystem/commons/misc/OptRef.html) (implemented as value
     classes)
   * [Components](docs/Components.md) and Dependency Injection library
+* `commons-redis` (DEPRECATED) - [Scala driver for Redis](docs/RedisDriver.md)
 * `commons-macros` contains implementations of macros used in other modules and reusable macro utilities:
   * `MacroCommons` trait with several convenience functions for implementing macros
   * `TypeClassDerivation` - implements infrastructure for automatic type class derivation

--- a/docs/RedisDriver.md
+++ b/docs/RedisDriver.md
@@ -1,5 +1,8 @@
 # Redis driver
 
+**⚠️ WARNING: This module is deprecated and scheduled for removal in a future release. Please migrate to an alternative
+solution.**
+
 `commons-redis` - Scala driver for Redis
 
 ```scala

--- a/docs/RedisDriver.md
+++ b/docs/RedisDriver.md
@@ -1,7 +1,7 @@
 # Redis driver
 
-**⚠️ WARNING: This module is deprecated and scheduled for removal in a future release. Please migrate to an alternative
-solution.**
+**⚠️ WARNING: This module is deprecated and scheduled for removal in a future release.
+It has not been actively tested since v2.21.0. Please migrate to an alternative solution. **
 
 `commons-redis` - Scala driver for Redis
 

--- a/install-redis.sh
+++ b/install-redis.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-REDIS_HOME=$PWD/redis-$REDIS_VERSION/src
-echo "REDIS_HOME=$REDIS_HOME" >> $GITHUB_ENV
-if [ ! -d $REDIS_HOME ]; then
-    wget http://download.redis.io/releases/redis-$REDIS_VERSION.tar.gz
-    tar -xzf redis-$REDIS_VERSION.tar.gz
-    cd redis-$REDIS_VERSION && make BUILD_TLS=yes
-fi
-

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -73,20 +73,9 @@ object Commons extends ProjectGroup("commons") {
 
     githubWorkflowTargetTags ++= Seq("v*"),
 
-    githubWorkflowEnv ++= Map(
-      "REDIS_VERSION" -> "6.2.12",
-    ),
     githubWorkflowArtifactUpload := false,
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"), JavaSpec.temurin("21")),
     githubWorkflowBuildPreamble ++= Seq(
-      WorkflowStep.Use(
-        UseRef.Public("actions", "cache", "v2"),
-        name = Some("Cache Redis"),
-        params = Map(
-          "path" -> "./redis-${{ env.REDIS_VERSION }}",
-          "key" -> "${{ runner.os }}-redis-cache-v2-${{ env.REDIS_VERSION }}"
-        )
-      ),
       WorkflowStep.Use(
         UseRef.Public("actions", "setup-node", "v2"),
         name = Some("Setup Node.js"),
@@ -100,10 +89,6 @@ object Commons extends ProjectGroup("commons") {
           "mongodb-replica-set" -> "test-rs",
         )
       ),
-      WorkflowStep.Run(
-        List("./install-redis.sh"),
-        name = Some("Setup Redis"),
-      )
     ),
 
     githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
@@ -338,6 +323,7 @@ object Commons extends ProjectGroup("commons") {
       ),
       Test / parallelExecution := false,
       Compile / scalacOptions += "-Wconf:cat=deprecation:is", // only inform about deprecations due to scheduled removal
+      Test / skip := true,
     )
 
   lazy val hocon = mkSubProject

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -337,6 +337,7 @@ object Commons extends ProjectGroup("commons") {
         "io.monix" %% "monix" % monixVersion,
       ),
       Test / parallelExecution := false,
+      Compile / scalacOptions += "-Wconf:cat=deprecation:is", // only inform about deprecations due to scheduled removal
     )
 
   lazy val hocon = mkSubProject

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
@@ -1,9 +1,6 @@
 package com.avsystem.commons
 package redis
 
-import org.apache.pekko.actor.{ActorSystem, Props}
-import org.apache.pekko.pattern.ask
-import org.apache.pekko.util.Timeout
 import com.avsystem.commons.concurrent.RetryStrategy
 import com.avsystem.commons.redis.RawCommand.Level
 import com.avsystem.commons.redis.RedisClusterClient.{AskingPack, CollectionPacks}
@@ -12,16 +9,19 @@ import com.avsystem.commons.redis.actor.ClusterMonitoringActor.{GetClient, GetCl
 import com.avsystem.commons.redis.actor.RedisConnectionActor.PacksResult
 import com.avsystem.commons.redis.commands.{Asking, SlotRange}
 import com.avsystem.commons.redis.config.{ClusterConfig, ExecutionConfig}
-import com.avsystem.commons.redis.exception._
+import com.avsystem.commons.redis.exception.*
 import com.avsystem.commons.redis.monitoring.ClusterStateObserver
-import com.avsystem.commons.redis.protocol._
+import com.avsystem.commons.redis.protocol.*
 import com.avsystem.commons.redis.util.DelayedFuture
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
   * Redis client implementation for Redis Cluster deployments. Internally, it uses single [[RedisNodeClient]] instance
@@ -45,6 +45,7 @@ import scala.concurrent.duration._
   * @param config    client configuration - [[ClusterConfig]]
   * @param clusterStateObserver optional observer for monitoring client's state and connections - [[ClusterStateObserver]]
   */
+@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
 final class RedisClusterClient(
   val seedNodes: Seq[NodeAddress] = List(NodeAddress.Default),
   val config: ClusterConfig = ClusterConfig(),

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisClusterClient.scala
@@ -45,7 +45,7 @@ import scala.concurrent.duration.*
   * @param config    client configuration - [[ClusterConfig]]
   * @param clusterStateObserver optional observer for monitoring client's state and connections - [[ClusterStateObserver]]
   */
-@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
+@deprecated("Redis driver is scheduled for removal. It has not been actively tested since v2.21.0. Use a different library, e.g. redisson.", "2.21.0")
 final class RedisClusterClient(
   val seedNodes: Seq[NodeAddress] = List(NodeAddress.Default),
   val config: ClusterConfig = ClusterConfig(),

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
@@ -1,8 +1,6 @@
 package com.avsystem.commons
 package redis
 
-import org.apache.pekko.actor.{ActorSystem, Props}
-import org.apache.pekko.pattern.ask
 import com.avsystem.commons.concurrent.RetryStrategy
 import com.avsystem.commons.redis.RawCommand.Level
 import com.avsystem.commons.redis.actor.RedisConnectionActor.PacksResult
@@ -10,6 +8,8 @@ import com.avsystem.commons.redis.actor.RedisOperationActor.OpResult
 import com.avsystem.commons.redis.actor.{RedisConnectionActor, RedisOperationActor}
 import com.avsystem.commons.redis.config.{ConfigDefaults, ConnectionConfig, ExecutionConfig}
 import com.avsystem.commons.redis.exception.ClientStoppedException
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.pattern.ask
 
 /**
   * Redis client that uses a single, non-reconnectable connection.
@@ -24,6 +24,7 @@ import com.avsystem.commons.redis.exception.ClientStoppedException
   * If you simply need a single-connection, reconnectable client, use [[RedisNodeClient]] with connection pool size
   * configured to 1.
   */
+@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
 final class RedisConnectionClient(
   val address: NodeAddress = NodeAddress.Default,
   val config: ConnectionConfig = ConnectionConfig(),

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisConnectionClient.scala
@@ -24,7 +24,7 @@ import org.apache.pekko.pattern.ask
   * If you simply need a single-connection, reconnectable client, use [[RedisNodeClient]] with connection pool size
   * configured to 1.
   */
-@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
+@deprecated("Redis driver is scheduled for removal. It has not been actively tested since v2.21.0. Use a different library, e.g. redisson.", "2.21.0")
 final class RedisConnectionClient(
   val address: NodeAddress = NodeAddress.Default,
   val config: ConnectionConfig = ConnectionConfig(),

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisExecutor.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisExecutor.scala
@@ -54,7 +54,7 @@ trait RedisNodeExecutor extends RedisKeyedExecutor with RedisOpExecutor
   */
 trait RedisConnectionExecutor extends RedisNodeExecutor
 
-@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
+@deprecated("Redis driver is scheduled for removal. It has not been actively tested since v2.21.0. Use a different library, e.g. redisson.", "2.21.0")
 abstract class RedisClient extends RedisExecutor with Closeable {
   def initialized: Future[this.type]
 }

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisExecutor.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisExecutor.scala
@@ -1,9 +1,9 @@
 package com.avsystem.commons
 package redis
 
-import java.io.Closeable
-
 import com.avsystem.commons.redis.config.ExecutionConfig
+
+import java.io.Closeable
 
 /**
   * Base trait for Redis clients with ability to execute [[RedisBatch]]es.
@@ -54,6 +54,7 @@ trait RedisNodeExecutor extends RedisKeyedExecutor with RedisOpExecutor
   */
 trait RedisConnectionExecutor extends RedisNodeExecutor
 
+@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
 abstract class RedisClient extends RedisExecutor with Closeable {
   def initialized: Future[this.type]
 }

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
@@ -1,12 +1,6 @@
 package com.avsystem.commons
 package redis
 
-import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.atomic.AtomicLong
-
-import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
-import org.apache.pekko.pattern.ask
-import org.apache.pekko.util.Timeout
 import com.avsystem.commons.concurrent.RunInQueueEC
 import com.avsystem.commons.redis.actor.ConnectionPoolActor.QueuedConn
 import com.avsystem.commons.redis.actor.RedisConnectionActor.PacksResult
@@ -14,15 +8,21 @@ import com.avsystem.commons.redis.actor.RedisOperationActor.OpResult
 import com.avsystem.commons.redis.actor.{ConnectionPoolActor, RedisConnectionActor, RedisOperationActor}
 import com.avsystem.commons.redis.config.{ConfigDefaults, ConnectionConfig, ExecutionConfig, NodeConfig}
 import com.avsystem.commons.redis.exception.{ClientStoppedException, NodeInitializationFailure, NodeRemovedException, TooManyConnectionsException}
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
   * Redis client implementation for a single Redis node using a connection pool. Connection pool size is constant
   * and batches and operations are distributed over connections using round-robin scheme. Connections are automatically
   * reconnected upon failure (possibly with an appropriate delay, see [[config.NodeConfig NodeConfig]] for details).
   */
+@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
 final class RedisNodeClient(
   val address: NodeAddress = NodeAddress.Default,
   val config: NodeConfig = NodeConfig(),

--- a/redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/RedisNodeClient.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration.*
   * and batches and operations are distributed over connections using round-robin scheme. Connections are automatically
   * reconnected upon failure (possibly with an appropriate delay, see [[config.NodeConfig NodeConfig]] for details).
   */
-@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
+@deprecated("Redis driver is scheduled for removal. It has not been actively tested since v2.21.0. Use a different library, e.g. redisson.", "2.21.0")
 final class RedisNodeClient(
   val address: NodeAddress = NodeAddress.Default,
   val config: NodeConfig = NodeConfig(),

--- a/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -161,7 +161,7 @@ case class NodeConfig(
   * @param debugListener        listener for traffic going through this connection. Only for debugging and testing
   *                             purposes
   */
-@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
+@deprecated("Redis driver is scheduled for removal. It has not been actively tested since v2.21.0. Use a different library, e.g. redisson.", "2.21.0")
 case class ConnectionConfig(
   initCommands: RedisBatch[Any] = RedisBatch.unit,
   sslEngineCreator: OptArg[() => SSLEngine] = OptArg.Empty,

--- a/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
+++ b/redis/src/main/scala/com/avsystem/commons/redis/config/config.scala
@@ -1,16 +1,16 @@
 package com.avsystem.commons
 package redis.config
 
-import java.net.InetSocketAddress
-import org.apache.pekko.io.Inet
-import org.apache.pekko.util.Timeout
 import com.avsystem.commons.concurrent.RetryStrategy
-import com.avsystem.commons.concurrent.RetryStrategy._
+import com.avsystem.commons.concurrent.RetryStrategy.*
 import com.avsystem.commons.redis.actor.RedisConnectionActor.{DebugListener, DevNullListener}
 import com.avsystem.commons.redis.{NodeAddress, RedisBatch, RedisOp}
+import org.apache.pekko.io.Inet
+import org.apache.pekko.util.Timeout
 
+import java.net.InetSocketAddress
 import javax.net.ssl.SSLEngine
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /**
   * Configuration of a [[com.avsystem.commons.redis.RedisClusterClient RedisClusterClient]]
@@ -161,6 +161,7 @@ case class NodeConfig(
   * @param debugListener        listener for traffic going through this connection. Only for debugging and testing
   *                             purposes
   */
+@deprecated("Redis driver is scheduled for removal. Use a different library, e.g. redisson.", "2.21.0")
 case class ConnectionConfig(
   initCommands: RedisBatch[Any] = RedisBatch.unit,
   sslEngineCreator: OptArg[() => SSLEngine] = OptArg.Empty,


### PR DESCRIPTION
Most of our internal products migrated or are in the process of migrating to Redisson so I propose to release a deprecation. 

This module is particularly flaky and maintenance intensive so I've also removed it from CI.