### PR TITLE
[Scala 3] port SourceInfo.here macro

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -55,6 +55,12 @@ the bottom of this file. Restoration ships incrementally per feature area.
 - `enum` was renamed to `e` at one call site in `GenKeyCodec` (`enum` is reserved in Scala 3).
 - `@targetName` annotation added to `CloseableIterator` overloaded methods.
 
+### core — misc SourceInfo (slice 02-02 partial)
+
+- `SourceInfo.here` ported from Scala 2 `c.macroApplication` macro to Scala 3 `inline implicit def here: SourceInfo = ${ hereImpl }` using `Position.ofMacroExpansion` and `Symbol.spliceOwner.owner` enclosing-symbol walk.
+- Public API preserved: `SourceInfo.here` remains an `implicit def` returning `SourceInfo`; callers unchanged.
+- `positioned.here` deferred to a follow-up slice in 02-02 scope.
+
 ### mongo
 
 - `BsonRef.Creator.ref`, `DataTypeDsl.{ref, as, is, isNot}`, `TypedMongoUtils.optionalizeFirstArg` are stubbed with
@@ -173,7 +179,6 @@ Full per-file list with locations is in the Backlog table below (filter rows whe
 | `core/src/main/scala/com/avsystem/commons/misc/SelfInstance.scala:4`                              | C[_] existential narrowed to C[Any] (Scala 3 forbids HKT wildcard application)                        | S      |
 | `core/src/main/scala/com/avsystem/commons/misc/SelfInstance.scala:7`                              | SelfInstance.materialize (Scala 2 macro def)                                                          | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/SimpleClassName.scala:8`                           | SimpleClassName.materialize (Scala 2 macro def)                                                       | L      |
-| `core/src/main/scala/com/avsystem/commons/misc/SourceInfo.scala:28`                               | SourceInfo.here (Scala 2 macro def)                                                                   | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/Timestamp.scala:13`                                | Comparable[Timestamp] (Scala 3 forbids AnyVal inheriting Object-derived traits)                       | S      |
 | `core/src/main/scala/com/avsystem/commons/misc/TypeString.scala:31`                               | TypeString.materialize (Scala 2 macro def)                                                            | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/TypeString.scala:90`                               | JavaClassName.materialize (Scala 2 macro def)                                                         | L      |

--- a/core/src/main/scala/com/avsystem/commons/misc/SourceInfo.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/SourceInfo.scala
@@ -1,6 +1,9 @@
 package com.avsystem.commons
 package misc
 
+import scala.annotation.tailrec
+import scala.quoted.*
+
 /** Macro-materialized implicit value that provides information about callsite source file position. It can be used in
   * runtime for logging and debugging purposes. Similar to Scalactic's `Position`, but contains more information.
   */
@@ -25,6 +28,31 @@ case class SourceInfo(
 object SourceInfo {
   def apply()(implicit si: SourceInfo): SourceInfo = si
 
-  // TODO[scala3-port]: SourceInfo.here (Scala 2 macro def) (L)
-  implicit def here: SourceInfo = ???
+  inline implicit def here: SourceInfo = ${ hereImpl }
+
+  private[misc] def hereImpl(using quotes: Quotes): Expr[SourceInfo] = {
+    import quotes.reflect.*
+    val pos = Position.ofMacroExpansion
+
+    @tailrec
+    def enclosingLoop(sym: Symbol, acc: Vector[String]): Seq[String] =
+      if (sym == defn.RootClass) acc
+      else enclosingLoop(sym.owner, acc :+ sym.name)
+
+    '{
+      SourceInfo(
+        ${ Expr(pos.sourceFile.path) },
+        ${ Expr(pos.sourceFile.name) },
+        ${ Expr(pos.start) },
+        ${ Expr(pos.startLine + 1) },
+        ${ Expr(pos.startColumn + 1) },
+        ${
+          Expr(
+            pos.sourceFile.content.flatMap(_.linesIterator.drop(pos.startLine).nextOption).getOrElse("<no content>")
+          )
+        },
+        ${ Expr(enclosingLoop(Symbol.spliceOwner.owner, Vector.empty).toList) },
+      )
+    }
+  }
 }


### PR DESCRIPTION
Slice 02-02 (partial) / Phase 2 leaf debug/source macros.

Port `SourceInfo.here` from Scala 2 macro stub (`???`) to a real Scala 3 `inline implicit def` backed by `Position.ofMacroExpansion` + `Symbol.spliceOwner.owner` enclosing-symbol walk.

**Diff:**
- `core/src/main/scala/com/avsystem/commons/misc/SourceInfo.scala` — `here` wired to `${ hereImpl }`; `private[misc] def hereImpl(using Quotes): Expr[SourceInfo]` added.
- `MIGRATION.md` — backlog row for `SourceInfo.here` removed; §3 entry under `core — misc SourceInfo (slice 02-02 partial)` added.

**Public API:** unchanged. `SourceInfo.here` remains an `implicit def` returning `SourceInfo`; callers untouched.

**Out of scope:** `positioned.here` ships in a follow-up slice covering the rest of 02-02.

Base: `scala-3` (upstream/scala-3).