### PR TITLE
[Scala 3] deprecate Delegation ahead of Scala 3 removal

### DIFF
--- a/core/src/main/scala/com/avsystem/commons/misc/Delegation.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/Delegation.scala
@@ -2,11 +2,24 @@ package com.avsystem.commons
 package misc
 
 /** A typeclass which witnesses that type `A` can be wrapped into trait or abstract class `B`
+  *
+  * @deprecated
+  *   `Delegation` is being removed in the Scala 3 release of scala-commons. The blackbox macros have no Scala 3
+  *   counterpart; write the delegating wrapper manually
+  *   (`new TargetTrait { def x = source.x; ... }`).
   */
+@deprecated(
+  "Delegation will be removed in the Scala 3 release of scala-commons. Write the delegating wrapper manually.",
+  since = "2.29.0",
+)
 trait Delegation[A, B] {
   def delegate(a: A): B
 }
 
+@deprecated(
+  "Delegation will be removed in the Scala 3 release of scala-commons. Write the delegating wrapper manually.",
+  since = "2.29.0",
+)
 object Delegation {
   implicit def materializeDelegation[A, B]: Delegation[A, B] =
     macro com.avsystem.commons.macros.misc.DelegationMacros.materializeDelegation[A, B]

--- a/core/src/main/scala/com/avsystem/commons/misc/Delegation.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/Delegation.scala
@@ -5,8 +5,7 @@ package misc
   *
   * @deprecated
   *   `Delegation` is being removed in the Scala 3 release of scala-commons. The blackbox macros have no Scala 3
-  *   counterpart; write the delegating wrapper manually
-  *   (`new TargetTrait { def x = source.x; ... }`).
+  *   counterpart; write the delegating wrapper manually (`new TargetTrait { def x = source.x; ... }`).
   */
 @deprecated(
   "Delegation will be removed in the Scala 3 release of scala-commons. Write the delegating wrapper manually.",


### PR DESCRIPTION
Marks `misc/Delegation` `@deprecated(since = "2.29.0")` on `master` so downstream gets a warning window before the symbol disappears in the upcoming Scala 3 release of scala-commons.

The blackbox macros have no Scala 3 counterpart. Replacement: write the delegating wrapper manually.

Paired PR deleting the symbol from `scala-3`: https://github.com/AVSystem/scala-commons/pull/879.