### PR TITLE
fix: badSingletonComponent false-positive on extension methods

### DIFF
--- a/analyzer/src/main/scala/com/avsystem/commons/analyzer/BadSingletonComponent.scala
+++ b/analyzer/src/main/scala/com/avsystem/commons/analyzer/BadSingletonComponent.scala
@@ -25,6 +25,13 @@ class BadSingletonComponent(g: Global) extends AnalyzerRule(g, "badSingletonComp
       case Typed(expr, _) => unapply(expr)
       case Annotated(_, expr) => unapply(expr)
       case UnwrapApply(Select(prefix, _)) if prefix.tpe =:= t.tpe => unapply(prefix)
+      // Peel a method call that arrives via a single-argument adapter (typically an implicit conversion
+      // used to add extension methods, e.g. `componentExt(c).chain(...)` desugared from `c.chain(...)`).
+      // We require the adapter's converted argument to share its type with the whole expression -
+      // this preserves the rule's "shape-preserving chain" invariant: whatever the adapter does, the
+      // chain is still rooted in the same `Component[T]`, so the underlying `cached(...)` call is
+      // structurally reachable.
+      case UnwrapApply(Select(Apply(_, List(orig)), _)) if orig.tpe =:= t.tpe => unapply(orig)
       case _ => Some(t)
     }
   }

--- a/analyzer/src/main/scala/com/avsystem/commons/analyzer/BadSingletonComponent.scala
+++ b/analyzer/src/main/scala/com/avsystem/commons/analyzer/BadSingletonComponent.scala
@@ -25,12 +25,6 @@ class BadSingletonComponent(g: Global) extends AnalyzerRule(g, "badSingletonComp
       case Typed(expr, _) => unapply(expr)
       case Annotated(_, expr) => unapply(expr)
       case UnwrapApply(Select(prefix, _)) if prefix.tpe =:= t.tpe => unapply(prefix)
-      // Peel a method call that arrives via a single-argument adapter (typically an implicit conversion
-      // used to add extension methods, e.g. `componentExt(c).chain(...)` desugared from `c.chain(...)`).
-      // We require the adapter's converted argument to share its type with the whole expression -
-      // this preserves the rule's "shape-preserving chain" invariant: whatever the adapter does, the
-      // chain is still rooted in the same `Component[T]`, so the underlying `cached(...)` call is
-      // structurally reachable.
       case UnwrapApply(Select(Apply(_, List(orig)), _)) if orig.tpe =:= t.tpe => unapply(orig)
       case _ => Some(t)
     }

--- a/analyzer/src/test/scala/com/avsystem/commons/analyzer/BadSingletonComponentTest.scala
+++ b/analyzer/src/test/scala/com/avsystem/commons/analyzer/BadSingletonComponentTest.scala
@@ -27,4 +27,28 @@ final class BadSingletonComponentTest extends AnyFunSuite with AnalyzerTest {
              |""".stripMargin,
     )
   }
+
+  test("extension methods reached via implicit conversion are accepted") {
+    // Without the Unwrap case for single-argument adapter Applys, the implicit conversion
+    // `componentExt(...)` would interrupt the prefix-type check (its type is the wrapper class,
+    // not `Component[T]`), causing a false positive on what is in fact a shape-preserving chain.
+    assertNoErrors(
+      scala"""
+             |import com.avsystem.commons.di._
+             |
+             |object test extends Components {
+             |  class ComponentExt[T](c: Component[T]) {
+             |    def chained(f: T => Unit): Component[T] = c
+             |  }
+             |  implicit def componentExt[T](c: Component[T]): ComponentExt[T] = new ComponentExt(c)
+             |
+             |  def good: Component[Int] = singleton(123)
+             |  def withExt: Component[Int] = singleton(123).chained(_ => ())
+             |  // also works when mixed with native shape-preserving methods on Component
+             |  def withExtAndNative: Component[Int] = singleton(123).chained(_ => ()).dependsOn(good)
+             |  def withNativeAndExt: Component[Int] = singleton(123).dependsOn(good).chained(_ => ())
+             |}
+             |""".stripMargin
+    )
+  }
 }


### PR DESCRIPTION
Resolves #851 

The Unwrap extractor inside BadSingletonComponent peels trailing shape-preserving method chains (e.g. `singleton(x).dependsOn(y)`) so the rule can recognise the body as rooted in a `cached(...)` call. It does that by requiring `prefix.tpe =:= t.tpe` - i.e. the prefix of the trailing `.method(...)` must have the same type as the whole expression.

That check breaks for extension methods reached via an implicit conversion.

This commit adds one extra Unwrap case that peels a method call reached through a single-argument adapter Apply, gated by `orig.tpe =:= t.tpe` on the adapter's converted argument. The invariant the rule relies on ("the chain returns the same `Component[T]` type that the cached singleton produced") is preserved, and the new case does not relax the checks the original test cases rely on: bad usages were reported by arm 2 (`t.symbol == cachedSym` catch-all), which is independent of Unwrap.

Tests: extend BadSingletonComponentTest with `extension methods reached via implicit conversion are accepted`, covering the bare extension call, the extension-then-native chain, and the native-then-extension chain. The original `general` test (5 errors) is unaffected.