### PR TITLE
deprecate `ValueOf` in favor of standard library `scala.ValueOf`

### DIFF
--- a/core/src/main/scala/com/avsystem/commons/misc/ValueOf.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/ValueOf.scala
@@ -1,8 +1,6 @@
 package com.avsystem.commons
 package misc
 
-import com.avsystem.commons.macros.misc.MiscMacros
-
 import scala.annotation.{implicitNotFound, nowarn}
 
 /** Macro materialized typeclass which captures the single value of a singleton type.
@@ -12,11 +10,12 @@ import scala.annotation.{implicitNotFound, nowarn}
   "Use scala.ValueOf[T] from the standard library - it is auto-materialized by the compiler for singleton types since Scala 2.13",
   "2.28.0",
 )
-class ValueOf[T](val value: T) extends AnyVal
+class ValueOf[T](val value: T) extends AnyVal {
+  def toScala: scala.ValueOf[T] = new scala.ValueOf[T](value)
+}
 
 @nowarn("msg=deprecated")
 object ValueOf {
   @deprecated("Use scala.valueOf[T] from the standard library (available since Scala 2.13)", "2.28.0")
   def apply[T](implicit vof: ValueOf[T]): T = vof.value
-  implicit def mkValueOf[T]: ValueOf[T] = macro MiscMacros.mkValueOf[T]
 }

--- a/core/src/main/scala/com/avsystem/commons/misc/ValueOf.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/ValueOf.scala
@@ -3,14 +3,20 @@ package misc
 
 import com.avsystem.commons.macros.misc.MiscMacros
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, nowarn}
 
 /** Macro materialized typeclass which captures the single value of a singleton type.
   */
 @implicitNotFound("Cannot derive value of ${T} - is not a singleton type")
+@deprecated(
+  "Use scala.ValueOf[T] from the standard library - it is auto-materialized by the compiler for singleton types since Scala 2.13",
+  "2.28.0",
+)
 class ValueOf[T](val value: T) extends AnyVal
