### PR TITLE
[Scala 3] drop deprecated private[this] qualifier

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -54,6 +54,11 @@ the bottom of this file. Restoration ships incrementally per feature area.
   compiles).
 - `enum` was renamed to `e` at one call site in `GenKeyCodec` (`enum` is reserved in Scala 3).
 - `@targetName` annotation added to `CloseableIterator` overloaded methods.
+- `private[this]` qualifier dropped on ~64 members across core / hocon / mongo. Plain
+  `private` has identical semantics in Scala 3 (the dialect deprecates `private[this]`
+  since 3.4.0). No access-level change for downstream callers; for `private[this] var`
+  fields the JVM-level accessor synthesis is now equivalent to a plain `private var`
+  (Scala 3 inlines `private` vars directly — no perf delta vs. the old qualifier).
 
 ### mongo
 

--- a/core/jvm/src/main/scala/com/avsystem/commons/concurrent/ObservableBlockingIterator.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/concurrent/ObservableBlockingIterator.scala
@@ -25,8 +25,8 @@ class ObservableBlockingIterator[T](
 
   import ObservableBlockingIterator._
 
-  @volatile private[this] var last: Any = Empty
-  @volatile private[this] var ackPromise: Promise[Ack] = _
+  @volatile private var last: Any = Empty
+  @volatile private var ackPromise: Promise[Ack] = _
   private val queue = new ArrayBlockingQueue[Any](bufferSize)
   private val cancelable = observable.subscribe(this)
 

--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/GuavaInterop.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/GuavaInterop.scala
@@ -98,7 +98,7 @@ object GuavaInterop extends GuavaInterop {
       p.future
     }
 
-    private[this] def unwrapFailures(expr: => T): T =
+    private def unwrapFailures(expr: => T): T =
       try expr
       catch {
         case ee: ExecutionException => throw ee.getCause
@@ -144,7 +144,7 @@ object GuavaInterop extends GuavaInterop {
     def isCancelled: Boolean =
       false
 
-    private[this] def wrapFailures(expr: => T): T =
+    private def wrapFailures(expr: => T): T =
       try expr
       catch {
         case NonFatal(e) => throw new ExecutionException(e)

--- a/core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -708,10 +708,10 @@ object SharedExtensionsUtils extends SharedExtensions {
 
     def collectWhileDefined[B](pf: PartialFunction[A, B]): Iterator[B] =
       new AbstractIterator[B] {
-        private[this] var fetched = false
-        private[this] var value: NOpt[B] = _
+        private var fetched = false
+        private var value: NOpt[B] = _
 
-        private[this] def fetch(): Unit =
+        private def fetch(): Unit =
           if (it.hasNext) {
             value = pf.applyNOpt(it.next())
           } else {
@@ -745,8 +745,8 @@ object SharedExtensionsUtils extends SharedExtensions {
   object IteratorCompanionOps {
     def untilEmpty[T](elem: => Opt[T]): Iterator[T] =
       new AbstractIterator[T] {
-        private[this] var fetched = false
-        private[this] var value = Opt.empty[T]
+        private var fetched = false
+        private var value = Opt.empty[T]
 
         def hasNext: Boolean = {
           if (!fetched) {
@@ -772,8 +772,8 @@ object SharedExtensionsUtils extends SharedExtensions {
 
     def iterateUntilEmpty[T](start: Opt[T])(nextFun: T => Opt[T]): Iterator[T] =
       new AbstractIterator[T] {
-        private[this] var fetched = true
-        private[this] var value = start
+        private var fetched = true
+        private var value = start
 
         def hasNext: Boolean = {
           if (!fetched) {

--- a/core/src/main/scala/com/avsystem/commons/collection/MutableStack.scala
+++ b/core/src/main/scala/com/avsystem/commons/collection/MutableStack.scala
@@ -2,8 +2,8 @@ package com.avsystem.commons
 package collection
 
 final class MutableStack[T] {
-  private[this] var ssize: Int = 0
-  private[this] var stack = List.empty[T]
+  private var ssize: Int = 0
+  private var stack = List.empty[T]
 
   def push(elem: T): Unit = {
     stack ::= elem

--- a/core/src/main/scala/com/avsystem/commons/di/Component.scala
+++ b/core/src/main/scala/com/avsystem/commons/di/Component.scala
@@ -63,7 +63,7 @@ final class Component[+T](
     */
   lazy val dependencies: IndexedSeq[Component[_]] = deps
 
-  private[this] val storage: AtomicReference[Future[T]] =
+  private val storage: AtomicReference[Future[T]] =
     cachedStorage.getOrElse(new AtomicReference)
 
   private def sameStorage(otherStorage: AtomicReference[_]): Boolean =
@@ -183,7 +183,7 @@ object Component {
   def emptyDestroy[T]: DestroyFunction[T] =
     reusableEmptyDestroy.asInstanceOf[DestroyFunction[T]]
 
-  private[this] val reusableEmptyDestroy: DestroyFunction[Any] =
+  private val reusableEmptyDestroy: DestroyFunction[Any] =
     _ => _ => Future.unit
 
   def async[T](definition: => T): ExecutionContext => Future[T] =

--- a/core/src/main/scala/com/avsystem/commons/meta/metadata.scala
+++ b/core/src/main/scala/com/avsystem/commons/meta/metadata.scala
@@ -51,8 +51,8 @@ final case class ParamFlags(rawFlags: Int) extends AnyVal {
 }
 
 object ParamFlags extends HasGenCodec[ParamFlags] {
-  private[this] var currentFlag: Int = 1
-  private[this] def nextFlag(): ParamFlags = {
+  private var currentFlag: Int = 1
+  private def nextFlag(): ParamFlags = {
     val flag = currentFlag
     currentFlag = currentFlag << 1
     new ParamFlags(flag)
@@ -152,8 +152,8 @@ final case class TypeFlags(rawFlags: Int) extends AnyVal {
 }
 
 object TypeFlags extends HasGenCodec[TypeFlags] {
-  private[this] var currentFlag: Int = 1
-  private[this] def nextFlag(): TypeFlags = {
+  private var currentFlag: Int = 1
+  private def nextFlag(): TypeFlags = {
     val flag = currentFlag
     currentFlag = currentFlag << 1
     new TypeFlags(flag)
@@ -212,8 +212,8 @@ final case class MethodFlags(rawFlags: Int) extends AnyVal {
   }
 }
 object MethodFlags extends HasGenCodec[MethodFlags] {
-  private[this] var currentFlag: Int = 1
-  private[this] def nextFlag(): MethodFlags = {
+  private var currentFlag: Int = 1
+  private def nextFlag(): MethodFlags = {
     val flag = currentFlag
     currentFlag = currentFlag << 1
     new MethodFlags(flag)

--- a/core/src/main/scala/com/avsystem/commons/misc/AnnotationOf.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/AnnotationOf.scala
@@ -40,7 +40,7 @@ object AnnotationsOf {
 @implicitNotFound("${T} is not annotated with ${A}")
 final class HasAnnotation[A, T] private ()
 object HasAnnotation {
-  private[this] val reusable = new HasAnnotation
+  private val reusable = new HasAnnotation
   def create[A, T]: HasAnnotation[A, T] = reusable.asInstanceOf[HasAnnotation[A, T]]
 
   // TODO[scala3-port]: HasAnnotation.materialize (Scala 2 macro def) (L)

--- a/core/src/main/scala/com/avsystem/commons/misc/ValueEnum.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/ValueEnum.scala
@@ -77,10 +77,10 @@ sealed trait EnumCtx extends Any {
 trait ValueEnumCompanion[T <: ValueEnum] extends NamedEnumCompanion[T] { companion =>
   type Value = T
 
-  private[this] val registryBuilder = IIndexedSeq.newBuilder[T]
-  private[this] var currentOrdinal: Int = 0
-  private[this] var finished: Boolean = false
-  private[this] var awaitingRegister: Boolean = false
+  private val registryBuilder = IIndexedSeq.newBuilder[T]
+  private var currentOrdinal: Int = 0
+  private var finished: Boolean = false
+  private var awaitingRegister: Boolean = false
 
   /** Holds an indexed sequence of all enum values, ordered by their ordinal (`values(i).ordinal` is always equal to
     * `i`).
@@ -104,7 +104,7 @@ trait ValueEnumCompanion[T <: ValueEnum] extends NamedEnumCompanion[T] { compani
     }
     awaitingRegister = true
 
-    private[this] var registered = false
+    private var registered = false
 
     override def register(value: ValueEnum): Unit = companion.synchronized {
       if (finished)

--- a/core/src/main/scala/com/avsystem/commons/serialization/DefaultCaseObjectInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/DefaultCaseObjectInput.scala
@@ -8,7 +8,7 @@ final class DefaultCaseObjectInput(firstField: FieldInput, actualInput: ObjectIn
 
   override def knownSize: Int = actualInput.knownSize
 
-  private[this] var atFirstField = true
+  private var atFirstField = true
 
   def hasNext: Boolean = atFirstField || actualInput.hasNext
   def nextField(): FieldInput =

--- a/core/src/main/scala/com/avsystem/commons/serialization/PeekingObjectInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/PeekingObjectInput.scala
@@ -4,7 +4,7 @@ package serialization
 /** Wrapper over [[ObjectInput]] that lets you peek next field name without advancing the input.
   */
 final class PeekingObjectInput(original: ObjectInput) extends ObjectInput {
-  private[this] var peekedField: FieldInput = _
+  private var peekedField: FieldInput = _
 
   override def knownSize: Int = original.knownSize
 

--- a/core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
@@ -137,7 +137,7 @@ class StreamInput(is: DataInputStream) extends InputAndSimpleInput {
 class StreamFieldInput(val fieldName: String, is: DataInputStream) extends StreamInput(is) with FieldInput
 
 private class StreamListInput(is: DataInputStream) extends ListInput {
-  private[this] var currentInput: Opt[StreamInput] = Opt.empty
+  private var currentInput: Opt[StreamInput] = Opt.empty
 
   private def ensureInput(): Unit =
     if (currentInput == Opt.empty) currentInput = Opt.some(new StreamInput(is))
@@ -159,7 +159,7 @@ private class StreamObjectInput(is: DataInputStream) extends ObjectInput {
 
   import StreamObjectInput._
 
-  private[this] var currentField: FieldInput = NoneYet
+  private var currentField: FieldInput = NoneYet
 
   private def ensureInput(): Unit = {
     if (currentField eq NoneYet) {
@@ -216,8 +216,8 @@ private object StreamObjectInput {
 
 class StreamOutput(os: DataOutputStream) extends OutputAndSimpleOutput {
 
-  private[this] val streamList = new StreamListOutput(os, this)
-  private[this] val streamObject = new StreamObjectOutput(os, this)
+  private val streamList = new StreamListOutput(os, this)
+  private val streamObject = new StreamObjectOutput(os, this)
 
   def writeNull(): Unit = os.write(NullMarker)
 

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets
 import scala.annotation.tailrec
 
 final class CborReader(val data: RawCbor) {
-  private[this] var idx = 0
+  private var idx = 0
 
   def index: Int = idx
 
@@ -87,7 +87,7 @@ final class CborReader(val data: RawCbor) {
     res
   }
 
-  private[this] var openIndefs = 0 // number of currently open values of indefinite length
+  private var openIndefs = 0 // number of currently open values of indefinite length
 
   def openIndefinites: Int =
     openIndefs
@@ -402,7 +402,7 @@ class CborInput(reader: CborReader, keyCodec: CborKeyCodec) extends InputAndSimp
 class CborFieldInput(val fieldName: String, reader: CborReader, keyCodec: CborKeyCodec)
   extends CborInput(reader, keyCodec) with FieldInput
 
-abstract class CborSequentialInput(reader: CborReader, private[this] var size: Int) extends SequentialInput {
+abstract class CborSequentialInput(reader: CborReader, private var size: Int) extends SequentialInput {
 
   private val indefDepth = reader.openIndefinites
 
@@ -440,8 +440,8 @@ class CborListInput(reader: CborReader, size: Int, keyCodec: CborKeyCodec)
 class CborObjectInput(reader: CborReader, size: Int, keyCodec: CborKeyCodec)
   extends CborSequentialInput(reader, size) with ObjectInput {
 
-  private[this] var forcedKeyCodec: CborKeyCodec = _
-  private[this] def currentKeyCodec = if (forcedKeyCodec != null) forcedKeyCodec else keyCodec
+  private var forcedKeyCodec: CborKeyCodec = _
+  private def currentKeyCodec = if (forcedKeyCodec != null) forcedKeyCodec else keyCodec
 
   /** Returns a [[CborOutput]] for reading a raw CBOR field key. This is an extension over standard [[ObjectOutput]]
     * which only allows string-typed keys. If this method is used to read the key then value MUST be read with

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
@@ -241,8 +241,8 @@ class CborObjectOutput(
 ) extends CborSequentialOutput(out, sizePolicy)
     with ObjectOutput {
 
-  private[this] var forcedKeyCodec: CborKeyCodec = _
-  private[this] def currentKeyCodec = if (forcedKeyCodec != null) forcedKeyCodec else keyCodec
+  private var forcedKeyCodec: CborKeyCodec = _
+  private def currentKeyCodec = if (forcedKeyCodec != null) forcedKeyCodec else keyCodec
 
   /** Returns a [[CborOutput]] for writing an arbitrary CBOR map key. This method is an extension of standard [[Output]]
     * which only allows string-typed keys. If a key is written using this method then its corresponding value MUST be

--- a/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -31,8 +31,8 @@ class JsonStringInput(
 ) extends InputAndSimpleInput
     with AfterElement {
 
-  private[this] val startIdx: Int = reader.parseValue()
-  private[this] var endIdx: Int = _
+  private val startIdx: Int = reader.parseValue()
+  private var endIdx: Int = _
 
   reader.jsonType match {
     case JsonType.list | JsonType.`object` =>
@@ -207,7 +207,7 @@ final class JsonStringFieldInput(
 final class JsonListInput(reader: JsonReader, options: JsonOptions, callback: AfterElement)
   extends ListInput with AfterElement {
 
-  private[this] var end = false
+  private var end = false
 
   prepareForNext(first = true)
 
@@ -230,12 +230,12 @@ final class JsonListInput(reader: JsonReader, options: JsonOptions, callback: Af
 final class JsonObjectInput(reader: JsonReader, options: JsonOptions, callback: AfterElement)
   extends ObjectInput with AfterElement {
 
-  private[this] var end = false
+  private var end = false
 
   prepareForNext(first = true)
 
-  private[this] var peekIdx = if (end) -1 else reader.index
-  private[this] var peekedFields: CrossUtils.NativeDict[Int] = _
+  private var peekIdx = if (end) -1 else reader.index
+  private var peekedFields: CrossUtils.NativeDict[Int] = _
 
   private def prepareForNext(first: Boolean): Unit = {
     reader.skipWs()
@@ -314,9 +314,9 @@ final class JsonObjectInput(reader: JsonReader, options: JsonOptions, callback: 
 final class JsonReader(val json: String) {
   json.checkNotNull("null JSON string")
 
-  private[this] var i: Int = 0
-  private[this] var value: Any = _
-  private[this] var tpe: JsonType = _
+  private var i: Int = 0
+  private var value: Any = _
+  private var tpe: JsonType = _
 
   def index: Int = i
   def currentValue: Any = value

--- a/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
@@ -141,7 +141,7 @@ final class JsonListOutput(builder: JStringBuilder, options: JsonOptions, depth:
 
   override def sizePolicy: SizePolicy = SizePolicy.Ignored
 
-  private[this] var first = true
+  private var first = true
 
   def writeElement(): JsonStringOutput = {
     builder.append(if (first) '[' else ',')
@@ -165,7 +165,7 @@ final class JsonObjectOutput(builder: JStringBuilder, options: JsonOptions, dept
 
   override def sizePolicy: SizePolicy = SizePolicy.Ignored
 
-  private[this] var first = true
+  private var first = true
 
   def writeField(key: String): JsonStringOutput = {
     builder.append(if (first) '{' else ',')

--- a/core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -27,7 +27,7 @@ abstract class ApplyUnapplyCodec[T](
   protected def dependencies: Array[GenCodec[_]]
   protected def instantiate(fieldValues: FieldValues): T
 
-  private[this] lazy val deps = dependencies
+  private lazy val deps = dependencies
 
   protected final def writeField[A](output: ObjectOutput, idx: Int, value: A): Unit =
     writeField(fieldNames(idx), output, value, deps(idx).asInstanceOf[GenCodec[A]])
@@ -154,7 +154,7 @@ abstract class NestedSealedHierarchyCodec[T](
 
   def caseDependencies: Array[GenCodec[_]]
 
-  private[this] lazy val caseDeps = caseDependencies
+  private lazy val caseDeps = caseDependencies
 
   final def writeObject(output: ObjectOutput, value: T): Unit = {
     val caseIdx = caseIndexByValue(value)
@@ -188,8 +188,8 @@ abstract class FlatSealedHierarchyCodec[T](
   def oooDependencies: Array[GenCodec[_]]
   def caseDependencies: Array[OOOFieldsObjectCodec[_]]
 
-  private[this] lazy val oooDeps = oooDependencies
-  private[this] lazy val caseDeps = caseDependencies
+  private lazy val oooDeps = oooDependencies
+  private lazy val caseDeps = caseDependencies
 
   final def writeObject(output: ObjectOutput, value: T): Unit = {
     val caseIdx = caseIndexByValue(value)

--- a/hocon/src/main/scala/com/avsystem/commons/hocon/HParser.scala
+++ b/hocon/src/main/scala/com/avsystem/commons/hocon/HParser.scala
@@ -19,7 +19,7 @@ class HParser(tokens: IndexedSeq[HToken]) {
   import HTokenType._
   import HTree._
 
-  private[this] var idx = 0
+  private var idx = 0
 
   private def fail(): Nothing =
     if (eof) throw new EOFException

--- a/hocon/src/main/scala/com/avsystem/commons/hocon/HTokenType.scala
+++ b/hocon/src/main/scala/com/avsystem/commons/hocon/HTokenType.scala
@@ -135,9 +135,9 @@ object HTokenType extends SealedEnumCompanion[HTokenType] {
 }
 
 class HLexer(input: SourceFile) {
-  private[this] val chars = input.contents
-  private[this] var tokenIdx = 0
-  private[this] var off = -1
+  private val chars = input.contents
+  private var tokenIdx = 0
+  private var off = -1
 
   def next(): HToken =
     if (off == -1) {

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
@@ -97,7 +97,7 @@ final class BsonReaderListInput(it: BsonReaderIterator[BsonReaderInput]) extends
 }
 
 final class BsonReaderObjectInput(br: BsonReader, legacyOptionEncoding: Boolean) extends ObjectInput {
-  private[this] val it = new BsonReaderIterator(
+  private val it = new BsonReaderIterator(
     br,
     _.readEndDocument(),
     br =>
@@ -108,8 +108,8 @@ final class BsonReaderObjectInput(br: BsonReader, legacyOptionEncoding: Boolean)
       ),
   )
 
-  private[this] var peekMark: BsonReaderMark = br.getMark
-  private[this] var peekedFields: MHashMap[String, BsonValue] = _
+  private var peekMark: BsonReaderMark = br.getMark
+  private var peekedFields: MHashMap[String, BsonValue] = _
 
   override def peekField(name: String): Opt[BsonFieldInput] =
     br match {

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFilter.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFilter.scala
@@ -42,7 +42,7 @@ object MongoFilter {
       MongoOperatorsFilter(operators(new MongoQueryOperator.Creator(format)))
   }
 
-  private[this] val reusableEmpty = Empty()
+  private val reusableEmpty = Empty()
 
   def empty[E]: MongoDocumentFilter[E] = reusableEmpty.asInstanceOf[MongoDocumentFilter[E]]
   def and[E](filters: MongoDocumentFilter[E]*): MongoDocumentFilter[E] = And(filters.toVector)

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/TypedMongoCollectionTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/TypedMongoCollectionTest.scala
@@ -70,7 +70,7 @@ class TypedMongoCollectionTest extends AnyFunSuite with ScalaFutures with Before
 
   private val entities = (0 until 100).map(recordTestEntity)
 
-  private[this] var seq = 100
+  private var seq = 100
   private def nextSeq(): Int = {
     val res = seq
     seq += 1


### PR DESCRIPTION
## Summary

Scala 3 deprecated `private[this]` since 3.4.0 — plain `private` has identical
semantics for class members (vals, defs, vars). This slice removes the qualifier
project-wide, eliminating the deprecation warnings.

- 64 occurrences across 21 files in core / hocon / mongo
- Mechanical `sed`-style rewrite; no logic touched
- No new `@nowarn` / `-Wconf`
- `private[this] var` → `private var`: in Scala 3 there is no accessor-synthesis
  difference, so no perf delta and no JVM-level field-name change worth flagging
- MIGRATION.md §3 updated

## Slice metadata

- Slice 3.9
- Independent
- Depends-on: none
- Base: `upstream/scala-3@0887d555`

## Verification

- `git grep -nE 'private\[this\]' -- '*.scala'` → 0 hits
- `sbt compile Test/compile scalafmtCheckAll` → green
- No new warnings; `private[this]` deprecations gone from compile output