### PR TITLE
[Scala 3] convert wildcard imports to Scala 3 syntax

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,6 +38,13 @@ the bottom of this file. Restoration ships incrementally per feature area.
 - `crossScalaVersions` removed — the build is single-axis Scala 3.8.2.
 - Java CI matrix is Temurin 17 / 21 / 25 (matches upstream/scala-3 baseline).
 
+### import syntax
+
+- All `import X._` wildcard imports modernized to Scala 3 `import X.*` (top-level and method-scoped occurrences).
+- All `import X.{Y => Z}` rename clauses converted to Scala 3 `import X.Y as Z` (or `import X.{Y as Z, ...}` for multi-selector forms).
+- `import java.io.{ObjectInput => _, _}` exclude+wildcard pattern rewritten as `import java.io.{ObjectInput as _, *}`.
+- Scaladoc `@example` blocks updated to use the new syntax to match emitted code.
+
 ### core
 
 - Type parameter wildcards `K[_]` / `D[_]` / `C[_]` narrowed to `K[Any]` / `D[Any]` / `C[Any]` at a few derivation

--- a/benchmark/js/src/main/scala/com/avsystem/commons/Main.scala
+++ b/benchmark/js/src/main/scala/com/avsystem/commons/Main.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 
 import com.avsystem.commons.ser.{IsoInstantBenchmarks, JsonBenchmarks}
 import japgolly.scalajs.benchmark.gui.BenchmarkGUI