-object ValueOf {
-  def apply[T](implicit vof: ValueOf[T]): T = vof.value
 
+@nowarn("msg=deprecated")
+object ValueOf {
+  @deprecated("Use scala.valueOf[T] from the standard library (available since Scala 2.13)", "2.28.0")
+  def apply[T](implicit vof: ValueOf[T]): T = vof.value
   implicit def mkValueOf[T]: ValueOf[T] = macro MiscMacros.mkValueOf[T]
 }

--- a/core/src/main/scala/com/avsystem/commons/misc/ValueOf.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/ValueOf.scala
@@ -18,4 +18,7 @@ class ValueOf[T](val value: T) extends AnyVal {
 object ValueOf {
   @deprecated("Use scala.valueOf[T] from the standard library (available since Scala 2.13)", "2.28.0")
   def apply[T](implicit vof: ValueOf[T]): T = vof.value
+
+  @deprecated("Use scala.ValueOf[T] from the standard library (available since Scala 2.13)", "2.28.0")
+  implicit def fromScala[T](implicit vof: scala.ValueOf[T]): ValueOf[T] = new ValueOf[T](vof.value)
 }

--- a/core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
@@ -3,7 +3,6 @@ package serialization
 
 import com.avsystem.commons.meta.MacroInstances
 import com.avsystem.commons.meta.MacroInstances.materializeWith
-import com.avsystem.commons.misc.ValueOf
 
 /** Convenience abstract class for companion objects of types that have a [[GenCodec]]. There are many other flavors of
   * this base companion class. For example, if you want to inject additional implicits into [[GenCodec]]

--- a/core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
@@ -1,6 +1,7 @@
 package com.avsystem.commons
 package serialization
 
+import com.avsystem.commons.annotation.bincompat
 import com.avsystem.commons.meta.MacroInstances
 import com.avsystem.commons.meta.MacroInstances.materializeWith
 import com.avsystem.commons.misc.ValueOf
@@ -31,8 +32,15 @@ abstract class HasGenObjectCodec[T](implicit macroCodec: MacroInstances[Unit, ()
 /** A version of [[HasGenCodec]] which injects additional implicits into macro materialization. Implicits are imported
   * from an object specified with type parameter `D`. It must be a singleton object type, i.e. `SomeObject.type`.
   */
-@nowarn("msg=deprecated")
-abstract class HasGenCodecWithDeps[D, T](implicit deps: ValueOf[D], macroCodec: MacroInstances[D, () => GenCodec[T]]) {
+abstract class HasGenCodecWithDeps[D, T](
+  implicit macroCodec: MacroInstances[D, () => GenCodec[T]],
+  deps: scala.ValueOf[D],
+) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(applyUnapplyProvider: ValueOf[D], instances: MacroInstances[D, () => GenCodec[T]]) =
+    this()(instances, applyUnapplyProvider.toScala)
+
   implicit val codec: GenCodec[T] = macroCodec(deps.value, this).apply()
 }
 
@@ -40,11 +48,17 @@ abstract class HasGenCodecWithDeps[D, T](implicit deps: ValueOf[D], macroCodec: 
   * Implicits are imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
-@nowarn("msg=deprecated")
 abstract class HasApplyUnapplyCodecWithDeps[D, T](
-  implicit deps: ValueOf[D],
-  macroCodec: MacroInstances[D, () => ApplyUnapplyCodec[T]],
+  implicit macroCodec: MacroInstances[D, () => ApplyUnapplyCodec[T]],
+  deps: scala.ValueOf[D],
 ) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(
+    applyUnapplyProvider: ValueOf[D],
+    instances: MacroInstances[D, () => ApplyUnapplyCodec[T]],
+  ) = this()(instances, applyUnapplyProvider.toScala)
+
   implicit val codec: ApplyUnapplyCodec[T] = macroCodec(deps.value, this).apply()
 }
 
@@ -52,11 +66,17 @@ abstract class HasApplyUnapplyCodecWithDeps[D, T](
   * imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
-@nowarn("msg=deprecated")
 abstract class HasGenObjectCodecWithDeps[D, T](
-  implicit deps: ValueOf[D],
-  macroCodec: MacroInstances[D, () => GenObjectCodec[T]],
+  implicit macroCodec: MacroInstances[D, () => GenObjectCodec[T]],
+  deps: scala.ValueOf[D],
 ) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(
+    applyUnapplyProvider: ValueOf[D],
+    instances: MacroInstances[D, () => GenObjectCodec[T]],
+  ) = this()(instances, applyUnapplyProvider.toScala)
+
   implicit val codec: GenObjectCodec[T] = macroCodec(deps.value, this).apply()
 }
 
@@ -74,11 +94,15 @@ abstract class HasPolyGenCodec[C[_]](implicit macroCodec: MacroInstances[Unit, P
   * imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
-@nowarn("msg=deprecated")
 abstract class HasPolyGenCodecWithDeps[D, C[_]](
-  implicit deps: ValueOf[D],
-  macroCodec: MacroInstances[D, PolyCodec[C]],
+  implicit macroCodec: MacroInstances[D, PolyCodec[C]],
+  deps: scala.ValueOf[D],
 ) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(applyUnapplyProvider: ValueOf[D], instances: MacroInstances[D, PolyCodec[C]]) =
+    this()(instances, applyUnapplyProvider.toScala)
+
   implicit def codec[T: GenCodec]: GenCodec[C[T]] = macroCodec(deps.value, this).codec
 }
 
@@ -96,11 +120,15 @@ abstract class HasPolyGenObjectCodec[C[_]](implicit macroCodec: MacroInstances[U
   * imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
-@nowarn("msg=deprecated")
 abstract class HasPolyGenObjectCodecWithDeps[D, C[_]](
-  implicit deps: ValueOf[D],
-  macroCodec: MacroInstances[D, PolyObjectCodec[C]],
+  implicit macroCodec: MacroInstances[D, PolyObjectCodec[C]],
+  deps: scala.ValueOf[D],
 ) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(applyUnapplyProvider: ValueOf[D], instances: MacroInstances[D, PolyObjectCodec[C]]) =
+    this()(instances, applyUnapplyProvider.toScala)
+
   implicit def codec[T: GenCodec]: GenObjectCodec[C[T]] = macroCodec(deps.value, this).codec
 }
 
@@ -151,11 +179,15 @@ trait AUCodec[AU, T] {
   * [[GenCodec.fromApplyUnapplyProvider]] macro. The object containing `apply` and `unapply` must be specified with
   * object singleton type passed as type parameter `AU`.
   */
-@nowarn("msg=deprecated")
 abstract class HasGenCodecFromAU[AU, T](
-  implicit applyUnapplyProvider: ValueOf[AU],
-  instances: MacroInstances[Unit, AUCodec[AU, T]],
+  implicit instances: MacroInstances[Unit, AUCodec[AU, T]],
+  applyUnapplyProvider: scala.ValueOf[AU],
 ) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(applyUnapplyProvider: ValueOf[AU], instances: MacroInstances[Unit, AUCodec[AU, T]]) =
+    this()(instances, applyUnapplyProvider.toScala)
+
   implicit final lazy val codec: GenCodec[T] =
     instances((), this).codec(applyUnapplyProvider.value)
 }

--- a/core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/HasGenCodec.scala
@@ -3,6 +3,9 @@ package serialization
 
 import com.avsystem.commons.meta.MacroInstances
 import com.avsystem.commons.meta.MacroInstances.materializeWith
+import com.avsystem.commons.misc.ValueOf
+
+import scala.annotation.nowarn
 
 /** Convenience abstract class for companion objects of types that have a [[GenCodec]]. There are many other flavors of
   * this base companion class. For example, if you want to inject additional implicits into [[GenCodec]]
@@ -28,6 +31,7 @@ abstract class HasGenObjectCodec[T](implicit macroCodec: MacroInstances[Unit, ()
 /** A version of [[HasGenCodec]] which injects additional implicits into macro materialization. Implicits are imported
   * from an object specified with type parameter `D`. It must be a singleton object type, i.e. `SomeObject.type`.
   */
+@nowarn("msg=deprecated")
 abstract class HasGenCodecWithDeps[D, T](implicit deps: ValueOf[D], macroCodec: MacroInstances[D, () => GenCodec[T]]) {
   implicit val codec: GenCodec[T] = macroCodec(deps.value, this).apply()
 }
@@ -36,6 +40,7 @@ abstract class HasGenCodecWithDeps[D, T](implicit deps: ValueOf[D], macroCodec: 
   * Implicits are imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
+@nowarn("msg=deprecated")
 abstract class HasApplyUnapplyCodecWithDeps[D, T](
   implicit deps: ValueOf[D],
   macroCodec: MacroInstances[D, () => ApplyUnapplyCodec[T]],
@@ -47,6 +52,7 @@ abstract class HasApplyUnapplyCodecWithDeps[D, T](
   * imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
+@nowarn("msg=deprecated")
 abstract class HasGenObjectCodecWithDeps[D, T](
   implicit deps: ValueOf[D],
   macroCodec: MacroInstances[D, () => GenObjectCodec[T]],
@@ -68,6 +74,7 @@ abstract class HasPolyGenCodec[C[_]](implicit macroCodec: MacroInstances[Unit, P
   * imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
+@nowarn("msg=deprecated")
 abstract class HasPolyGenCodecWithDeps[D, C[_]](
   implicit deps: ValueOf[D],
   macroCodec: MacroInstances[D, PolyCodec[C]],
@@ -89,6 +96,7 @@ abstract class HasPolyGenObjectCodec[C[_]](implicit macroCodec: MacroInstances[U
   * imported from an object specified with type parameter `D`. It must be a singleton object type, i.e.
   * `SomeObject.type`.
   */
+@nowarn("msg=deprecated")
 abstract class HasPolyGenObjectCodecWithDeps[D, C[_]](
   implicit deps: ValueOf[D],
   macroCodec: MacroInstances[D, PolyObjectCodec[C]],
@@ -143,6 +151,7 @@ trait AUCodec[AU, T] {
   * [[GenCodec.fromApplyUnapplyProvider]] macro. The object containing `apply` and `unapply` must be specified with
   * object singleton type passed as type parameter `AU`.
   */
+@nowarn("msg=deprecated")
 abstract class HasGenCodecFromAU[AU, T](
   implicit applyUnapplyProvider: ValueOf[AU],
   instances: MacroInstances[Unit, AUCodec[AU, T]],

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborAdtMetadata.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborAdtMetadata.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package serialization.cbor
 
-import com.avsystem.commons.annotation.{positioned, AnnotationAggregate}
+import com.avsystem.commons.annotation.{bincompat, positioned, AnnotationAggregate}
 import com.avsystem.commons.meta.*
 import com.avsystem.commons.misc.ValueOf
 import com.avsystem.commons.serialization.GenCodec.OOOFieldsObjectCodec
@@ -22,11 +22,17 @@ abstract class HasCborCodec[T](implicit instances: MacroInstances[CborOptimizedC
 
 /** Like [[HasCborCodec]] but allows injecting additional implicits - like [[HasGenCodecWithDeps]].
   */
-@nowarn("msg=deprecated")
 abstract class HasCborCodecWithDeps[D, T](
-  implicit deps: ValueOf[D],
-  instances: MacroInstances[(CborOptimizedCodecs, D), CborAdtInstances[T]],
+  implicit instances: MacroInstances[(CborOptimizedCodecs, D), CborAdtInstances[T]],
+  deps: scala.ValueOf[D],
 ) {
+  @bincompat
+  @nowarn("msg=deprecated")
+  private[serialization] def this(
+    applyUnapplyProvider: ValueOf[D],
+    instances: MacroInstances[(CborOptimizedCodecs, D), CborAdtInstances[T]],
+  ) = this()(using instances, applyUnapplyProvider.toScala)
+
   implicit lazy val codec: GenObjectCodec[T] = instances((CborOptimizedCodecs, deps.value), this).cborCodec
 }
 
@@ -206,12 +212,12 @@ object CborAdtMetadata extends AdtMetadataCompanion[CborAdtMetadata] {
     @composite val keyInfo: CborKeyInfo[T]
   ) extends TypedMetadata[T]
 
-  @nowarn("msg=deprecated")
   @positioned(positioned.here)
   final class Singleton[T](
-    @infer @checked val value: ValueOf[T],
+    @infer @checked val value: scala.ValueOf[T],
     @composite val keyInfo: CborKeyInfo[T],
   ) extends Case[T] {
+
     def adjustCodec(codec: GenObjectCodec[T]): GenObjectCodec[T] = codec
     def ensureUniqueKeys(discriminatorKey: Opt[RawCbor]): Unit = ()
     def validate(): Unit = ()

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborAdtMetadata.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborAdtMetadata.scala
@@ -3,8 +3,11 @@ package serialization.cbor
 
 import com.avsystem.commons.annotation.{positioned, AnnotationAggregate}
 import com.avsystem.commons.meta.*
-import com.avsystem.commons.serialization.*
+import com.avsystem.commons.misc.ValueOf
 import com.avsystem.commons.serialization.GenCodec.OOOFieldsObjectCodec
+import com.avsystem.commons.serialization.*
+
+import scala.annotation.nowarn
 
 /** Like [[HasGenCodec]] but generates a codec optimized for writing and reading CBOR via [[CborOutput]] and
   * [[CborInput]]. The differences between this codec and regular codec are: <ul> <li>case class fields that are `Map`s
@@ -19,6 +22,7 @@ abstract class HasCborCodec[T](implicit instances: MacroInstances[CborOptimizedC
 
 /** Like [[HasCborCodec]] but allows injecting additional implicits - like [[HasGenCodecWithDeps]].
   */
+@nowarn("msg=deprecated")
 abstract class HasCborCodecWithDeps[D, T](
   implicit deps: ValueOf[D],
   instances: MacroInstances[(CborOptimizedCodecs, D), CborAdtInstances[T]],
@@ -202,6 +206,7 @@ object CborAdtMetadata extends AdtMetadataCompanion[CborAdtMetadata] {
     @composite val keyInfo: CborKeyInfo[T]
   ) extends TypedMetadata[T]
 
+  @nowarn("msg=deprecated")
   @positioned(positioned.here)
   final class Singleton[T](
     @infer @checked val value: ValueOf[T],

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborAdtMetadata.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborAdtMetadata.scala
@@ -2,10 +2,9 @@ package com.avsystem.commons
 package serialization.cbor
 
 import com.avsystem.commons.annotation.{positioned, AnnotationAggregate}
-import com.avsystem.commons.meta._
-import com.avsystem.commons.misc.ValueOf
+import com.avsystem.commons.meta.*
+import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.GenCodec.OOOFieldsObjectCodec
-import com.avsystem.commons.serialization._
 
 /** Like [[HasGenCodec]] but generates a codec optimized for writing and reading CBOR via [[CborOutput]] and
   * [[CborInput]]. The differences between this codec and regular codec are: <ul> <li>case class fields that are `Map`s

--- a/core/src/test/scala/com/avsystem/commons/misc/AdtMetadataTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/AdtMetadataTest.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package misc
 
 import com.avsystem.commons.annotation.positioned
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.{adtCaseMetadata, adtCaseSealedParentMetadata, adtParamMetadata, allowUnorderedSubtypes, checked, composite, infer, multi, AdtMetadataCompanion, MacroInstances, TypedMetadata}
 import com.avsystem.commons.serialization.{name, GenCaseInfo, GenCodec, GenParamInfo, GenUnionInfo}
 
 trait GenCodecStructure[T] {
@@ -78,7 +78,7 @@ case class GenSealedParent[T](
 
 @positioned(positioned.here) case class GenSingleton[T](
   @composite info: GenCaseInfo[T],
-  @checked @infer valueOf: ValueOf[T],
+  @checked @infer valueOf: scala.ValueOf[T],
   @multi @adtCaseSealedParentMetadata sealedParents: List[GenSealedParent[_]],
 ) extends GenCase[T]
     with GenStructure[T] {

--- a/core/src/test/scala/com/avsystem/commons/misc/ValueOfTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/ValueOfTest.scala
@@ -3,6 +3,9 @@ package misc
 
 import org.scalatest.funsuite.AnyFunSuite
 
+import scala.annotation.nowarn
+
+@nowarn("cat=deprecation")
 object Obj {
   val x: String = "fuu"
 
@@ -14,6 +17,7 @@ object Obj {
   }
 }
 
+@nowarn("cat=deprecation")
 class ValueOfTest extends AnyFunSuite {
   test("object") {
     assert(ValueOf[Obj.type] == Obj)

--- a/macros/src/main/scala/com/avsystem/commons/macros/misc/MiscMacros.scala
+++ b/macros/src/main/scala/com/avsystem/commons/macros/misc/MiscMacros.scala
@@ -352,14 +352,6 @@ final class MiscMacros(ctx: blackbox.Context) extends AbstractMacroCommons(ctx) 
   def lazyMetadata(metadata: Tree): Tree =
     q"${c.prefix}($metadata)"
 
-  def mkValueOf[T: WeakTypeTag]: Tree = instrument {
-    val tpe = weakTypeOf[T].dealias
-    singleValueFor(tpe) match {
-      case Some(sv) => q"new $MiscPkg.ValueOf[$tpe]($sv)"
-      case None => abort(s"$tpe is not a singleton type")
-    }
-  }
-
   def macroInstances: Tree = {
     val resultTpe = c.macroApplication.tpe
     val applySig = resultTpe.member(TermName("apply")).typeSignatureIn(resultTpe)

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFormat.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFormat.scala
@@ -2,13 +2,13 @@ package com.avsystem.commons
 package mongo.typed
 
 import com.avsystem.commons.annotation.positioned
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 import com.avsystem.commons.misc.{TypedMap, ValueOf}
 import com.avsystem.commons.mongo.{BsonValueInput, BsonValueOutput}
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import org.bson.{BsonNull, BsonValue}
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 
 /** Typeclass that captures internal structure of a type that can be saved to MongoDB (directly as a toplevel entity or
   * indirectly as an embedded value).
@@ -319,6 +319,7 @@ object MongoAdtFormat extends AdtMetadataCompanion[MongoAdtFormat] {
     }
   }
 
+  @nowarn("msg=deprecated")
   @positioned(positioned.here)
   final class SingletonCase[T](
     @composite val info: GenCaseInfo[T],

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFormat.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFormat.scala
@@ -3,12 +3,12 @@ package mongo.typed
 
 import com.avsystem.commons.annotation.positioned
 import com.avsystem.commons.meta.*
-import com.avsystem.commons.misc.{TypedMap, ValueOf}
+import com.avsystem.commons.misc.TypedMap
 import com.avsystem.commons.mongo.{BsonValueInput, BsonValueOutput}
 import com.avsystem.commons.serialization.*
 import org.bson.{BsonNull, BsonValue}
 
-import scala.annotation.{nowarn, tailrec}
+import scala.annotation.tailrec
 
 /** Typeclass that captures internal structure of a type that can be saved to MongoDB (directly as a toplevel entity or
   * indirectly as an embedded value).
@@ -319,13 +319,12 @@ object MongoAdtFormat extends AdtMetadataCompanion[MongoAdtFormat] {
     }
   }
 
-  @nowarn("msg=deprecated")
   @positioned(positioned.here)
   final class SingletonCase[T](
     @composite val info: GenCaseInfo[T],
     @infer val classTag: ClassTag[T],
     @multi @adtCaseSealedParentMetadata val sealedParents: List[SealedParent[_]],
-    @infer @checked val value: ValueOf[T],
+    @infer @checked val value: scala.ValueOf[T],
   ) extends Case[T] {
     def asAdtFormat(codec: GenObjectCodec[T]): MongoAdtFormat[T] =
       new SingletonFormat(this, codec)


### PR DESCRIPTION
Scala has already native support for ValueOf