### PR TITLE
[Scala 3] consolidate type+val aliases to export

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -40,6 +40,12 @@ the bottom of this file. Restoration ships incrementally per feature area.
 
 ### core
 
+- `CommonAliases`, `MiscAliases`, `CollectionAliases` switched from `type X = Y` + `final def/val X: Y.type = Y`
+  pairs to single Scala 3 `export Y as X` (or `export Y` for no-rename) clauses. Source-level callers are unaffected
+  (same names resolve to the same `Y` symbols), but the JVM bytecode no longer emits dedicated forwarders for the type
+  aliases / companion vals — `export` re-exports the source symbol directly. May affect MiMa-style bincompat tooling
+  once a Scala 3 baseline is published. `MColBuilder` retained as plain `type` (its RHS `scm.Builder[Elem, Col[Elem]]`
+  is a higher-kinded substitution, not a pure symbol rename, so `export` doesn't apply).
 - Type parameter wildcards `K[_]` / `D[_]` / `C[_]` narrowed to `K[Any]` / `D[Any]` / `C[Any]` at a few derivation
   seams (`TypedMap`, `SelfInstance`, `HasGenCodec.wildcardCodec`). Scala 3 forbids HKT wildcard application; downstream
   callers using the explicit signatures may need to cast.

--- a/core/src/main/scala/com/avsystem/commons/CommonAliases.scala
+++ b/core/src/main/scala/com/avsystem/commons/CommonAliases.scala
@@ -1,27 +1,20 @@
 package com.avsystem.commons
 
 trait CommonAliases {
-  type Try[+T] = scala.util.Try[T]
-  final val Try = scala.util.Try
-  type Success[+T] = scala.util.Success[T]
-  final val Success = scala.util.Success
-  type Failure[+T] = scala.util.Failure[T]
-  final val Failure = scala.util.Failure
+  export scala.util.Try
+  export scala.util.Success
+  export scala.util.Failure
 
-  type Future[+T] = scala.concurrent.Future[T]
-  final val Future = scala.concurrent.Future
-  type Promise[T] = scala.concurrent.Promise[T]
-  final val Promise = scala.concurrent.Promise
-  type ExecutionContext = scala.concurrent.ExecutionContext
-  final val ExecutionContext = scala.concurrent.ExecutionContext
+  export scala.concurrent.Future
+  export scala.concurrent.Promise
+  export scala.concurrent.ExecutionContext
 
-  final val NonFatal = scala.util.control.NonFatal
+  export scala.util.control.NonFatal
 
-  type ClassTag[T] = scala.reflect.ClassTag[T]
-  final val ClassTag = scala.reflect.ClassTag
-  final def classTag[T: ClassTag]: ClassTag[T] = scala.reflect.classTag[T]
+  export scala.reflect.ClassTag
+  export scala.reflect.classTag
 
-  type Annotation = scala.annotation.Annotation
-  type StaticAnnotation = scala.annotation.StaticAnnotation
+  export scala.annotation.Annotation
+  export scala.annotation.StaticAnnotation
 }
 object CommonAliases extends CommonAliases

--- a/core/src/main/scala/com/avsystem/commons/collection/CollectionAliases.scala
+++ b/core/src/main/scala/com/avsystem/commons/collection/CollectionAliases.scala
@@ -1,8 +1,8 @@
 package com.avsystem.commons
 package collection
 
-import scala.collection.{immutable => sci, mutable => scm}
-import scala.{collection => sc}
+import scala.collection.{immutable as sci, mutable as scm}
+import scala.collection as sc
 
 /** Aliases for Scala collections which are both concise and leave no doubt about whether the collection type is
   * immutable, mutable or the base type (read only).
@@ -10,116 +10,73 @@ import scala.{collection => sc}
   * `B` stands for base (read only) `I` stands for immutable `M` stands for mutable
   */
 trait CollectionAliases {
-  type BIterable[+A] = sc.Iterable[A]
-  final def BIterable: sc.Iterable.type = sc.Iterable
-  type IIterable[+A] = sci.Iterable[A]
-  final def IIterable: sci.Iterable.type = sci.Iterable
-  type MIterable[A] = scm.Iterable[A]
-  final def MIterable: scm.Iterable.type = scm.Iterable
+  export sc.Iterable as BIterable
+  export sci.Iterable as IIterable
+  export scm.Iterable as MIterable
 
-  type BSeq[+A] = sc.Seq[A]
-  final def BSeq: sc.Seq.type = sc.Seq
-  type ISeq[+A] = sci.Seq[A]
-  final def ISeq: sci.Seq.type = sci.Seq
-  type MSeq[A] = scm.Seq[A]
-  final def MSeq: scm.Seq.type = scm.Seq
+  export sc.Seq as BSeq
+  export sci.Seq as ISeq
+  export scm.Seq as MSeq
 
-  type BIndexedSeq[+A] = sc.IndexedSeq[A]
-  final def BIndexedSeq: sc.IndexedSeq.type = sc.IndexedSeq
-  type IIndexedSeq[+A] = sci.IndexedSeq[A]
-  final def IIndexedSeq: sci.IndexedSeq.type = sci.IndexedSeq
-  type MIndexedSeq[A] = scm.IndexedSeq[A]
-  final def MIndexedSeq: scm.IndexedSeq.type = scm.IndexedSeq
+  export sc.IndexedSeq as BIndexedSeq
+  export sci.IndexedSeq as IIndexedSeq
+  export scm.IndexedSeq as MIndexedSeq
 
-  type MArraySeq[A] = scm.ArraySeq[A]
-  final def MArraySeq: scm.ArraySeq.type = scm.ArraySeq
-  type IArraySeq[+A] = sci.ArraySeq[A]
-  final def IArraySeq: sci.ArraySeq.type = sci.ArraySeq
+  export scm.ArraySeq as MArraySeq
+  export sci.ArraySeq as IArraySeq
 
-  type BLinearSeq[+A] = sc.LinearSeq[A]
-  final def BLinearSeq: sc.LinearSeq.type = sc.LinearSeq
-  type ILinearSeq[+A] = sci.LinearSeq[A]
-  final def ILinearSeq: sci.LinearSeq.type = sci.LinearSeq
+  export sc.LinearSeq as BLinearSeq
+  export sci.LinearSeq as ILinearSeq
 
-  type IQueue[+A] = sci.Queue[A]
-  final def IQueue: sci.Queue.type = sci.Queue
-  type MQueue[A] = scm.Queue[A]
-  final def MQueue: scm.Queue.type = scm.Queue
+  export sci.Queue as IQueue
+  export scm.Queue as MQueue
 
-  type BSet[A] = sc.Set[A]
-  final def BSet: sc.Set.type = sc.Set
-  type ISet[A] = sci.Set[A]
-  final def ISet: Set.type = sci.Set
-  type MSet[A] = scm.Set[A]
-  final def MSet: scm.Set.type = scm.Set
+  export sc.Set as BSet
+  export sci.Set as ISet
+  export scm.Set as MSet
 
-  type IHashSet[A] = sci.HashSet[A]
-  final def IHashSet: sci.HashSet.type = sci.HashSet
-  type MHashSet[A] = scm.HashSet[A]
-  final def MHashSet: scm.HashSet.type = scm.HashSet
+  export sci.HashSet as IHashSet
+  export scm.HashSet as MHashSet
 
-  type BSortedSet[A] = sc.SortedSet[A]
-  final def BSortedSet: sc.SortedSet.type = sc.SortedSet
-  type ISortedSet[A] = sci.SortedSet[A]
-  final def ISortedSet: sci.SortedSet.type = sci.SortedSet
-  type MSortedSet[A] = scm.SortedSet[A]
-  final def MSortedSet: scm.SortedSet.type = scm.SortedSet
+  export sc.SortedSet as BSortedSet
+  export sci.SortedSet as ISortedSet
+  export scm.SortedSet as MSortedSet
 
-  type ITreeSet[A] = sci.TreeSet[A]
-  final def ITreeSet: sci.TreeSet.type = sci.TreeSet
-  type MTreeSet[A] = scm.TreeSet[A]
-  final def MTreeSet: scm.TreeSet.type = scm.TreeSet
+  export sci.TreeSet as ITreeSet
+  export scm.TreeSet as MTreeSet
 
-  type BBitSet = sc.BitSet
-  final def BBitSet: sc.BitSet.type = sc.BitSet
-  type IBitSet = sci.BitSet
-  final def IBitSet: sci.BitSet.type = sci.BitSet
-  type MBitSet = scm.BitSet
-  final def MBitSet: scm.BitSet.type = scm.BitSet
+  export sc.BitSet as BBitSet
+  export sci.BitSet as IBitSet
+  export scm.BitSet as MBitSet
 
-  type MLinkedHashSet[A] = scm.LinkedHashSet[A]
-  final def MLinkedHashSet: scm.LinkedHashSet.type = scm.LinkedHashSet
+  export scm.LinkedHashSet as MLinkedHashSet
 
-  type BMap[A, +B] = sc.Map[A, B]
-  final def BMap: sc.Map.type = sc.Map
-  type IMap[A, +B] = sci.Map[A, B]
-  final def IMap: sci.Map.type = sci.Map
-  type MMap[A, B] = scm.Map[A, B]
-  final def MMap: scm.Map.type = scm.Map
+  export sc.Map as BMap
+  export sci.Map as IMap
+  export scm.Map as MMap
 
-  type IHashMap[A, +B] = sci.HashMap[A, B]
-  final def IHashMap: sci.HashMap.type = sci.HashMap
-  type MHashMap[A, B] = scm.HashMap[A, B]
-  final def MHashMap: scm.HashMap.type = scm.HashMap
+  export sci.HashMap as IHashMap
+  export scm.HashMap as MHashMap
 
-  type MLinkedHashMap[A, B] = scm.LinkedHashMap[A, B]
-  final def MLinkedHashMap: scm.LinkedHashMap.type = scm.LinkedHashMap
+  export scm.LinkedHashMap as MLinkedHashMap
 
-  type IListMap[A, +B] = sci.ListMap[A, B]
-  final def IListMap: sci.ListMap.type = sci.ListMap
+  export sci.ListMap as IListMap
 
-  type BSortedMap[A, +B] = sc.SortedMap[A, B]
-  final def BSortedMap: sc.SortedMap.type = sc.SortedMap
-  type ISortedMap[A, +B] = sci.SortedMap[A, B]
-  final def ISortedMap: sci.SortedMap.type = sci.SortedMap
+  export sc.SortedMap as BSortedMap
+  export sci.SortedMap as ISortedMap
 
-  type ITreeMap[A, +B] = sci.TreeMap[A, B]
-  final def ITreeMap: sci.TreeMap.type = sci.TreeMap
+  export sci.TreeMap as ITreeMap
 
-  type MTreeMap[A, B] = scm.TreeMap[A, B]
-  final def MTreeMap: scm.TreeMap.type = scm.TreeMap
+  export scm.TreeMap as MTreeMap
 
-  type MBuffer[A] = scm.Buffer[A]
-  final def MBuffer: scm.Buffer.type = scm.Buffer
+  export scm.Buffer as MBuffer
 
-  type MBuilder[-Elem, +To] = scm.Builder[Elem, To]
+  export scm.Builder as MBuilder
   type MColBuilder[Elem, +Col[_]] = scm.Builder[Elem, Col[Elem]]
 
-  type MListBuffer[A] = scm.ListBuffer[A]
-  final def MListBuffer: scm.ListBuffer.type = scm.ListBuffer
+  export scm.ListBuffer as MListBuffer
 
-  type MArrayBuffer[A] = scm.ArrayBuffer[A]
-  final def MArrayBuffer: scm.ArrayBuffer.type = scm.ArrayBuffer
+  export scm.ArrayBuffer as MArrayBuffer
 }
 
 object CollectionAliases extends CollectionAliases

--- a/core/src/main/scala/com/avsystem/commons/collection/CollectionAliases.scala
+++ b/core/src/main/scala/com/avsystem/commons/collection/CollectionAliases.scala
@@ -72,7 +72,7 @@ trait CollectionAliases {
   export scm.Buffer as MBuffer
 
   export scm.Builder as MBuilder
-  type MColBuilder[Elem, +Col[_]] = scm.Builder[Elem, Col[Elem]]
+  type MColBuilder[Elem, +Col[_]] = MBuilder[Elem, Col[Elem]]
 
   export scm.ListBuffer as MListBuffer
 

--- a/core/src/main/scala/com/avsystem/commons/misc/MiscAliases.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/MiscAliases.scala
@@ -2,13 +2,9 @@ package com.avsystem.commons
 package misc
 
 trait MiscAliases {
-  type Opt[+A] = com.avsystem.commons.misc.Opt[A]
-  final val Opt = com.avsystem.commons.misc.Opt
-  type OptArg[+A] = com.avsystem.commons.misc.OptArg[A]
-  final val OptArg = com.avsystem.commons.misc.OptArg
-  type NOpt[+A] = com.avsystem.commons.misc.NOpt[A]
-  final val NOpt = com.avsystem.commons.misc.NOpt
-  type OptRef[+A >: Null] = com.avsystem.commons.misc.OptRef[A]
-  final val OptRef = com.avsystem.commons.misc.OptRef
+  export com.avsystem.commons.misc.Opt
+  export com.avsystem.commons.misc.OptArg
+  export com.avsystem.commons.misc.NOpt
+  export com.avsystem.commons.misc.OptRef
 }
 object MiscAliases extends MiscAliases


### PR DESCRIPTION
**Slice:** 3.6 of Phase 3 (Scala 3 syntax modernization)
**Merge order:** Independent — can land any time (no overlap with 3.1/3.2/3.3/3.4/3.5)
**Depends on:** none
**Base branch:** upstream/scala-3 (not stacked)

Consolidate `type X = Y; final def X: Y.type = Y` and `type X = Y; final val X: Y.type = Y` patterns into Scala 3 `export Y` (or `export Y as X` for rename) clauses. Reduces redundancy: a single declaration re-exports both the type AND the term.

Touches:
- `core/.../CommonAliases.scala` — `Try`/`Success`/`Failure`/`Future`/`Promise`/`ExecutionContext`/`NonFatal`/`ClassTag`/`classTag`/`Annotation`/`StaticAnnotation`
- `core/.../misc/MiscAliases.scala` — `Opt`/`OptArg`/`NOpt`/`OptRef`
- `core/.../collection/CollectionAliases.scala` — ~30 rename pairs (`BIterable`/`IIterable`/`MIterable`/…/`MArrayBuffer`); `MColBuilder` retained as plain `type` (RHS is HK substitution, not a pure rename)

`MIGRATION.md` §3 updated with the source-compat note.

`sbt compile + Test/compile + scalafmtCheckAll` exit 0. No new warnings, no `@nowarn`/`-Wconf`.

### Drift note

halotukozak fork (`origin/master`) already uses `export` for `CommonAliases` and `MiscAliases`; we mirror it. For `CollectionAliases` the fork still keeps the `type + final def` pair shape — we diverge per user directive 2026-06-01 to consolidate via `export`.