### PR TITLE
[Scala 3] deprecate Bidirectional ahead of Scala 3 removal

### DIFF
--- a/core/src/main/scala/com/avsystem/commons/misc/Bidirectional.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/Bidirectional.scala
@@ -1,7 +1,16 @@
 package com.avsystem.commons
 package misc
 
-/** Creates reversed partial function. */
+/** Creates reversed partial function.
+  *
+  * @deprecated
+  *   `Bidirectional` is being removed in the Scala 3 release of scala-commons. The whitebox macro has no Scala 3
+  *   counterpart; write the reversed `PartialFunction` manually at call sites.
+  */
+@deprecated(
+  "Bidirectional will be removed in the Scala 3 release of scala-commons. Write the reversed PartialFunction manually.",
+  since = "2.29.0",
+)
 object Bidirectional {
   def apply[A, B](pf: PartialFunction[A, B]): (PartialFunction[A, B], PartialFunction[B, A]) =
     macro com.avsystem.commons.macros.misc.BidirectionalMacro.impl[A, B]


### PR DESCRIPTION
Marks misc/Bidirectional @deprecated(since = "2.29.0") on master so downstream gets a warning window before the symbol disappears in the upcoming Scala 3 release of scala-commons.

The whitebox macro has no Scala 3 counterpart. Replacement: write the reversed PartialFunction manually at call sites.

Paired PR deleting the symbol from scala-3: #877.