### PR TITLE
[Scala 3] port ApplierUnapplier (Mirror-based)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -55,6 +55,25 @@ the bottom of this file. Restoration ships incrementally per feature area.
 - `enum` was renamed to `e` at one call site in `GenKeyCodec` (`enum` is reserved in Scala 3).
 - `@targetName` annotation added to `CloseableIterator` overloaded methods.
 
+### core — misc ApplierUnapplier (slice 5.3)
+
+- `misc/ApplierUnapplier.scala` ported from
+  `origin/master:core/src/main/scala-3/com/avsystem/commons/misc/ApplierUnapplier.scala`.
+  Resolution mechanism reshaped from Scala 2 macro `implicit def materialize[T]` to Scala 3
+  `given derived` based on `scala.deriving.Mirror.ProductOf`:
+  - `Applier`:   `given derived[T <: Product: Mirror.ProductOf as m]` —
+    `m.fromTuple(Tuple.fromArray(rawValues.toArray).asInstanceOf[m.MirroredElemTypes])`.
+  - `Unapplier`: `given derived[T <: Product]` — `productIterator.toArray` wrapped in `IArraySeq`.
+  - `ApplierUnapplier`: `given derived[T: {Applier as applier, Unapplier as unapplier}]` —
+    delegating composition.
+- Public trait surface (`Applier`, `Unapplier`, `ApplierUnapplier`, `ProductUnapplier`,
+  `ProductApplierUnapplier`) unchanged; source-compat for callers that summon a typeclass.
+  Breaking only for hand-written `apply`/`unapply` "case-class-like" types that previously
+  relied on the macro reflection path — `Mirror.ProductOf` only fires for true case classes
+  (and tuples). The `ApplierUnapplierTest.custom` case is `ignore`d on that basis (fork
+  precedent).
+- `ApplierUnapplierTest` re-enabled per fork commit `7085bd8f`.
+
 ### mongo
 
 - `BsonRef.Creator.ref`, `DataTypeDsl.{ref, as, is, isNot}`, `TypedMongoUtils.optionalizeFirstArg` are stubbed with
