### PR TITLE
deprecate SAM macro

### DIFF
--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/GuavaInterop.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/GuavaInterop.scala
@@ -1,13 +1,11 @@
 package com.avsystem.commons
 package jiop
 
-import java.util.concurrent.{Executor, TimeUnit}
-
-import com.avsystem.commons.jiop.GuavaInterop._
-import com.avsystem.commons.misc.Sam
+import com.avsystem.commons.jiop.GuavaInterop.*
+import com.google.common.base as gbase
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture, SettableFuture}
-import com.google.common.{base => gbase}
 
+import java.util.concurrent.{Executor, TimeUnit}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, CanAwait, ExecutionException, TimeoutException}
@@ -17,9 +15,9 @@ trait GuavaInterop {
   type GSupplier[T] = gbase.Supplier[T]
   type GPredicate[T] = gbase.Predicate[T]
 
-  def gFunction[F, T](fun: F => T) = Sam[GFunction[F, T]](fun)
-  def gSupplier[T](expr: => T) = Sam[GSupplier[T]](expr)
-  def gPredicate[T](pred: T => Boolean) = Sam[GPredicate[T]](pred)
+  def gFunction[F, T](fun: F => T): GFunction[F, T] = fun(_)
+  def gSupplier[T](expr: => T): GSupplier[T] = () => expr
+  def gPredicate[T](pred: T => Boolean): GPredicate[T] = pred(_)
 
   implicit def toDecorateAsScala[T](gfut: ListenableFuture[T]): DecorateFutureAsScala[T] =
     new DecorateFutureAsScala(gfut)

--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/JFunctionUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/JFunctionUtils.scala
@@ -1,9 +1,7 @@
 package com.avsystem.commons
 package jiop
 
-import java.util.{function => juf}
-
-import com.avsystem.commons.misc.Sam
+import java.util.function as juf
 
 /** Utils to convert Scala functions and expressions to most common Java functional interfaces.
   */
@@ -52,47 +50,47 @@ trait JFunctionUtils {
   type JToLongFunction[T] = juf.ToLongFunction[T]
   type JUnaryOperator[T] = juf.UnaryOperator[T]
 
-  def jBiConsumer[T, U](code: (T, U) => Any) = Sam[JBiConsumer[T, U]](code)
-  def jBiFunction[T, U, R](fun: (T, U) => R) = Sam[JBiFunction[T, U, R]](fun)
-  def jBiPredicate[T, U](pred: (T, U) => Boolean) = Sam[JBiPredicate[T, U]](pred)
-  def jBinaryOperator[T](op: (T, T) => T) = Sam[JBinaryOperator[T]](op)
-  def jBooleanSupplier(expr: => Boolean) = Sam[JBooleanSupplier](expr)
-  def jConsumer[T](code: T => Any) = Sam[JConsumer[T]](code)
-  def jDoubleBinaryOperator(op: (Double, Double) => Double) = Sam[JDoubleBinaryOperator](op)
-  def jDoubleConsumer(code: Double => Any) = Sam[JDoubleConsumer](code)
-  def jDoubleFunction[R](fun: Double => R) = Sam[JDoubleFunction[R]](fun)
-  def jDoublePredicate(pred: Double => Boolean) = Sam[JDoublePredicate](pred)
-  def jDoubleSupplier(expr: => Double) = Sam[JDoubleSupplier](expr)
-  def jDoubleToIntFunction(fun: Double => Int) = Sam[JDoubleToIntFunction](fun)
-  def jDoubleToLongFunction(fun: Double => Long) = Sam[JDoubleToLongFunction](fun)
-  def jDoubleUnaryOperator(op: Double => Double) = Sam[JDoubleUnaryOperator](op)
-  def jFunction[T, R](fun: T => R) = Sam[JFunction[T, R]](fun)
-  def jIntBinaryOperator(op: (Int, Int) => Int) = Sam[JIntBinaryOperator](op)
-  def jIntConsumer(code: Int => Any) = Sam[JIntConsumer](code)
-  def jIntFunction[R](fun: Int => R) = Sam[JIntFunction[R]](fun)
-  def jIntPredicate(pred: Int => Boolean) = Sam[JIntPredicate](pred)
-  def jIntSupplier(expr: => Int) = Sam[JIntSupplier](expr)
-  def jIntToDoubleFunction(fun: Int => Double) = Sam[JIntToDoubleFunction](fun)
-  def jIntToLongFunction(fun: Int => Long) = Sam[JIntToLongFunction](fun)
-  def jIntUnaryOperator(op: Int => Int) = Sam[JIntUnaryOperator](op)
-  def jLongBinaryOperator(op: (Long, Long) => Long) = Sam[JLongBinaryOperator](op)
-  def jLongConsumer(code: Long => Any) = Sam[JLongConsumer](code)
-  def jLongFunction[R](fun: Long => R) = Sam[JLongFunction[R]](fun)
-  def jLongPredicate(pred: Long => Boolean) = Sam[JLongPredicate](pred)
-  def jLongSupplier(expr: => Long) = Sam[JLongSupplier](expr)
-  def jLongToDoubleFunction(fun: Long => Double) = Sam[JLongToDoubleFunction](fun)
-  def jLongToIntFunction(fun: Long => Int) = Sam[JLongToIntFunction](fun)
-  def jLongUnaryOperator(op: Long => Long) = Sam[JLongUnaryOperator](op)
-  def jObjDoubleConsumer[T](code: (T, Double) => Any) = Sam[JObjDoubleConsumer[T]](code)
-  def jObjIntConsumer[T](code: (T, Int) => Any) = Sam[JObjIntConsumer[T]](code)
-  def jObjLongConsumer[T](code: (T, Long) => Any) = Sam[JObjLongConsumer[T]](code)
-  def jPredicate[T](pred: T => Boolean) = Sam[JPredicate[T]](pred)
-  def jSupplier[T](expr: => T) = Sam[JSupplier[T]](expr)
-  def jToDoubleBiFunction[T, U](fun: (T, U) => Double) = Sam[JToDoubleBiFunction[T, U]](fun)
-  def jToDoubleFunction[T](fun: T => Double) = Sam[JToDoubleFunction[T]](fun)
-  def jToIntBiFunction[T, U](fun: (T, U) => Int) = Sam[JToIntBiFunction[T, U]](fun)
-  def jToIntFunction[T](fun: T => Int) = Sam[JToIntFunction[T]](fun)
-  def jToLongBiFunction[T, U](fun: (T, U) => Long) = Sam[JToLongBiFunction[T, U]](fun)
-  def jToLongFunction[T](fun: T => Long) = Sam[JToLongFunction[T]](fun)
-  def jUnaryOperator[T](op: T => T) = Sam[JUnaryOperator[T]](op)
+  def jBiConsumer[T, U](code: (T, U) => Any): JBiConsumer[T, U] = (t, u) => { code(t, u); () }
+  def jBiFunction[T, U, R](fun: (T, U) => R): JBiFunction[T, U, R] = fun(_, _)
+  def jBiPredicate[T, U](pred: (T, U) => Boolean): JBiPredicate[T, U] = pred(_, _)
+  def jBinaryOperator[T](op: (T, T) => T): JBinaryOperator[T] = op(_, _)
+  def jBooleanSupplier(expr: => Boolean): JBooleanSupplier = () => expr
+  def jConsumer[T](code: T => Any): JConsumer[T] = t => { code(t); () }
+  def jDoubleBinaryOperator(op: (Double, Double) => Double): JDoubleBinaryOperator = op(_, _)
+  def jDoubleConsumer(code: Double => Any): JDoubleConsumer = d => { code(d); () }
+  def jDoubleFunction[R](fun: Double => R): JDoubleFunction[R] = fun(_)
+  def jDoublePredicate(pred: Double => Boolean): JDoublePredicate = pred(_)
+  def jDoubleSupplier(expr: => Double): JDoubleSupplier = () => expr
+  def jDoubleToIntFunction(fun: Double => Int): JDoubleToIntFunction = fun(_)
+  def jDoubleToLongFunction(fun: Double => Long): JDoubleToLongFunction = fun(_)
+  def jDoubleUnaryOperator(op: Double => Double): JDoubleUnaryOperator = op(_)
+  def jFunction[T, R](fun: T => R): JFunction[T, R] = fun(_)
+  def jIntBinaryOperator(op: (Int, Int) => Int): JIntBinaryOperator = op(_, _)
+  def jIntConsumer(code: Int => Any): JIntConsumer = i => { code(i); () }
+  def jIntFunction[R](fun: Int => R): JIntFunction[R] = fun(_)
+  def jIntPredicate(pred: Int => Boolean): JIntPredicate = pred(_)
+  def jIntSupplier(expr: => Int): JIntSupplier = () => expr
+  def jIntToDoubleFunction(fun: Int => Double): JIntToDoubleFunction = fun(_)
+  def jIntToLongFunction(fun: Int => Long): JIntToLongFunction = fun(_)
+  def jIntUnaryOperator(op: Int => Int): JIntUnaryOperator = op(_)
+  def jLongBinaryOperator(op: (Long, Long) => Long): JLongBinaryOperator = op(_, _)
+  def jLongConsumer(code: Long => Any): JLongConsumer = l => { code(l); () }
+  def jLongFunction[R](fun: Long => R): JLongFunction[R] = fun(_)
+  def jLongPredicate(pred: Long => Boolean): JLongPredicate = pred(_)
+  def jLongSupplier(expr: => Long): JLongSupplier = () => expr
+  def jLongToDoubleFunction(fun: Long => Double): JLongToDoubleFunction = fun(_)
+  def jLongToIntFunction(fun: Long => Int): JLongToIntFunction = fun(_)
+  def jLongUnaryOperator(op: Long => Long): JLongUnaryOperator = op(_)
+  def jObjDoubleConsumer[T](code: (T, Double) => Any): JObjDoubleConsumer[T] = (t, d) => { code(t, d); () }
+  def jObjIntConsumer[T](code: (T, Int) => Any): JObjIntConsumer[T] = (t, i) => { code(t, i); () }
+  def jObjLongConsumer[T](code: (T, Long) => Any): JObjLongConsumer[T] = (t, l) => { code(t, l); () }
+  def jPredicate[T](pred: T => Boolean): JPredicate[T] = pred(_)
+  def jSupplier[T](expr: => T): JSupplier[T] = () => expr
+  def jToDoubleBiFunction[T, U](fun: (T, U) => Double): JToDoubleBiFunction[T, U] = fun(_, _)
+  def jToDoubleFunction[T](fun: T => Double): JToDoubleFunction[T] = fun(_)
+  def jToIntBiFunction[T, U](fun: (T, U) => Int): JToIntBiFunction[T, U] = fun(_, _)
+  def jToIntFunction[T](fun: T => Int): JToIntFunction[T] = fun(_)
+  def jToLongBiFunction[T, U](fun: (T, U) => Long): JToLongBiFunction[T, U] = fun(_, _)
+  def jToLongFunction[T](fun: T => Long): JToLongFunction[T] = fun(_)
+  def jUnaryOperator[T](op: T => T): JUnaryOperator[T] = op(_)
 }

--- a/core/src/main/scala/com/avsystem/commons/jiop/JBasicUtils.scala
+++ b/core/src/main/scala/com/avsystem/commons/jiop/JBasicUtils.scala
@@ -1,16 +1,16 @@
 package com.avsystem.commons
 package jiop
 
+import com.avsystem.commons.misc.TimestampConversions
+
 import java.util.Comparator
 import java.util.concurrent.Callable
-import java.{lang => jl, math => jm, util => ju}
-
-import com.avsystem.commons.misc.{Sam, TimestampConversions}
+import java.{lang as jl, math as jm, util as ju}
 
 trait JBasicUtils {
-  def jRunnable(code: => Any) = Sam[Runnable](code)
-  def jCallable[T](expr: => T) = Sam[Callable[T]](expr)
-  def jComparator[T](cmp: (T, T) => Int) = Sam[Comparator[T]](cmp)
+  def jRunnable(code: => Any): Runnable = () => code
+  def jCallable[T](expr: => T): Callable[T] = () => expr
+  def jComparator[T](cmp: (T, T) => Int): Comparator[T] = cmp(_, _)
 
   implicit def jDateTimestampConversions(date: JDate): TimestampConversions =
     new TimestampConversions(date.getTime)

--- a/core/src/main/scala/com/avsystem/commons/misc/Sam.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/Sam.scala
@@ -1,6 +1,10 @@
 package com.avsystem.commons
 package misc
 
+@deprecated(
+  "Use native SAM conversion instead, e.g. `val r: Runnable = () => doStuff()` or `val c: JConsumer[T] = t => ...`",
+  "2.28.0",
+)
 object Sam {
 
   /** Implements a single abstract method trait/class `T` using passed function or expression as implementation of the

--- a/core/src/main/scala/com/avsystem/commons/misc/SamCompanion.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/SamCompanion.scala
@@ -3,12 +3,17 @@ package misc
 
 import com.avsystem.commons.misc.SamCompanion.ValidSam
 
+@deprecated(
+  "Use native SAM conversion instead, e.g. `val r: Runnable = () => doStuff()` or `val c: JConsumer[T] = t => ...`",
+  "2.28.0",
+)
 abstract class SamCompanion[T, F](implicit vs: ValidSam[T, F]) {
   def apply(fun: F): T = macro com.avsystem.commons.macros.misc.SamMacros.toSam[T, F]
 }
 
 object SamCompanion {
   sealed trait ValidSam[T, F]
+
   object ValidSam {
     implicit def isValidSam[T, F]: ValidSam[T, F] = macro com.avsystem.commons.macros.misc.SamMacros.validateSam[T, F]
   }

--- a/core/src/test/scala/com/avsystem/commons/misc/SamTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/SamTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import scala.annotation.nowarn
 
+@nowarn("msg=deprecated")
 class SamTest extends AnyFunSuite {
 
   test("no arg lists by name") {


### PR DESCRIPTION
Scala has native SAM conversion support since 2.11.x. One less macro to migrate