### PR TITLE
[Scala 3] Add empty Scala 3 source dir for macros module

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,7 +16,7 @@ Status tokens: `cross` (cross-builds on both versions), `stub` (Scala 3 wired wi
 
 | Module | 2.13 | 3.x | MiMa | Tasty-MiMa | Notes |
 |--------|------|-----|------|------------|-------|
-| macros | cross | stub | n/a | n/a | Whitebox 2.13 macros; Scala 3 jar empty in the next port. |
+| macros | cross | stub | n/a | n/a | Empty scala-3 dir; whitebox impls remain 2.13-only. |
 | made | n/a | pending | n/a | n/a | Scala-3-only dep, pinned to `io.github.halotukozak:made_3:0.1.0`. |
 | core | cross | pending | green | pending | Cross-compile target; tests still pending on Scala 3. |
 | hocon | cross | pending | green | pending | Pure-Scala; first downstream port after `core`. |


### PR DESCRIPTION
Adds an empty `macros/src/main/scala-3/` source tree (anchored by `.gitkeep`) so the `macros` module cross-builds on Scala 3. Downstream modules that `dependsOn(macros)` now resolve a valid `commons-macros_3` artifact (335-byte jar containing only the manifest) and can compile on Scala 3 without inheriting the whitebox / `scala.reflect`-based macro implementations.

## What this PR adds

- `macros/src/main/scala-3/.gitkeep` — anchors the empty Scala 3 source set in git; sbt's `unmanagedSourceDirectories` resolves it via the existing `scala-${binaryVersion}` convention. No `build.sbt` / `project/Commons.scala` changes required.
- `MIGRATION.md` — `macros` row notes column updated to reflect the landed stub.

## What this PR does NOT add

- No Scala 3 reimplementation of any macro. The Scala 3 jar is intentionally empty. Whitebox macro impls under `macros/src/main/scala-2.13/` remain the source of truth for Scala 2.13 builds, untouched.
- No `build.sbt` / `project/Commons.scala` / `.scalafmt.conf` / `.github/workflows/*` edits.

## Verification

- `sbt '++3.8.2 commons-macros/compile'` — green (Scala 3 cross-build foothold).
- `sbt '++3.8.2 commons-macros/package'` — green, produces 335-byte jar.
- `sbt '++2.13.18 commons-macros/compile'` — green (no 2.13 regression; 28 sources compile).
- `sbt scalafmtCheckAll` — green.
- GitHub Actions CI on this branch — green.

Note: \`commons-core\` Scala 3 compile still fails (114 errors) due to a pre-existing source-port gap in shared \`core/src/main/scala/\` sources — addressed in later module-port PRs (Phase 4+), not a regression introduced by this PR.

Stacked on #857.