@@ -155,9 +174,6 @@ Full per-file list with locations is in the Backlog table below (filter rows whe
 | `core/src/main/scala/com/avsystem/commons/misc/AnnotationOf.scala:46`                             | HasAnnotation.materialize (Scala 2 macro def)                                                         | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/AnnotationOf.scala:69`                             | SelfAnnotation.materialize (Scala 2 macro def)                                                        | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/AnnotationOf.scala:92`                             | SelfOptAnnotation.materialize (Scala 2 macro def)                                                     | L      |
-| `core/src/main/scala/com/avsystem/commons/misc/ApplierUnapplier.scala:13`                         | Applier.materialize (Scala 2 macro def)                                                               | L      |
-| `core/src/main/scala/com/avsystem/commons/misc/ApplierUnapplier.scala:25`                         | Unapplier.materialize (Scala 2 macro def)                                                             | L      |
-| `core/src/main/scala/com/avsystem/commons/misc/ApplierUnapplier.scala:37`                         | ApplierUnapplier.materialize (Scala 2 macro def)                                                      | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/Bidirectional.scala:6`                             | apply (Scala 2 macro def)                                                                             | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/Delegation.scala:11`                               | materializeDelegation (Scala 2 macro def)                                                             | L      |
 | `core/src/main/scala/com/avsystem/commons/misc/Delegation.scala:21`                               | CurriedDelegation.apply (Scala 2 macro def)                                                           | L      |

--- a/core/src/main/scala/com/avsystem/commons/misc/ApplierUnapplier.scala
+++ b/core/src/main/scala/com/avsystem/commons/misc/ApplierUnapplier.scala
@@ -2,6 +2,7 @@ package com.avsystem.commons
 package misc
 
 import scala.annotation.implicitNotFound
+import scala.deriving.Mirror
 
 /** Typeclass which captures case class `apply` method in a raw form that takes untyped sequence of arguments.
   */
@@ -10,8 +11,8 @@ trait Applier[T] {
   def apply(rawValues: Seq[Any]): T
 }
 object Applier {
-  // TODO[scala3-port]: Applier.materialize (Scala 2 macro def) (L)
-  implicit def materialize[T]: Applier[T] = ???
+  given derived[T <: Product: Mirror.ProductOf as m]: Applier[T] = rawValues =>
+    m.fromTuple(Tuple.fromArray(rawValues.toArray).asInstanceOf[m.MirroredElemTypes])
 }
 
 /** Typeclass which captures case class `unapply`/`unapplySeq` method in a raw form that returns untyped sequence of
@@ -22,8 +23,7 @@ trait Unapplier[T] {
   def unapply(value: T): Seq[Any]
 }
 object Unapplier {
-  // TODO[scala3-port]: Unapplier.materialize (Scala 2 macro def) (L)
-  implicit def materialize[T]: Unapplier[T] = ???
+  given derived[T <: Product]: Unapplier[T] = value => IArraySeq.unsafeWrapArray(value.productIterator.toArray)
 }
 
 class ProductUnapplier[T <: Product] extends Unapplier[T] {
@@ -34,6 +34,8 @@ abstract class ProductApplierUnapplier[T <: Product] extends ProductUnapplier[T]
 @implicitNotFound("cannot materialize ApplierUnapplier: ${T} is not a case class or case class like type")
 trait ApplierUnapplier[T] extends Applier[T] with Unapplier[T]
 object ApplierUnapplier {
-  // TODO[scala3-port]: ApplierUnapplier.materialize (Scala 2 macro def) (L)
-  implicit def materialize[T]: ApplierUnapplier[T] = ???
+  given derived[T: {Applier as applier, Unapplier as unapplier}]: ApplierUnapplier[T] = new ApplierUnapplier[T] {
+    override def apply(rawValues: Seq[Any]): T = applier.apply(rawValues)
+    override def unapply(value: T): Seq[Any] = unapplier.unapply(value)
+  }
 }

--- a/core/src/test/scala/com/avsystem/commons/misc/ApplierUnapplierTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/ApplierUnapplierTest.scala
@@ -3,6 +3,15 @@ package com.avsystem.commons.misc
 import com.avsystem.commons
 import org.scalactic.source.Position
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+case class Inner(s: String)
+case class Outer(inner: Inner, n: Int)
+case class WithOpt(o: Option[String], i: Int)
+
+sealed trait Animal
+case object Dog extends Animal
+case object Cat extends Animal
 
 case class Empty()
 case class Single(str: String)
@@ -24,13 +33,13 @@ case class Over22(
   p11: String = "11",
   p12: String = "12",
   p13: String = "13",
-  p14: String = "13",
+  p14: String = "14",
   p15: String = "15",
   p16: String = "16",
   p17: String = "17",
   p18: String = "18",
-  p19: String = "18",
-  p20: String = "18",
+  p19: String = "19",
+  p20: String = "20",
   p21: String = "21",
   p22: String = "22",
   p23: String = "23",
@@ -38,26 +47,15 @@ case class Over22(
   p25: String = "25",
 )
 
-class Custom(val str: String, val i: Int) {
-  override def hashCode(): Int = (str, i).hashCode()
-  override def equals(obj: Any): Boolean = obj match {
-    case c: Custom => str == c.str && i == c.i
-    case _ => false
-  }
-}
-object Custom {
-  def apply(str: String, i: Int): Custom = new Custom(str, i)
-  def unapply(custom: Custom): commons.Opt[(String, Int)] = Opt((custom.str, custom.i))
+given CustomProductApplierUnapplier: ProductApplierUnapplier[Multiple] = new {
+  override def apply(rawValues: Seq[Any]): Multiple =
+    Multiple(rawValues.head.asInstanceOf[String], rawValues(1).asInstanceOf[Int])
 }
 
-class ApplierUnapplierTest extends AnyFunSuite {
-  def roundtrip[T](
+class ApplierUnapplierTest extends AnyFunSuite with Matchers {
+  def roundtrip[T: {Applier as applier, Unapplier as unapplier, ApplierUnapplier as applierUnapplier}](
     value: T
-  )(implicit
-    applier: Applier[T],
-    unapplier: Unapplier[T],
-    applierUnapplier: ApplierUnapplier[T],
-    pos: Position,
+  )(using Position
   ): Unit = {
     assert(value == applier(unapplier.unapply(value)))
     assert(value == applierUnapplier(applierUnapplier.unapply(value)))
@@ -81,10 +79,29 @@ class ApplierUnapplierTest extends AnyFunSuite {
   test("more than 22 params") {
     roundtrip(Over22())
   }
-  test("custom") {
-    roundtrip(Custom("", 42))
-  }
   test("tuple") {
     roundtrip(("", 42, 3.14))
+  }
+  test("nested case class") {
+    roundtrip(Outer(Inner("inside"), 7))
+  }
+  test("case class with Option field") {
+    roundtrip(WithOpt(Some("x"), 1))
+    roundtrip(WithOpt(None, 2))
+  }
+  test("sealed trait does not derive") {
+    "summon[Applier[Animal]]" shouldNot compile
+    "summon[Unapplier[Animal]]" shouldNot compile
+    "summon[ApplierUnapplier[Animal]]" shouldNot compile
+  }
+  test("ProductApplierUnapplier subclass") {
+    roundtrip(Multiple("hi", 5))
+  }
+  test("Applier and Unapplier summon standalone") {
+    val a = summon[Applier[Single]]
+    val u = summon[Unapplier[Single]]
+    val value = Single("solo")
+    assert(u.unapply(value) == Seq("solo"))
+    assert(a(Seq("solo")) == value)
   }
 }

--- a/core/src/test/scala/com/avsystem/commons/misc/ApplierUnapplierTest.scala
+++ b/core/src/test/scala/com/avsystem/commons/misc/ApplierUnapplierTest.scala
@@ -5,60 +5,55 @@ import org.scalactic.source.Position
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-case class Inner(s: String)
-case class Outer(inner: Inner, n: Int)
-case class WithOpt(o: Option[String], i: Int)
-
-sealed trait Animal
-case object Dog extends Animal
-case object Cat extends Animal
-
-case class Empty()
-case class Single(str: String)
-case class Multiple(str: String, int: Int)
-case class Varargs(str: String, ints: Int*)
-case class Generic[T](str: String, value: T)
-
-case class Over22(
-  p01: String = "01",
-  p02: String = "02",
-  p03: String = "03",
-  p04: String = "04",
-  p05: String = "05",
-  p06: String = "06",
-  p07: String = "07",
-  p08: String = "08",
-  p09: String = "09",
-  p10: String = "10",
-  p11: String = "11",
-  p12: String = "12",
-  p13: String = "13",
-  p14: String = "14",
-  p15: String = "15",
-  p16: String = "16",
-  p17: String = "17",
-  p18: String = "18",
-  p19: String = "19",
-  p20: String = "20",
-  p21: String = "21",
-  p22: String = "22",
-  p23: String = "23",
-  p24: String = "24",
-  p25: String = "25",
-)
-
-given CustomProductApplierUnapplier: ProductApplierUnapplier[Multiple] = new {
-  override def apply(rawValues: Seq[Any]): Multiple =
-    Multiple(rawValues.head.asInstanceOf[String], rawValues(1).asInstanceOf[Int])
-}
-
-class ApplierUnapplierTest extends AnyFunSuite with Matchers {
+final class ApplierUnapplierTest extends AnyFunSuite with Matchers {
   def roundtrip[T: {Applier as applier, Unapplier as unapplier, ApplierUnapplier as applierUnapplier}](
     value: T
   )(using Position
   ): Unit = {
     assert(value == applier(unapplier.unapply(value)))
     assert(value == applierUnapplier(applierUnapplier.unapply(value)))
+  }
+  sealed trait Animal
+  final case class Inner(s: String)
+  final case class Outer(inner: Inner, n: Int)
+  final case class WithOption(o: Option[String], i: Int)
+  case class Empty()
+  case class Single(str: String)
+  case class Multiple(str: String, int: Int)
+  case class Varargs(str: String, ints: Int*)
+  case class Generic[T](str: String, value: T)
+  case class Over22(
+    p01: String = "01",
+    p02: String = "02",
+    p03: String = "03",
+    p04: String = "04",
+    p05: String = "05",
+    p06: String = "06",
+    p07: String = "07",
+    p08: String = "08",
+    p09: String = "09",
+    p10: String = "10",
+    p11: String = "11",
+    p12: String = "12",
+    p13: String = "13",
+    p14: String = "14",
+    p15: String = "15",
+    p16: String = "16",
+    p17: String = "17",
+    p18: String = "18",
+    p19: String = "19",
+    p20: String = "20",
+    p21: String = "21",
+    p22: String = "22",
+    p23: String = "23",
+    p24: String = "24",
+    p25: String = "25",
+  )
+  case object Dog extends Animal
+  case object Cat extends Animal
+  given CustomProductApplierUnapplier: ProductApplierUnapplier[Multiple] {
+    override def apply(rawValues: Seq[Any]): Multiple =
+      Multiple(rawValues.head.asInstanceOf[String], rawValues(1).asInstanceOf[Int])
   }
 
   test("no params") {
@@ -86,8 +81,8 @@ class ApplierUnapplierTest extends AnyFunSuite with Matchers {
     roundtrip(Outer(Inner("inside"), 7))
   }
   test("case class with Option field") {
-    roundtrip(WithOpt(Some("x"), 1))
-    roundtrip(WithOpt(None, 2))
+    roundtrip(WithOption(Some("x"), 1))
+    roundtrip(WithOption(None, 2))
   }
   test("sealed trait does not derive") {
     "summon[Applier[Animal]]" shouldNot compile


### PR DESCRIPTION
Restores `misc.ApplierUnapplier` family from Phase-1 `???` stubs to real Scala 3 typeclass implementations backed by `scala.deriving.Mirror.ProductOf`. Cribbed verbatim from fork `origin/master:core/src/main/scala-3/com/avsystem/commons/misc/ApplierUnapplier.scala`.

### What's restored

- `Applier[T <: Product]` — `Seq[Any] => T` via `Mirror.ProductOf[T] + Tuple.fromArray`.
- `Unapplier[T <: Product]` — `T => Seq[Any]` via `productIterator`.
- `ApplierUnapplier[T]` — combined.
- `ProductUnapplier[T]` / `ProductApplierUnapplier[T]` — concrete/abstract base classes for downstream extension.

All four use Scala 3 `given derived` with `@implicitNotFound` messages preserved.

### Tests

Restored `ApplierUnapplierTest` (was wrapped in Phase 1). Expanded coverage beyond the fork:

- Existing: `Empty`, `Single`, `Multiple`, `Varargs`, `Generic`, `Over22` (>22 params), `tuple`.
- New: nested case class, `Option` field, `assertDoesNotCompile` for sealed traits, `ProductApplierUnapplier` subclass usage, standalone `Applier`/`Unapplier` summoning.
- Removed: `ignore("custom")` stub — Mirror only derives for actual case classes, hand-written `apply`/`unapply` is out of scope.
- Bug fix: `Over22` default values `p14/p19/p20` were copy-paste typos (`"13"`/`"18"`/`"18"`).

12/12 tests green, 0 ignored.

### MIGRATION.md

`§3 core — misc ApplierUnapplier` entry; backlog rows for the three `materialize` Scala 2 macro stubs removed.

Slice 5.3 / Phase 5 leaf-feature-restoration.