### PR TITLE
[Scala 3] convert varargs splice : _* to *

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -54,6 +54,9 @@ the bottom of this file. Restoration ships incrementally per feature area.
   compiles).
 - `enum` was renamed to `e` at one call site in `GenKeyCodec` (`enum` is reserved in Scala 3).
 - `@targetName` annotation added to `CloseableIterator` overloaded methods.
+- Varargs splice syntax modernized from Scala 2 `foo(seq: _*)` to Scala 3 `foo(seq*)` across all
+  call sites (`CrossUtils.wrappedArray`/`dictionary`, `JCollectionUtils.JIterable.apply`,
+  `MongoOrder.apply`). Pure call-site syntax — no signature change, no source-compat impact.
 
 ### mongo
 

--- a/core/js/src/main/scala/com/avsystem/commons/misc/CrossUtils.scala
+++ b/core/js/src/main/scala/com/avsystem/commons/misc/CrossUtils.scala
@@ -19,7 +19,7 @@ object CrossUtils {
 
   def newNativeDict[A]: NativeDict[A] = js.Dictionary.empty[A]
 
-  def wrappedArray[A](elems: A*): MIndexedSeq[A] = js.Array(elems: _*)
+  def wrappedArray[A](elems: A*): MIndexedSeq[A] = js.Array(elems*)
   def arrayBuffer[A]: MIndexedSeq[A] with MBuffer[A] = js.Array[A]()
-  def dictionary[A](keyValues: (String, A)*): MMap[String, A] = js.Dictionary(keyValues: _*)
+  def dictionary[A](keyValues: (String, A)*): MMap[String, A] = js.Dictionary(keyValues*)
 }

--- a/core/jvm/src/main/scala/com/avsystem/commons/misc/CrossUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/misc/CrossUtils.scala
@@ -9,7 +9,7 @@ object CrossUtils {
   def newNativeDict[A]: NativeDict[A] = new MHashMap[String, A]
   def unsetArrayValue: Any = null
 
-  def wrappedArray[A: ClassTag](elems: A*): MIndexedSeq[A] = Array(elems: _*)
+  def wrappedArray[A: ClassTag](elems: A*): MIndexedSeq[A] = Array(elems*)
   def arrayBuffer[A]: MIndexedSeq[A] with MBuffer[A] = new MArrayBuffer[A]
-  def dictionary[A](keyValues: (String, A)*): MMap[String, A] = MHashMap[String, A](keyValues: _*)
+  def dictionary[A](keyValues: (String, A)*): MMap[String, A] = MHashMap[String, A](keyValues*)
 }

--- a/core/src/main/scala/com/avsystem/commons/annotation/atLeast.scala
+++ b/core/src/main/scala/com/avsystem/commons/annotation/atLeast.scala
@@ -4,9 +4,9 @@ package annotation
 /** When applied on varargs parameter, indicates that at least some number of parameters is required. This is later
   * checked by the static analyzer. <br/> WARNING: implementation of method which takes a varargs parameter may NOT
   * assume that given number of arguments will always be passed, because it's still possible to pass a `Seq` where
-  * varargs parameter is required using the `: _*` ascription, e.g.
+  * varargs parameter is required using the `*` ascription, e.g.
   * {{{
-  *   varargsMethod(List(): _*)
+  *   varargsMethod(List()*)
   * }}}
   * and that is not checked by the static analyzer.
   */

--- a/core/src/main/scala/com/avsystem/commons/jiop/JCollectionUtils.scala
+++ b/core/src/main/scala/com/avsystem/commons/jiop/JCollectionUtils.scala
@@ -73,7 +73,7 @@ trait JCollectionUtils extends JFactories {
 
   object JIterable {
     def apply[T](values: T*): JIterable[T] =
-      JArrayList(values: _*)
+      JArrayList(values*)
 
     implicit def asJIterableFactory[T](obj: JIterable.type): Factory[T, JIterable[T]] =
       new JCollectionFactory(new JArrayList)

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoOrder.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoOrder.scala
@@ -22,7 +22,7 @@ object MongoOrder {
   def simple[T](ascending: Boolean): MongoOrder[T] = Simple(ascending)
 
   def apply[E](refs: (MongoPropertyRef[E, _], Boolean)*): MongoDocumentOrder[E] =
-    MongoDocumentOrder(refs: _*)
+    MongoDocumentOrder(refs*)
 
   final case class Simple[T](ascending: Boolean) extends MongoOrder[T] {
     def toBson: BsonValue = Bson.int(if (ascending) 1 else -1)


### PR DESCRIPTION
**Slice:** 3.7 of Phase 3 (Scala 3 syntax modernization)
**Merge order:** Independent — can land any time (no overlap with 3.1/3.2/3.3/3.4/3.5/3.6)
**Depends on:** none
**Base branch:** upstream/scala-3 (not stacked)

Converts Scala 2 varargs splice `foo(seq: _*)` to Scala 3 `foo(seq*)` per stdlib-migration deprecation.

Pure call-site syntax. No source-compat impact for callers of unchanged signatures.

Sites updated:
- `core/js,jvm CrossUtils`: `wrappedArray`, `dictionary`
- `core jiop JCollectionUtils.JIterable.apply`
- `mongo MongoOrder.apply`
- `atLeast.scala` scaladoc updated to current syntax

`sbt compile + Test/compile + scalafmtCheckAll` exit 0. No new warnings, no new `@nowarn`/`-Wconf`.

Only remaining `: _*` hit is in disabled `analyzer/` module (will-not-migrate / phase-deferred).