### PR TITLE
Enforce scalafmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,47 @@ jobs:
 
       - name: Check binary compatibility
         run: sbt mimaReportBinaryIssues
+
+  scalafmt:
+    name: Scalafmt Check
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.18]
+        java: [temurin@21]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+
+      - name: Setup Java (temurin@21)
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Check Scala formatting
+        run: sbt scalafmtCheckAll scalafmtSbtCheck

--- a/project/Commons.scala
+++ b/project/Commons.scala
@@ -85,6 +85,16 @@ object Commons extends ProjectGroup("commons") {
         name = Some("Check binary compatibility"),
       ),
     ),
+    githubWorkflowAddedJobs += WorkflowJob(
+      id = "scalafmt",
+      name = "Scalafmt Check",
+      scalas = List(scalaVersion.value),
+      javas = List(JavaSpec.temurin("21")),
+      steps = githubWorkflowJobSetup.value.toList :+ WorkflowStep.Sbt(
+        List("scalafmtCheckAll", "scalafmtSbtCheck"),
+        name = Some("Check Scala formatting"),
+      ),
+    ),
     githubWorkflowBuildPreamble ++= Seq(
       WorkflowStep.Use(
         UseRef.Public("actions", "setup-node", "v4"),


### PR DESCRIPTION
## Summary

- Adds a dedicated `scalafmt` GitHub Actions job (parallel to `build` and `mima`) that runs `scalafmtCheckAll` + `scalafmtSbtCheck` on every PR. Modeled on the existing `mima` job — single JDK (temurin@21), single Scala version.
- Two files change: a new `WorkflowJob` in `project/Commons.scala` and the regenerated `.github/workflows/ci.yml`.

## Why now

Pattern check across our other repos: the DSLAM family (dhcp, dslam-ui, dslam-mc, yanush) all enforce scalafmt in CI; standalone Scala apps (ump, coiote-ae) carry `.scalafmt.conf` but no enforcement. scala-commons was the odd one out — it tracked the sbt plugin via steward without actually invoking it. With AI-assisted edits becoming more common, automated format enforcement earns its keep.

## Test plan

- [x] `sbt scalafmtCheckAll scalafmtSbtCheck` passes locally (post #845 / #846 merges, the codebase is already conformant)
- [x] `sbt githubWorkflowCheck` passes (generated workflow matches build config)
- [ ] CI green on this PR