-import org.scalajs.dom._
+import org.scalajs.dom.*
 
 object Main {
   def main(args: Array[String]): Unit = {

--- a/benchmark/jvm/src/main/scala/com/avsystem/commons/core/OptBenchmarks.scala
+++ b/benchmark/jvm/src/main/scala/com/avsystem/commons/core/OptBenchmarks.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package core
 
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 
 import scala.annotation.tailrec
 

--- a/benchmark/jvm/src/main/scala/com/avsystem/commons/core/generalBenchmarks.scala
+++ b/benchmark/jvm/src/main/scala/com/avsystem/commons/core/generalBenchmarks.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package core
 
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 
 @Warmup(iterations = 5)

--- a/benchmark/jvm/src/main/scala/com/avsystem/commons/core/generalBenchmarks.scala
+++ b/benchmark/jvm/src/main/scala/com/avsystem/commons/core/generalBenchmarks.scala
@@ -10,7 +10,7 @@ import org.openjdk.jmh.infra.Blackhole
 @BenchmarkMode(Array(Mode.Throughput))
 class LoopBenchmark {
 
-  import LoopBenchmark._
+  import LoopBenchmark.*
 
   @Benchmark
   def rangeForeachTest(blackhole: Blackhole): Unit = {

--- a/benchmark/jvm/src/main/scala/com/avsystem/commons/mongo/BsonCodecBenchmark.scala
+++ b/benchmark/jvm/src/main/scala/com/avsystem/commons/mongo/BsonCodecBenchmark.scala
@@ -16,7 +16,7 @@ import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Fork, Measurement,
 @State(Scope.Thread)
 class BsonCodecBenchmark {
 
-  import BsonCodecBenchmark._
+  import BsonCodecBenchmark.*
 
   private val something = Toplevel(42, Nested(List(4, 8, 15, 16, 23, 42, 0), 131), "lol")
   private val doc = somethingCodec.toDocument(something)
@@ -52,7 +52,7 @@ class BsonCodecBenchmark {
 
 object BsonCodecBenchmark {
 
-  import BsonCodec._
+  import BsonCodec.*
 
   val bsonDocumentCodec = new BsonDocumentCodec()
 

--- a/benchmark/jvm/src/main/scala/com/avsystem/commons/ser/GenCodecBenchmarks.scala
+++ b/benchmark/jvm/src/main/scala/com/avsystem/commons/ser/GenCodecBenchmarks.scala
@@ -1,9 +1,9 @@
 package com.avsystem.commons
 package ser
 
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.json.{JsonBinaryFormat, JsonOptions, JsonStringInput, JsonStringOutput}
-import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.*
 
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 10, time = 2)

--- a/core/js/src/main/scala/com/avsystem/commons/serialization/nativejs/NativeJsonOutput.scala
+++ b/core/js/src/main/scala/com/avsystem/commons/serialization/nativejs/NativeJsonOutput.scala
@@ -48,7 +48,7 @@ final class NativeJsonOutput(
     new NativeJsonObjectOutput(valueConsumer, options)
 
   override def writeBinary(binary: Array[Byte]): Unit = {
-    import js.JSConverters._
+    import js.JSConverters.*
     valueConsumer(binary.toJSArray)
   }
 

--- a/core/js/src/main/scala/com/avsystem/commons/serialization/nativejs/NativeJsonOutput.scala
+++ b/core/js/src/main/scala/com/avsystem/commons/serialization/nativejs/NativeJsonOutput.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package serialization.nativejs
 
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.json.RawJson
 
 import scala.scalajs.js

--- a/core/js/src/test/scala/com/avsystem/commons/serialization/nativejs/NativeJsonInputOutputTest.scala
+++ b/core/js/src/test/scala/com/avsystem/commons/serialization/nativejs/NativeJsonInputOutputTest.scala
@@ -23,7 +23,7 @@ object NativeJsonInputOutputTest {
 }
 
 class NativeJsonInputOutputTest extends AnyFunSuite {
-  import NativeJsonInputOutputTest._
+  import NativeJsonInputOutputTest.*
 
   case class BilateralTestCase(name: String, options: NativeFormatOptions, testStringRepr: Boolean = true)
 

--- a/core/jvm/src/main/scala/com/avsystem/commons/concurrent/BlockingUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/concurrent/BlockingUtils.scala
@@ -7,7 +7,7 @@ import monix.execution.Scheduler
 import monix.reactive.Observable
 
 import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 abstract class BlockingUtils {
   def defaultTimeout: Duration = 60.seconds

--- a/core/jvm/src/main/scala/com/avsystem/commons/concurrent/ObservableBlockingIterator.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/concurrent/ObservableBlockingIterator.scala
@@ -23,7 +23,7 @@ class ObservableBlockingIterator[T](
 ) extends CloseableIterator[T]
     with Subscriber[T] {
 
-  import ObservableBlockingIterator._
+  import ObservableBlockingIterator.*
 
   @volatile private[this] var last: Any = Empty
   @volatile private[this] var ackPromise: Promise[Ack] = _

--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/JOptionalUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/JOptionalUtils.scala
@@ -1,11 +1,11 @@
 package com.avsystem.commons
 package jiop
 
-import java.{util => ju}
+import java.util as ju
 
 trait JOptionalUtils {
 
-  import JOptionalUtils._
+  import JOptionalUtils.*
 
   type JOptional[T] = ju.Optional[T]
   type JOptionalDouble = ju.OptionalDouble

--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/JStreamUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/JStreamUtils.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package jiop
 
-import java.{util => ju}
+import java.util as ju
 
 trait JStreamUtils {
   type JBaseStream[T, S <: ju.stream.BaseStream[T, S]] = ju.stream.BaseStream[T, S]
@@ -11,7 +11,7 @@ trait JStreamUtils {
   type JLongStream = ju.stream.LongStream
   type JCollector[T, A, R] = ju.stream.Collector[T, A, R]
 
-  import JStreamUtils._
+  import JStreamUtils.*
 
   implicit def jStream2AsScala[T](jStream: JStream[T]): JStream2AsScala[T] =
     new JStream2AsScala(jStream)

--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/Java8CollectionUtils.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/Java8CollectionUtils.scala
@@ -3,7 +3,7 @@ package jiop
 
 trait Java8CollectionUtils {
 
-  import Java8CollectionUtils._
+  import Java8CollectionUtils.*
 
   implicit def jIteratorOps[A](it: JIterator[A]): jIteratorOps[A] = new jIteratorOps(it)
   implicit def jIterableOps[A](it: JIterable[A]): jIterableOps[A] = new jIterableOps(it)

--- a/core/jvm/src/main/scala/com/avsystem/commons/jiop/ScalaJStream.scala
+++ b/core/jvm/src/main/scala/com/avsystem/commons/jiop/ScalaJStream.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package jiop
 
-import scala.annotation.unchecked.{uncheckedVariance => uV}
+import scala.annotation.unchecked.uncheckedVariance as uV
 import scala.collection.Factory
 
 final class ScalaJStream[+A](private val jStream: JStream[A @uV]) extends AnyVal {

--- a/core/jvm/src/test/scala/com/avsystem/commons/concurrent/JvmTaskExtensionsTest.scala
+++ b/core/jvm/src/test/scala/com/avsystem/commons/concurrent/JvmTaskExtensionsTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.concurrent.TimeoutException
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class JvmTaskExtensionsTest extends AnyFunSuite with Matchers with ScalaCheckDrivenPropertyChecks with ScalaFutures {
 

--- a/core/jvm/src/test/scala/com/avsystem/commons/concurrent/JvmTaskExtensionsTest.scala
+++ b/core/jvm/src/test/scala/com/avsystem/commons/concurrent/JvmTaskExtensionsTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.*
 
 class JvmTaskExtensionsTest extends AnyFunSuite with Matchers with ScalaCheckDrivenPropertyChecks with ScalaFutures {
 
-  import com.avsystem.commons.concurrent.TaskExtensions._
+  import com.avsystem.commons.concurrent.TaskExtensions.*
 
   private implicit val scheduler: Scheduler = Scheduler.global
 

--- a/core/jvm/src/test/scala/com/avsystem/commons/concurrent/ObservableBlockingIteratorTest.scala
+++ b/core/jvm/src/test/scala/com/avsystem/commons/concurrent/ObservableBlockingIteratorTest.scala
@@ -4,7 +4,7 @@ package concurrent
 import monix.reactive.Observable
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class ObservableBlockingIteratorTest extends AnyFunSuite {
   test("empty") {

--- a/core/jvm/src/test/scala/com/avsystem/commons/jiop/JavaInteropTest.scala
+++ b/core/jvm/src/test/scala/com/avsystem/commons/jiop/JavaInteropTest.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package jiop
 
-import com.avsystem.commons.jiop.GuavaInterop._
+import com.avsystem.commons.jiop.GuavaInterop.*
 import com.google.common.util.concurrent.{MoreExecutors, SettableFuture}
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/jvm/src/test/scala/com/avsystem/commons/macros/TypeClassDerivationTest.scala
+++ b/core/jvm/src/test/scala/com/avsystem/commons/macros/TypeClassDerivationTest.scala
@@ -6,7 +6,7 @@ package macros
 import com.avsystem.commons.derivation.{AllowImplicitMacro, DeferredInstance}
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.reflect.runtime.{universe => ru}
+import scala.reflect.runtime.universe as ru
 
 object TypeClassDerivationTest {
 
@@ -70,7 +70,7 @@ object TypeClassDerivationTest {
 
 class TypeClassDerivationTest extends AnyFunSuite {
 
-  import TypeClassDerivationTest._
+  import TypeClassDerivationTest.*
 
   test("unknown test") {
     assert(materialize[Int] == UnknownTC(typeRepr[Int]))

--- a/core/jvm/src/test/scala/com/avsystem/commons/serialization/JCodecTestBase.scala
+++ b/core/jvm/src/test/scala/com/avsystem/commons/serialization/JCodecTestBase.scala
@@ -3,7 +3,7 @@ package serialization
 
 // TODO[scala3-port]: JCodecTestBase — depends on commented serialization test data / stubbed materialize (M)
 /*
-import CodecTestData._
+import CodecTestData.*
 
 trait JCodecTestBase extends AbstractCodecTest {
   val jTreeMap = stringMap(new JTreeMap[String, Int])

--- a/core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
+++ b/core/src/main/scala/com/avsystem/commons/SharedExtensions.scala
@@ -97,7 +97,7 @@ object SharedExtensionsUtils extends SharedExtensions {
       *
       * @example
       *   {{{
-      * import javax.swing._
+      * import javax.swing.*
       * // this entire expression returns the panel
       * new JPanel().setup { p =>
       *   p.setEnabled(true)

--- a/core/src/main/scala/com/avsystem/commons/annotation/AnnotationAggregate.scala
+++ b/core/src/main/scala/com/avsystem/commons/annotation/AnnotationAggregate.scala
@@ -10,8 +10,8 @@ package annotation
   * into implementation so that they can be accessed both in compile time and in runtime.
   *
   * {{{
-  *   import scala.annotation._
-  *   import com.avsystem.commons.serialization._
+  *   import scala.annotation.*
+  *   import com.avsystem.commons.serialization.*
   *
   *   class mongoId extends AnnotationAggregate {
   *     @name("_id") @outOfOrder

--- a/core/src/main/scala/com/avsystem/commons/collection/CollectionAliases.scala
+++ b/core/src/main/scala/com/avsystem/commons/collection/CollectionAliases.scala
@@ -1,8 +1,8 @@
 package com.avsystem.commons
 package collection
 
-import scala.collection.{immutable => sci, mutable => scm}
-import scala.{collection => sc}
+import scala.collection.{immutable as sci, mutable as scm}
+import scala.collection as sc
 
 /** Aliases for Scala collections which are both concise and leave no doubt about whether the collection type is
   * immutable, mutable or the base type (read only).

--- a/core/src/main/scala/com/avsystem/commons/concurrent/DurationPostfixConverters.scala
+++ b/core/src/main/scala/com/avsystem/commons/concurrent/DurationPostfixConverters.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package concurrent
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 trait DurationPostfixConverters {
   implicit def durationInt(int: Int): DurationInt = new DurationInt(int)

--- a/core/src/main/scala/com/avsystem/commons/concurrent/RetryStrategy.scala
+++ b/core/src/main/scala/com/avsystem/commons/concurrent/RetryStrategy.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package concurrent
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /** A `RetryStrategy` is conceptually a lazy sequence of delays, possibly infinite.
   */

--- a/core/src/main/scala/com/avsystem/commons/jiop/JCollectionUtils.scala
+++ b/core/src/main/scala/com/avsystem/commons/jiop/JCollectionUtils.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package jiop
 
-import java.{lang => jl, util => ju}
+import java.{lang as jl, util as ju}
 import scala.collection.Factory
 
 trait JCollectionUtils extends JFactories {
@@ -213,7 +213,7 @@ trait JCollectionUtils extends JFactories {
     }
   }
 
-  import JCollectionUtils._
+  import JCollectionUtils.*
 
   implicit def pairIterableOps[A, B](coll: IterableOnce[(A, B)]): pairIterableOps[A, B] = new pairIterableOps(coll)
 }

--- a/core/src/main/scala/com/avsystem/commons/meta/metadata.scala
+++ b/core/src/main/scala/com/avsystem/commons/meta/metadata.scala
@@ -21,7 +21,7 @@ final class DefaultValue[T](dv: => T) {
 @transparent
 final case class ParamFlags(rawFlags: Int) extends AnyVal {
 
-  import ParamFlags._
+  import ParamFlags.*
 
   def |(other: ParamFlags): ParamFlags = new ParamFlags(rawFlags | other.rawFlags)
   def &(other: ParamFlags): ParamFlags = new ParamFlags(rawFlags & other.rawFlags)
@@ -120,7 +120,7 @@ object SymbolSource extends HasGenCodec[SymbolSource]
 @transparent
 final case class TypeFlags(rawFlags: Int) extends AnyVal {
 
-  import TypeFlags._
+  import TypeFlags.*
 
   def |(other: TypeFlags): TypeFlags = new TypeFlags(rawFlags | other.rawFlags)
   def &(other: TypeFlags): TypeFlags = new TypeFlags(rawFlags & other.rawFlags)
@@ -173,7 +173,7 @@ object TypeFlags extends HasGenCodec[TypeFlags] {
 @transparent
 final case class MethodFlags(rawFlags: Int) extends AnyVal {
 
-  import MethodFlags._
+  import MethodFlags.*
 
   def |(other: MethodFlags): MethodFlags = new MethodFlags(rawFlags | other.rawFlags)
   def &(other: MethodFlags): MethodFlags = new MethodFlags(rawFlags & other.rawFlags)

--- a/core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/NOpt.scala
@@ -41,7 +41,7 @@ object NOpt {
   */
 final class NOpt[+A] private (private val rawValue: Any) extends AnyVal with OptBase[A] with Serializable {
 
-  import NOpt._
+  import NOpt.*
 
   private def value: A = (if (rawValue.asInstanceOf[AnyRef] eq NullMarker) null else rawValue).asInstanceOf[A]
 

--- a/core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/OptArg.scala
@@ -43,7 +43,7 @@ object OptArg {
   * methods).
   */
 final class OptArg[+A] private (private val rawValue: Any) extends AnyVal with OptBase[A] with Serializable {
-  import OptArg._
+  import OptArg.*
 
   private def value: A = rawValue.asInstanceOf[A]
 

--- a/core/src/main/scala/com/avsystem/commons/misc/TypedMap.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/TypedMap.scala
@@ -1,8 +1,8 @@
 package com.avsystem.commons.misc
 
-import com.avsystem.commons.SharedExtensions._
+import com.avsystem.commons.SharedExtensions.*
 import com.avsystem.commons.misc.TypedMap.GenCodecMapping
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 
 /** A map whose keys are parameterized with value type. This makes it possible to associate different value type with
   * each key, in a type-safe way.

--- a/core/src/main/scala/com/avsystem/commons/rpc/RPCFramework.scala
+++ b/core/src/main/scala/com/avsystem/commons/rpc/RPCFramework.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package rpc
 
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 import com.avsystem.commons.serialization.GenCodec
 
 trait RPCFramework {

--- a/core/src/main/scala/com/avsystem/commons/rpc/StandardRPCFramework.scala
+++ b/core/src/main/scala/com/avsystem/commons/rpc/StandardRPCFramework.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package rpc
 
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 
 /** Mix in this trait into your RPC framework to support remote procedures, i.e. fire-and-forget methods with `Unit`
   * return type.

--- a/core/src/main/scala/com/avsystem/commons/rpc/rpcAnnotations.scala
+++ b/core/src/main/scala/com/avsystem/commons/rpc/rpcAnnotations.scala
@@ -108,10 +108,10 @@ sealed trait RpcEncoding extends RawMethodAnnotation with RawParamAnnotation
   * `AsReal` and `AsRaw`).
   *
   * {{{
-  * import com.avsystem.commons._
-  * import com.avsystem.commons.rpc._
-  * import com.avsystem.commons.serialization._
-  * import com.avsystem.commons.serialization.json._
+  * import com.avsystem.commons.*
+  * import com.avsystem.commons.rpc.*
+  * import com.avsystem.commons.serialization.*
+  * import com.avsystem.commons.serialization.json.*
   *
   * case class Json(jsonStr: String)
   * object Json {

--- a/core/src/main/scala/com/avsystem/commons/rpc/rpcAnnotations.scala
+++ b/core/src/main/scala/com/avsystem/commons/rpc/rpcAnnotations.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package rpc
 
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 
 /** You can use this annotation on overloaded RPC methods to give them unique identifiers for RPC serialization. You can
   * also subclass this annotation provided that you always override the `name` parameter with another constructor

--- a/core/src/main/scala/com/avsystem/commons/serialization/Base64.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/Base64.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package serialization
 
-import java.util.{Base64 => JBase64}
+import java.util.Base64 as JBase64
 
 object Base64 {
   def encode(bytes: Array[Byte], withoutPadding: Boolean = false, urlSafe: Boolean = false): String = {

--- a/core/src/main/scala/com/avsystem/commons/serialization/FieldValues.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/FieldValues.scala
@@ -23,7 +23,7 @@ final class FieldValues(
 
   private val values = new Array[Any](fieldNames.length)
 
-  import FieldValues._
+  import FieldValues.*
 
   def readField(input: FieldInput): Unit =
     if (!tryReadField(input)) {

--- a/core/src/main/scala/com/avsystem/commons/serialization/GenCodecStructure.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/GenCodecStructure.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package serialization
 
 import com.avsystem.commons.annotation.{bincompat, positioned}
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 
 sealed trait GenInfo[T] extends TypedMetadata[T] {
   def sourceName: String

--- a/core/src/main/scala/com/avsystem/commons/serialization/GenRef.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/GenRef.scala
@@ -3,7 +3,7 @@ package serialization
 
 sealed trait RawRef {
 
-  import RawRef._
+  import RawRef.*
 
   def normalize: Iterator[SimpleRawRef] = this match {
     case Identity => Iterator.empty

--- a/core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
@@ -32,7 +32,7 @@ private object FormatConstants {
   final val BigDecimalMarker: Byte = 15
 }
 
-import com.avsystem.commons.serialization.FormatConstants._
+import com.avsystem.commons.serialization.FormatConstants.*
 
 class StreamInput(is: DataInputStream) extends InputAndSimpleInput {
   private[serialization] val markerByte = is.readByte()

--- a/core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/StreamInputOutput.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package serialization
 
 import java.io.{DataInputStream, DataOutputStream}
-import java.{lang => jl}
+import java.lang as jl
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
 
@@ -157,7 +157,7 @@ private class StreamListInput(is: DataInputStream) extends ListInput {
 
 private class StreamObjectInput(is: DataInputStream) extends ObjectInput {
 
-  import StreamObjectInput._
+  import StreamObjectInput.*
 
   private[this] var currentField: FieldInput = NoneYet
 

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package serialization.cbor
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.cbor.InitialByte.IndefiniteLength
 
 import java.io.{ObjectInput => _, _}

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborInput.scala
@@ -5,7 +5,7 @@ import com.avsystem.commons.serialization.GenCodec.ReadFailure
 import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.cbor.InitialByte.IndefiniteLength
 
-import java.io.{ObjectInput => _, _}
+import java.io.{ObjectInput as _, *}
 import java.nio.charset.StandardCharsets
 import scala.annotation.tailrec
 
@@ -168,7 +168,7 @@ object CborInput {
   */
 class CborInput(reader: CborReader, keyCodec: CborKeyCodec) extends InputAndSimpleInput {
 
-  import reader._
+  import reader.*
 
   def readNull(): Boolean = peekInitial() match {
     case InitialByte.Null =>
@@ -374,7 +374,7 @@ class CborInput(reader: CborReader, keyCodec: CborKeyCodec) extends InputAndSimp
     }
 
   private def skip(initialByte: InitialByte): Unit = {
-    import MajorType._
+    import MajorType.*
     initialByte match {
       case InitialByte(Unsigned | Negative, info) =>
         advance(unsignedSize(info))
@@ -480,7 +480,7 @@ abstract class CborChunkedInput(reader: CborReader) {
   protected def majorType: MajorType
   protected def doReadChunk(info: Int): Chunk
 
-  import reader._
+  import reader.*
 
   private def byteOrText: String = majorType match {
     case MajorType.ByteString => "byte"

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOptimizedCodecs.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOptimizedCodecs.scala
@@ -3,7 +3,7 @@ package serialization.cbor
 
 import com.avsystem.commons.jiop.JFactory
 import com.avsystem.commons.serialization.GenCodec.OOOFieldsObjectCodec
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 
 import scala.collection.Factory
 

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/CborOutput.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package serialization.cbor
 
 import com.avsystem.commons.serialization.GenCodec.WriteFailure
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.cbor.InitialByte.IndefiniteLength
 
 import java.io.{ByteArrayOutputStream, DataOutput, DataOutputStream}

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/HFloat.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/HFloat.scala
@@ -78,7 +78,7 @@ object HFloat {
   */
 final class HFloat(val raw: Short) extends AnyVal {
 
-  import HFloat._
+  import HFloat.*
 
   private def bits: Int =
     raw.toInt & 0xffff

--- a/core/src/main/scala/com/avsystem/commons/serialization/cbor/definitions.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/cbor/definitions.scala
@@ -22,7 +22,7 @@ final class InitialByte(val value: Byte) extends AnyVal {
 }
 object InitialByte extends InputMetadata[InitialByte] {
 
-  import MajorType._
+  import MajorType.*
 
   def apply(major: MajorType, info: Int): InitialByte = {
     require(info >= 0 && info < 32)

--- a/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringInput.scala
@@ -4,8 +4,8 @@ package serialization.json
 import com.avsystem.commons.annotation.explicitGenerics
 import com.avsystem.commons.misc.CrossUtils
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization._
-import com.avsystem.commons.serialization.json.JsonStringInput._
+import com.avsystem.commons.serialization.*
+import com.avsystem.commons.serialization.json.JsonStringInput.*
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/json/JsonStringOutput.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package serialization.json
 
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
+++ b/core/src/main/scala/com/avsystem/commons/serialization/macroCodecs.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package serialization
 
 import com.avsystem.commons.meta.OptionLike
-import com.avsystem.commons.serialization.GenCodec._
+import com.avsystem.commons.serialization.GenCodec.*
 
 import scala.annotation.tailrec
 

--- a/core/src/test/scala/com/avsystem/commons/concurrent/ExponentialBackoffTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/concurrent/ExponentialBackoffTest.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.*
   */
 class ExponentialBackoffTest extends AnyFunSuite with Matchers {
   test("simple") {
-    import RetryStrategy._
+    import RetryStrategy.*
     val eb = immediately.andThen(exponentially(1.second)).maxDelay(20.seconds).maxRetries(64)
 
     val allDelays = Iterator.iterateUntilEmpty(eb.nextRetry)(_._2.nextRetry).map(_._1).toList

--- a/core/src/test/scala/com/avsystem/commons/concurrent/ExponentialBackoffTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/concurrent/ExponentialBackoffTest.scala
@@ -4,7 +4,7 @@ package concurrent
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 /** Author: ghik Created: 31/08/16.
   */

--- a/core/src/test/scala/com/avsystem/commons/concurrent/TaskExtensionsTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/concurrent/TaskExtensionsTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class TaskExtensionsTest extends AnyFunSuite with Matchers with ScalaCheckDrivenPropertyChecks with ScalaFutures {
-  import com.avsystem.commons.concurrent.TaskExtensions._
+  import com.avsystem.commons.concurrent.TaskExtensions.*
 
   private implicit val scheduler: Scheduler = Scheduler.global
 

--- a/core/src/test/scala/com/avsystem/commons/macros/TreeForTypeTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/macros/TreeForTypeTest.scala
@@ -37,7 +37,7 @@ object TreeForTypeTest {
 
 class TreeForTypeTest {
 
-  import TreeForTypeTest._
+  import TreeForTypeTest.*
 
   type B
   val y = "y"
@@ -107,7 +107,7 @@ class TreeForTypeTest {
 
 object UnrelatedTreeForType {
 
-  import TreeForTypeTest._
+  import TreeForTypeTest.*
 
   testTreeForType("Int")
   testTreeForType("Integer")

--- a/core/src/test/scala/com/avsystem/commons/macros/TypeStringTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/macros/TypeStringTest.scala
@@ -137,7 +137,7 @@ class TypeStringTest extends AnyFunSuite {
 
 object UnrelatedTypeString {
 
-  import TypeStringTest._
+  import TypeStringTest.*
 
   def defineTests[T: TypeString](suite: TypeStringTest): Unit = {
     import suite.testTypeString

--- a/core/src/test/scala/com/avsystem/commons/misc/NamedEnumTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/NamedEnumTest.scala
@@ -46,7 +46,7 @@ class NamedEnumTest extends AnyFunSuite with Matchers {
   }
 
   test("all possible ways of `name` override") {
-    import SomeNamedEnum._
+    import SomeNamedEnum.*
     assert(
       byName == Map(
         "First" -> First,

--- a/core/src/test/scala/com/avsystem/commons/misc/OptArgTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/OptArgTest.scala
@@ -1,6 +1,6 @@
 package com.avsystem.commons.misc
 
-import com.avsystem.commons.SharedExtensions._
+import com.avsystem.commons.SharedExtensions.*
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/core/src/test/scala/com/avsystem/commons/misc/SealedEnumTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/SealedEnumTest.scala
@@ -16,12 +16,12 @@ class SealedEnumTest extends AnyFunSuite {
   }
 
   test("case objects listing") {
-    import SomeEnum._
+    import SomeEnum.*
     assert(values == List(First, Second, Third, Fourth))
   }
 
   test("typeclass instance listing") {
-    import SomeEnum._
+    import SomeEnum.*
     assert(classTags.map(_.runtimeClass) == List(First.getClass, Second.getClass, Third.getClass, Fourth.getClass))
   }
 }

--- a/core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/SharedExtensionsPropertyTest.scala
@@ -1,6 +1,6 @@
 package com.avsystem.commons.misc
 
-import com.avsystem.commons.SharedExtensions._
+import com.avsystem.commons.SharedExtensions.*
 
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.funsuite.AnyFunSuite

--- a/core/src/test/scala/com/avsystem/commons/misc/ValueEnumTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/ValueEnumTest.scala
@@ -12,7 +12,7 @@ class ValueEnumTest extends AnyFunSuite {
   }
 
   test("value enum test") {
-    import SomeValueEnum._
+    import SomeValueEnum.*
     assert(values == List(One, Two, Three, Four, Five_?))
     assert(values.map(_.ordinal) == List.range(0, 5))
     assert(values.map(_.name) == List("One", "Two", "Three", "Four", "Five_?"))

--- a/core/src/test/scala/com/avsystem/commons/rpc/ApiReflectionTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/rpc/ApiReflectionTest.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package rpc
 
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 import com.avsystem.commons.misc.TypeString
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/com/avsystem/commons/rpc/GenericMetadataTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/rpc/GenericMetadataTest.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package rpc
 
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 import com.avsystem.commons.misc.TypeString
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/com/avsystem/commons/rpc/NewRawRpc.scala
+++ b/core/src/test/scala/com/avsystem/commons/rpc/NewRawRpc.scala
@@ -4,7 +4,7 @@ package rpc
 import java.util.regex.Matcher
 
 import com.avsystem.commons.annotation.AnnotationAggregate
-import com.avsystem.commons.meta._
+import com.avsystem.commons.meta.*
 import com.avsystem.commons.misc.TypeString
 
 trait DummyParamTag extends RpcTag with AnnotationAggregate
@@ -79,7 +79,7 @@ object Utils {
   }
 }
 
-import com.avsystem.commons.rpc.Utils._
+import com.avsystem.commons.rpc.Utils.*
 
 case class DoSomethings(
   @rpcMethodMetadata doSomething: DoSomethingSignature,

--- a/core/src/test/scala/com/avsystem/commons/rpc/RPCMetadataTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/rpc/RPCMetadataTest.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package rpc
 
 import com.avsystem.commons.misc.TypeString
-import com.avsystem.commons.rpc.DummyRPC._
+import com.avsystem.commons.rpc.DummyRPC.*
 import com.avsystem.commons.serialization.GenCodec
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/com/avsystem/commons/rpc/RPCTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/rpc/RPCTest.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package rpc
 
 import com.avsystem.commons.concurrent.{HasExecutionContext, RunNowEC}
-import com.avsystem.commons.rpc.DummyRPC._
+import com.avsystem.commons.rpc.DummyRPC.*
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/core/src/test/scala/com/avsystem/commons/rpc/TestRPC.scala
+++ b/core/src/test/scala/com/avsystem/commons/rpc/TestRPC.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package rpc
 
-import com.avsystem.commons.rpc.DummyRPC._
+import com.avsystem.commons.rpc.DummyRPC.*
 import com.avsystem.commons.serialization.{optionalParam, transientDefault, whenAbsent, HasGenCodec}
 import scala.annotation.nowarn
 

--- a/core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
@@ -208,7 +208,7 @@ abstract class GenCodecRoundtripTest extends AbstractCodecTest {
   }
 
   test("typed map") {
-    import SealedKey._
+    import SealedKey.*
     testRoundtrip(TypedMap(StringKey -> "lol", IntKey -> 42, BooleanKey -> true))
   }
 

--- a/core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/GenCodecRoundtripTest.scala
@@ -5,7 +5,7 @@ package serialization
 /*
 import com.avsystem.commons.misc.TypedMap
 import com.avsystem.commons.serialization.CodecTestData.{TransparentFlatSealedBase, _}
-import com.avsystem.commons.serialization.JavaCodecs._
+import com.avsystem.commons.serialization.JavaCodecs.*
 
 abstract class GenCodecRoundtripTest extends AbstractCodecTest {
   test("java collections") {

--- a/core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
@@ -26,7 +26,7 @@ class SimpleGenCodecRoundtripTest extends GenCodecRoundtripTest with SimpleIOCod
 @nowarn
 class SimpleGenCodecTest extends SimpleIOCodecTest {
 
-  import CodecTestData._
+  import CodecTestData.*
 
   test("java collections") {
     testWrite[JCollection[Int]](jArrayList, List(1, 2, 3))
@@ -355,7 +355,7 @@ class SimpleGenCodecTest extends SimpleIOCodecTest {
   }
 
   test("typed map") {
-    import SealedKey._
+    import SealedKey.*
 
     testWrite(
       TypedMap(StringKey -> "lol", IntKey -> 42, BooleanKey -> true),

--- a/core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/SimpleGenCodecTest.scala
@@ -7,7 +7,7 @@ import com.avsystem.commons.misc.TypedMap
 import scala.annotation.nowarn
 
 import scala.collection.immutable.ListMap
-import JavaCodecs._
+import JavaCodecs.*
 
 trait SimpleIOCodecTest extends AbstractCodecTest {
   type Raw = Any

--- a/core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/cbor/CborInputOutputTest.scala
@@ -5,7 +5,7 @@ package serialization.cbor
 /*
 import com.avsystem.commons.misc.{Bytes, Timestamp}
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import com.avsystem.commons.serialization.json.JsonStringOutput
 import org.scalactic.source.Position
 import org.scalatest.funsuite.AnyFunSuite

--- a/core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/serialization/json/JsonStringInputOutputTest.scala
@@ -5,9 +5,9 @@ package serialization.json
 /*
 import com.avsystem.commons.serialization.CodecTestData.{CustomizedSeal, FlatSealedBase, OtherCustomCase}
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck._
+import org.scalacheck.*
 import org.scalactic.source.Position
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/hocon/src/main/scala/com/avsystem/commons/hocon/HParser.scala
+++ b/hocon/src/main/scala/com/avsystem/commons/hocon/HParser.scala
@@ -15,9 +15,9 @@ object HParser {
 }
 class HParser(tokens: IndexedSeq[HToken]) {
 
-  import HParser._
-  import HTokenType._
-  import HTree._
+  import HParser.*
+  import HTokenType.*
+  import HTree.*
 
   private[this] var idx = 0
 

--- a/hocon/src/main/scala/com/avsystem/commons/hocon/HoconInput.scala
+++ b/hocon/src/main/scala/com/avsystem/commons/hocon/HoconInput.scala
@@ -6,8 +6,8 @@ import java.time.{Duration, Period}
 
 import com.avsystem.commons.annotation.explicitGenerics
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization._
-import com.typesafe.config._
+import com.avsystem.commons.serialization.*
+import com.typesafe.config.*
 
 object HoconInput {
   @explicitGenerics def read[T: GenCodec](value: ConfigValue): T =

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonCodec.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonCodec.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package mongo
 
 import org.bson.types.ObjectId
-import org.bson._
+import org.bson.*
 
 import java.time.Instant
 import _root_.scala.collection.Factory

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonGenCodecs.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonGenCodecs.scala
@@ -2,8 +2,8 @@ package com.avsystem.commons
 package mongo
 
 import com.avsystem.commons.serialization.GenCodec.ReadFailure
-import com.avsystem.commons.serialization._
-import org.bson._
+import com.avsystem.commons.serialization.*
+import org.bson.*
 import org.bson.io.BasicOutputBuffer
 import org.bson.types.{Decimal128, ObjectId}
 

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonReaderInput.scala
@@ -3,7 +3,7 @@ package mongo
 
 import com.avsystem.commons.serialization.{ListInput, ObjectInput}
 import com.google.common.collect.AbstractIterator
-import org.bson._
+import org.bson.*
 import org.bson.types.{Decimal128, ObjectId}
 
 import _root_.scala.annotation.tailrec

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueInput.scala
@@ -1,8 +1,8 @@
 package com.avsystem.commons
 package mongo
 
-import com.avsystem.commons.serialization._
-import org.bson._
+import com.avsystem.commons.serialization.*
+import org.bson.*
 import org.bson.types.{Decimal128, ObjectId}
 
 object BsonValueInput {

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueOutput.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/BsonValueOutput.scala
@@ -2,7 +2,7 @@ package com.avsystem.commons
 package mongo
 
 import com.avsystem.commons.serialization.{GenCodec, ListOutput, ObjectOutput}
-import org.bson._
+import org.bson.*
 import org.bson.types.{Decimal128, ObjectId}
 
 object BsonValueOutput {

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Filter.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Filter.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package mongo
 
-import com.mongodb.client.model.{Filters => F}
+import com.mongodb.client.model.Filters as F
 import org.bson.conversions.Bson
 import org.bson.*
 
@@ -12,7 +12,7 @@ import _root_.scala.collection.Factory
   */
 object Filter {
 
-  import Limitations._
+  import Limitations.*
 
   def and(filters: Bson*): Bson = F.and(filters.asJava)
   def or(filters: Bson*): Bson = F.or(filters.asJava)

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Filter.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Filter.scala
@@ -3,7 +3,7 @@ package mongo
 
 import com.mongodb.client.model.{Filters => F}
 import org.bson.conversions.Bson
-import org.bson._
+import org.bson.*
 
 import _root_.scala.collection.Factory
 

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Sort.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Sort.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package mongo
 
-import com.mongodb.client.model.{Sorts => S}
+import com.mongodb.client.model.Sorts as S
 import org.bson.conversions.Bson
 
 /** @author

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Update.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/Update.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package mongo
 
-import com.mongodb.client.model.{Updates => U}
+import com.mongodb.client.model.Updates as U
 import org.bson.conversions.Bson
 
 /** @author

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/reactive/ReactiveMongoExtensions.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/reactive/ReactiveMongoExtensions.scala
@@ -6,7 +6,7 @@ import monix.reactive.Observable
 import org.reactivestreams.Publisher
 
 trait ReactiveMongoExtensions {
-  import ReactiveMongoExtensions._
+  import ReactiveMongoExtensions.*
 
   implicit final def publisherOps[T](publisher: Publisher[T]): PublisherOps[T] = new PublisherOps(publisher)
 }

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/sync/MongoOps.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/sync/MongoOps.scala
@@ -12,7 +12,7 @@ import org.bson.conversions.Bson
   */
 trait MongoOps {
 
-  import MongoOps._
+  import MongoOps.*
 
   implicit def dbOps(db: MongoDatabase): DBOps = new DBOps(db)
   implicit def findIterableOps[T](find: FindIterable[T]): FindIterableOps[T] = new FindIterableOps(find)

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/Bson.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/Bson.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package mongo.typed
 
-import org.bson._
+import org.bson.*
 
 object Bson {
   final val And = "$and"

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/FilterDocBuilder.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/FilterDocBuilder.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package mongo.typed
 
-import com.avsystem.commons.mongo.typed.MongoFilter._
+import com.avsystem.commons.mongo.typed.MongoFilter.*
 import org.bson.{BsonArray, BsonDocument}
 
 import scala.annotation.tailrec

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFilter.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoFilter.scala
@@ -14,7 +14,7 @@ import org.bson.{BsonArray, BsonDocument}
   */
 sealed trait MongoFilter[T] {
 
-  import MongoFilter._
+  import MongoFilter.*
 
   def on[E](prefix: MongoPropertyRef[E, T]): MongoDocumentFilter[E] =
     PropertyValueFilter(prefix, this)
@@ -120,7 +120,7 @@ final case class MongoOperatorsFilter[T](operators: Seq[MongoQueryOperator[T]]) 
   */
 sealed trait MongoDocumentFilter[E] extends MongoFilter[E] {
 
-  import MongoFilter._
+  import MongoFilter.*
 
   def and(other: MongoDocumentFilter[E]): MongoDocumentFilter[E] = (this, other) match {
     case (Empty(), other) => other

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoIndex.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoIndex.scala
@@ -24,7 +24,7 @@ import org.bson.{BsonDocument, BsonValue}
   *   MongoIndex.ascending(MyEntity.ref(_.int), MyEntity.ref(_.num))
   *
   *   // {"int": 1, "num": -1, "_id": "hashed"}
-  *   import MongoIndexType._
+  *   import MongoIndexType.*
   *   MongoIndex(
   *     MyEntity.ref(_.int) -> Ascending,
   *     MyEntity.ref(_.num) -> Descending,
@@ -69,7 +69,7 @@ object MongoIndex {
 
 final class MongoIndexType(implicit enumCtx: EnumCtx) extends AbstractValueEnum {
 
-  import MongoIndexType._
+  import MongoIndexType.*
 
   def toBson: BsonValue = this match {
     case Ascending => Bson.int(1)

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoQueryOperator.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoQueryOperator.scala
@@ -7,7 +7,7 @@ import org.bson.{BsonDocument, BsonType, BsonValue}
 
 sealed trait MongoQueryOperator[T] extends Product {
 
-  import MongoQueryOperator._
+  import MongoQueryOperator.*
 
   def rawOperator: String = "$" + productPrefix.uncapitalize
 

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoRef.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoRef.scala
@@ -108,7 +108,7 @@ sealed trait MongoPropertyRef[E, T]
   type ThisRef[E0, T0] = MongoPropertyRef[E0, T0]
   def SelfRef: MongoPropertyRef[E, T] = this
 
-  import MongoRef._
+  import MongoRef.*
 
   @macroPrivate def subtypeRefFor[C <: T: ClassTag]: MongoPropertyRef[E, C] =
     format.assumeUnion.subtypeRefFor(this, classTag[C].runtimeClass.asInstanceOf[Class[C]])

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoUpdate.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoUpdate.scala
@@ -11,7 +11,7 @@ import org.bson.BsonDocument
   */
 sealed trait MongoUpdate[T] {
 
-  import MongoUpdate._
+  import MongoUpdate.*
 
   def on[E](property: MongoPropertyRef[E, T]): MongoDocumentUpdate[E] =
     PropertyUpdate(property, this)
@@ -133,7 +133,7 @@ object MongoUpdate {
   */
 sealed trait MongoDocumentUpdate[E] extends MongoUpdate[E] {
 
-  import MongoUpdate._
+  import MongoUpdate.*
 
   // distinction between MultiUpdate and PropertyUpdate is mostly to avoid creating too many Vectors
   def and(other: MongoDocumentUpdate[E]): MongoDocumentUpdate[E] = (this, other) match {

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoUpdateOperator.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoUpdateOperator.scala
@@ -6,7 +6,7 @@ import org.bson.{BsonDocument, BsonValue}
 
 sealed trait MongoUpdateOperator[T] extends Product {
 
-  import MongoUpdateOperator._
+  import MongoUpdateOperator.*
 
   def rawOperator: String = "$" + productPrefix.uncapitalize
 

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoWrite.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoWrite.scala
@@ -11,7 +11,7 @@ import com.mongodb.client.model.*
   */
 sealed trait MongoWrite[E] {
 
-  import MongoWrite._
+  import MongoWrite.*
 
   def toWriteModel: WriteModel[E] = this match {
     case InsertOne(value) =>

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoWrite.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/MongoWrite.scala
@@ -1,7 +1,7 @@
 package com.avsystem.commons
 package mongo.typed
 
-import com.mongodb.client.model._
+import com.mongodb.client.model.*
 
 /** Represents a single MongoDB write operation in a
   * [[https://docs.mongodb.com/manual/core/bulk-write-operations/ bulk write operation]].

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/QueryOperatorsDsl.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/QueryOperatorsDsl.scala
@@ -8,11 +8,11 @@ import org.bson.{BsonType, BsonValue}
 
 import java.util.regex.Pattern
 import scala.annotation.tailrec
-import scala.util.matching.{Regex => SRegex}
+import scala.util.matching.Regex as SRegex
 
 trait VanillaQueryOperatorsDsl[T, R] {
 
-  import MongoQueryOperator._
+  import MongoQueryOperator.*
 
   def format: MongoFormat[T]
 
@@ -62,7 +62,7 @@ object VanillaQueryOperatorsDsl {
   implicit class ForCollection[C[X] <: Iterable[X], T, R](private val dsl: VanillaQueryOperatorsDsl[C[T], R])
     extends AnyVal {
 
-    import MongoQueryOperator._
+    import MongoQueryOperator.*
 
     private def format: MongoFormat[T] = dsl.format.assumeCollection.elementFormat
 

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoClient.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoClient.scala
@@ -3,7 +3,7 @@ package mongo.typed
 
 import com.avsystem.commons.mongo.BsonValueInput
 import com.avsystem.commons.serialization.GenCodec
-import com.mongodb._
+import com.mongodb.*
 import com.mongodb.connection.ClusterDescription
 import com.mongodb.reactivestreams.client.{MongoClient, MongoClients}
 import monix.eval.Task

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoCollection.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoCollection.scala
@@ -396,7 +396,7 @@ object TypedMongoCollection {
     rawCollection: MongoCollection[_]
   )(implicit meta: MongoEntityMeta[E]
   ): MongoCollection[E] = {
-    import meta.format._
+    import meta.format.*
     val codecRegistry: CodecRegistry = GenCodecRegistry.create[E](rawCollection.getCodecRegistry)
     val documentClass = classTag.runtimeClass.asInstanceOf[Class[E]]
     rawCollection.withCodecRegistry(codecRegistry).withDocumentClass(documentClass)

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoCollection.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoCollection.scala
@@ -4,8 +4,8 @@ package mongo.typed
 import com.avsystem.commons.annotation.bincompat
 import com.avsystem.commons.mongo.core.GenCodecRegistry
 import com.mongodb.bulk.BulkWriteResult
-import com.mongodb.client.model._
-import com.mongodb.client.result._
+import com.mongodb.client.model.*
+import com.mongodb.client.result.*
 import com.mongodb.reactivestreams.client.{DistinctPublisher, FindPublisher, MongoCollection}
 import com.mongodb.{MongoNamespace, ReadConcern, ReadPreference, WriteConcern}
 import monix.eval.Task

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoUtils.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/TypedMongoUtils.scala
@@ -6,7 +6,7 @@ import monix.reactive.Observable
 import org.reactivestreams.Publisher
 
 trait TypedMongoUtils {
-  import com.avsystem.commons.mongo.reactive.ReactiveMongoExtensions._
+  import com.avsystem.commons.mongo.reactive.ReactiveMongoExtensions.*
 
   protected final def empty(publisher: Publisher[Void]): Task[Unit] = publisher.completedL
   protected final def single[T](publisher: Publisher[T]): Task[T] = publisher.headL

--- a/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/UpdateOperatorsDsl.scala
+++ b/mongo/jvm/src/main/scala/com/avsystem/commons/mongo/typed/UpdateOperatorsDsl.scala
@@ -3,7 +3,7 @@ package mongo.typed
 
 trait UpdateOperatorsDsl[T, R] {
 
-  import MongoUpdateOperator._
+  import MongoUpdateOperator.*
 
   def format: MongoFormat[T]
   protected def wrapUpdate(update: MongoUpdate[T]): R
@@ -25,7 +25,7 @@ trait UpdateOperatorsDsl[T, R] {
 object UpdateOperatorsDsl {
   implicit class ForCollection[C[X] <: Iterable[X], T, R](private val dsl: UpdateOperatorsDsl[C[T], R]) extends AnyVal {
 
-    import MongoUpdateOperator._
+    import MongoUpdateOperator.*
 
     private def format: MongoFormat[T] = dsl.format.assumeCollection.elementFormat
 

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonInputOutputTest.scala
@@ -3,8 +3,8 @@ package mongo
 
 // TODO[scala3-port]: BsonInputOutputTest — depends on stubbed materialize / mongo entity companions (M)
 /*
-import com.avsystem.commons.serialization._
-import org.bson._
+import com.avsystem.commons.serialization.*
+import org.bson.*
 import org.bson.io.BasicOutputBuffer
 import org.bson.json.{JsonMode, JsonWriterSettings}
 import org.bson.types.Decimal128

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonValueCodecsTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/BsonValueCodecsTest.scala
@@ -3,7 +3,7 @@ package mongo
 
 import com.avsystem.commons.serialization.json.{JsonStringInput, JsonStringOutput}
 import com.avsystem.commons.serialization.{GenCodec, HasGenCodecWithDeps}
-import org.bson._
+import org.bson.*
 import org.bson.json.JsonReader
 import org.bson.types.{Decimal128, ObjectId}
 import org.scalactic.source.Position

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/DocTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/DocTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.funsuite.AnyFunSuite
   */
 class DocTest extends AnyFunSuite {
 
-  import DocTest._
+  import DocTest.*
 
   test("get variance") {
     val doc = Doc()

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/KeyEscaperTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/KeyEscaperTest.scala
@@ -7,8 +7,8 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class KeyEscaperTest extends AnyFunSuite with ScalaCheckPropertyChecks {
 
-  import KeyEscaper._
-  import KeyEscaperTest._
+  import KeyEscaper.*
+  import KeyEscaperTest.*
 
   test("custom keys") {
     val customCases = List(

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/core/ops/BsonRefIterableUpdatingCompilationTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/core/ops/BsonRefIterableUpdatingCompilationTest.scala
@@ -5,7 +5,7 @@ import com.avsystem.commons.mongo.BsonRef
 import com.avsystem.commons.serialization.GenCodec
 
 class BsonRefIterableUpdatingCompilationTest extends BsonRef.Creator[Something] {
-  import Updating._
+  import Updating.*
 
   implicit val codec: GenCodec[Something] = GenCodec.materialize
 

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/core/ops/FilteringTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/core/ops/FilteringTest.scala
@@ -12,8 +12,8 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class FilteringTest extends AnyFunSuite {
 
-  import Filtering._
-  import FilteringTest._
+  import Filtering.*
+  import FilteringTest.*
 
   private def testCase(name: String)(filter: (Ref[String]) => Bson)(verify: (String) => Bson): Unit = {
     import BsonEquality.bsonEquality

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/core/ops/SortingTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/core/ops/SortingTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class SortingTest extends AnyFunSuite {
 
-  import Sorting._
+  import Sorting.*
 
   val someKey = "someKey"
   val otherKey = "otherKey"

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/TypedMongoCollectionTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/TypedMongoCollectionTest.scala
@@ -31,7 +31,7 @@ class TypedMongoCollectionTest extends AnyFunSuite with ScalaFutures with Before
   final val Rte = RecordTestEntity
   final val Rtaie = RecordTestAutoIdEntity
 
-  import UnionTestEntity._
+  import UnionTestEntity.*
 
   private val client = TypedMongoClient()
   private val db = client.getDatabase("test")

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/TypedMongoCollectionTest.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/TypedMongoCollectionTest.scala
@@ -13,7 +13,7 @@ import org.scalactic.source.Position
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.time._
+import org.scalatest.time.*
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/testEntities.scala
+++ b/mongo/jvm/src/test/scala/com/avsystem/commons/mongo/typed/testEntities.scala
@@ -4,7 +4,7 @@ package mongo.typed
 // TODO[scala3-port]: testEntities — depends on stubbed materialize / mongo entity companions (M)
 /*
 import com.avsystem.commons.misc.{AutoNamedEnum, NamedEnumCompanion, Timestamp, TypedMap}
-import com.avsystem.commons.serialization._
+import com.avsystem.commons.serialization.*
 import org.bson.types.ObjectId
 
 case class RecordId(id: String) extends AnyVal


### PR DESCRIPTION
## Summary

Mechanical syntax sweep: convert Scala 2 wildcard and rename imports to Scala 3 syntax.

- `import X._` → `import X.*` (top-level and method-scoped)
- `import X.{Y => Z}` → `import X.Y as Z` (and multi-selector `{Y as Z}` variants)
- `import java.io.{ObjectInput => _, _}` → `import java.io.{ObjectInput as _, *}`
- Scaladoc `import` examples updated to match.

No behavioral change; pure syntax modernization. Scope excludes `analyzer/` (will-not-migrate) and `jetty/` (deferred module).

## Commits

- `refactor(scala-3,core): wildcard imports ._ → .*`
- `refactor(scala-3,mongo): wildcard imports ._ → .*`
- `refactor(scala-3,hocon): wildcard imports ._ → .*`
- `refactor(scala-3,benchmark): wildcard imports ._ → .*`
- `refactor(scala-3): rename imports => → as, nested wildcards ._ → .*`
- `docs(migration): record import syntax modernization`

## Metadata

- Slice: 3.8
- Independent: yes
- Depends-on: none
- Base: `upstream/scala-3`

## Verification

- `git grep -nE '^import .*\._$' -- '*.scala'` → 0 hits (scope)
- `sbt scalafmtCheckAll` → green
- `sbt compile Test/compile` → green
- No new `@nowarn` / `-Wconf`